### PR TITLE
Temporarily disable pricing component

### DIFF
--- a/apollo/createSchema.ts
+++ b/apollo/createSchema.ts
@@ -317,18 +317,18 @@ const createSchema = async () => {
           return delegator;
         }
 
-        const response = await fetch(CHAIN_INFO[DEFAULT_CHAIN_ID].pricingUrl);
-        const transcodersWithPrice = await response.json();
-        const transcoderWithPrice = transcodersWithPrice.filter(
-          (t) =>
-            t.Address.toLowerCase() === delegator?.delegate?.id.toLowerCase()
-        )[0];
+        // const response = await fetch(CHAIN_INFO[DEFAULT_CHAIN_ID].pricingUrl);
+        // const transcodersWithPrice = await response.json();
+        // const transcoderWithPrice = transcodersWithPrice.filter(
+        //   (t) =>
+        //     t.Address.toLowerCase() === delegator?.delegate?.id.toLowerCase()
+        // )[0];
 
-        if (delegator?.delegate) {
-          delegator.delegate.price = transcoderWithPrice?.PricePerPixel
-            ? transcoderWithPrice?.PricePerPixel
-            : 0;
-        }
+        // if (delegator?.delegate) {
+        //   delegator.delegate.price = transcoderWithPrice?.PricePerPixel
+        //     ? transcoderWithPrice?.PricePerPixel
+        //     : 0;
+        // }
 
         return delegator;
       },
@@ -341,14 +341,14 @@ const createSchema = async () => {
           return transcoder;
         }
 
-        const response = await fetch(CHAIN_INFO[DEFAULT_CHAIN_ID].pricingUrl);
-        const transcodersWithPrice = await response.json();
-        const transcoderWithPrice = transcodersWithPrice.filter(
-          (t) => t.Address.toLowerCase() === args.id.toLowerCase()
-        )[0];
-        transcoder["price"] = transcoderWithPrice?.PricePerPixel
-          ? transcoderWithPrice?.PricePerPixel
-          : 0;
+        // const response = await fetch(CHAIN_INFO[DEFAULT_CHAIN_ID].pricingUrl);
+        // const transcodersWithPrice = await response.json();
+        // const transcoderWithPrice = transcodersWithPrice.filter(
+        //   (t) => t.Address.toLowerCase() === args.id.toLowerCase()
+        // )[0];
+        // transcoder["price"] = transcoderWithPrice?.PricePerPixel
+        //   ? transcoderWithPrice?.PricePerPixel
+        //   : 0;
         return transcoder;
       },
       transcoders: async (resolve, parent, args, ctx, info) => {
@@ -358,20 +358,20 @@ const createSchema = async () => {
         const performanceMetrics = [];
 
         //if selection set includes 'price', return transcoders merge prices and performance metrics
-        if (selectionSet.includes("price")) {
-          // get price data
-          const response = await fetch(CHAIN_INFO[DEFAULT_CHAIN_ID].pricingUrl);
-          const transcodersWithPrice = await response.json();
+        // if (selectionSet.includes("price")) {
+        //   // get price data
+        //   const response = await fetch(CHAIN_INFO[DEFAULT_CHAIN_ID].pricingUrl);
+        //   const transcodersWithPrice = await response.json();
 
-          for (const t of transcodersWithPrice) {
-            if (transcoders.filter((a) => a.id === t.Address).length > 0) {
-              prices.push({
-                id: t.Address,
-                price: t.PricePerPixel,
-              });
-            }
-          }
-        }
+        //   for (const t of transcodersWithPrice) {
+        //     if (transcoders.filter((a) => a.id === t.Address).length > 0) {
+        //       prices.push({
+        //         id: t.Address,
+        //         price: t.PricePerPixel,
+        //       });
+        //     }
+        //   }
+        // }
 
         function avg(obj, key) {
           const arr = Object.values(obj);

--- a/components/OrchestratingView/index.tsx
+++ b/components/OrchestratingView/index.tsx
@@ -117,7 +117,7 @@ const Index = ({ currentRound, transcoder }) => {
           }
         />
 
-        <Stat
+        {/* <Stat
           className="masonry-grid_item"
           label={
             <Flex css={{ ai: "center" }}>
@@ -145,7 +145,7 @@ const Index = ({ currentRound, transcoder }) => {
               )}
             </>
           }
-        />
+        /> */}
         {transcoder?.lastRewardRound?.id && (
           <Stat
             className="masonry-grid_item"

--- a/queries/accountQuery.ts
+++ b/queries/accountQuery.ts
@@ -44,7 +44,7 @@ export const accountQuery = (currentRound) => {
         active
         feeShare
         rewardCut
-        price
+        # price
         status
         active
         totalStake

--- a/queries/orchestratorsQuery.ts
+++ b/queries/orchestratorsQuery.ts
@@ -26,7 +26,7 @@ export const orchestratorsQuery = (currentRound) => {
         deactivationRound
         rewardCut
         totalStake
-        price
+        # price
         scores {
           global
           mdw


### PR DESCRIPTION
The API endpoint the explorer relies on to fetch off-chain pricing info is timing out (https://nyc.livepeer.com/orchestratorStats). The orchestrator detail view relies on this endpoint so that page is timing out as a result.

This PR temporarily removes the pricing component on that page until API endpoint is restored.