### PR TITLE
feat: add ENS Github record to profile

### DIFF
--- a/components/Profile/index.tsx
+++ b/components/Profile/index.tsx
@@ -6,6 +6,7 @@ import {
   CopyIcon,
   GlobeIcon,
   TwitterLogoIcon,
+  GitHubLogoIcon,
 } from "@modulz/radix-icons";
 import QRCode from "qrcode.react";
 import { useEffect, useState } from "react";
@@ -138,7 +139,7 @@ const Index = ({ account, isMyAccount = false, identity }: Props) => {
             </CopyToClipboard>
             {isMyAccount && <EditProfile />}
           </Flex>
-          <Flex align="center">
+          <Flex align="center" css={{ flexWrap: 'wrap' }}>
             {identity?.url && (
               <Flex align="center" css={{ mt: "$2", mr: "$3" }}>
                 <Box as={GlobeIcon} css={{ mr: "$1" }} />
@@ -165,6 +166,21 @@ const Index = ({ account, isMyAccount = false, identity }: Props) => {
                   rel="noopener noreferrer"
                 >
                   @{identity.twitter}
+                </A>
+              </Flex>
+            )}
+
+            {identity?.github && (
+              <Flex align="center" css={{ mt: "$2", mr: "$3" }}>
+                <Box as={GitHubLogoIcon} css={{ mr: "$1" }} />
+                <A
+                  variant="contrast"
+                  css={{ fontSize: "$2" }}
+                  href={`https://github.com/${identity.github}`}
+                  target="__blank"
+                  rel="noopener noreferrer"
+                >
+                  {identity.github}
                 </A>
               </Flex>
             )}

--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -30,6 +30,10 @@ const Index = ({ css = {}, ...props }) => {
             weight: 0.5,
           },
           {
+            name: "github",
+            weight: 0.5,
+          },
+          {
             name: "url",
             weight: 0.5,
           },

--- a/lib/api/ens.ts
+++ b/lib/api/ens.ts
@@ -58,10 +58,11 @@ export const getEnsForAddress = async (address: string | null | undefined) => {
 
   if (name) {
     const resolver = await l1Provider.getResolver(name);
-    const [description, url, twitter, avatar] = await Promise.all([
+    const [description, url, twitter, github, avatar] = await Promise.all([
       resolver?.getText("description"),
       resolver?.getText("url"),
       resolver?.getText("com.twitter"),
+      resolver?.getText("com.github"),
       resolver?.getAvatar(),
     ]);
 
@@ -72,6 +73,7 @@ export const getEnsForAddress = async (address: string | null | undefined) => {
       description: sanitizeHtml(nl2br(description), sanitizeOptions),
       url,
       twitter,
+      github,
       avatar: avatar?.url ? `/api/ens-data/image/${name}` : null,
     };
 

--- a/lib/api/types/get-ens.ts
+++ b/lib/api/types/get-ens.ts
@@ -5,5 +5,6 @@ export type EnsIdentity = {
   name?: string | null;
   url?: string | null;
   twitter?: string | null;
+  github?: string | null;
   description?: string | null;
 };


### PR DESCRIPTION
**Overview:**

This pull request adds functionality to display the `com.github` ENS TXT record on user profile pages, should it exist. Additionally, to enhance usability on smaller screens, I've implemented a responsive design where social items wrap to the following line when there isn't enough space to display them horizontally.

**Alternative Consideration:**

An alternative approach is to simplify the display on smaller screens by showing only buttons for social items, omitting the text. This version is found at https://github.com/livepeer/explorer/pull/248.

**Feedback Request:**

I am open to feedback on this approach. I will make the necessary code adjustments if the consensus is that a button-only display is more user-friendly for mobile views.

**Visual Preview:**

Here's how the implementation currently looks:

![image](https://github.com/livepeer/explorer/assets/17570430/06acb96a-7060-4c08-921c-e3335333899f)

![image](https://github.com/livepeer/explorer/assets/17570430/7dc63822-828e-4630-8499-9bb6f690e26a)

![mobile_desin_1](https://github.com/livepeer/explorer/assets/17570430/8ab2a789-21eb-488c-b955-bf2cae7912cf)

And this would be the alternative solution on small screens:

![Social Items Display on Profile Page](https://github.com/livepeer/explorer/assets/17570430/c608b883-8877-4fed-b73a-28f468633d68)

![mobile_design_2](https://github.com/livepeer/explorer/assets/17570430/18de31d4-8783-472a-ad8a-4521de376278)

