### PR TITLE
feat: add treasury drawer item

### DIFF
--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -177,7 +177,7 @@ const Layout = ({ children, title = "Livepeer Explorer" }) => {
     {
       name: (
         <Flex css={{ alignItems: "center" }}>
-          Voting{" "}
+          Governance{" "}
           {(totalActivePolls ?? 0) > 0 && (
             <Badge
               size="2"
@@ -195,6 +195,28 @@ const Layout = ({ children, title = "Livepeer Explorer" }) => {
       as: "/voting",
       icon: Ballot,
       className: "voting",
+    },
+    {
+      name: (
+        <Flex css={{ alignItems: "center" }}>
+          Treasury{" "}
+          {(totalActiveTreasuryProposals ?? 0) > 0 && (
+            <Badge
+              size="2"
+              variant="green"
+              css={{
+                ml: "6px",
+              }}
+            >
+              {totalActiveTreasuryProposals}
+            </Badge>
+          )}
+        </Flex>
+      ),
+      href: "/treasury",
+      as: "/treasury",
+      icon: Ballot,
+      className: "treasury",
     },
   ];
 


### PR DESCRIPTION
This commit introduces the Treasury drawer item for mobile devices, enhancing user navigation to the treasury page. It also fixes the active proposals indicator shown on the desktop version.

I currently implemented the treasury page as a standalone item for minimal code changes; an alternative could be to group it with governance features in a submenu. Feedback on the preferred approach is welcome.

**Visual Preview**

![image](https://github.com/livepeer/explorer/assets/17570430/c7f24a91-5a5b-4978-950f-a0b432369063)