### PR TITLE
feat: add ENS Github record to profile 2 (alternative)

### DIFF
--- a/components/Profile/index.tsx
+++ b/components/Profile/index.tsx
@@ -6,6 +6,7 @@ import {
   CopyIcon,
   GlobeIcon,
   TwitterLogoIcon,
+  GitHubLogoIcon,
 } from "@modulz/radix-icons";
 import QRCode from "qrcode.react";
 import { useEffect, useState } from "react";
@@ -138,7 +139,7 @@ const Index = ({ account, isMyAccount = false, identity }: Props) => {
             </CopyToClipboard>
             {isMyAccount && <EditProfile />}
           </Flex>
-          <Flex align="center">
+          <Flex align="center" css={{ flexWrap: 'wrap' }}>
             {identity?.url && (
               <Flex align="center" css={{ mt: "$2", mr: "$3" }}>
                 <Box as={GlobeIcon} css={{ mr: "$1" }} />
@@ -165,6 +166,21 @@ const Index = ({ account, isMyAccount = false, identity }: Props) => {
                   rel="noopener noreferrer"
                 >
                   @{identity.twitter}
+                </A>
+              </Flex>
+            )}
+
+            {identity?.github && (
+              <Flex align="center" css={{ mt: "$2", mr: "$3" }}>
+                <Box as={GitHubLogoIcon} css={{ mr: "$1" }} />
+                <A
+                  variant="contrast"
+                  css={{ fontSize: "$2" }}
+                  href={`https://github.com/${identity.github}`}
+                  target="__blank"
+                  rel="noopener noreferrer"
+                >
+                  {identity.github}
                 </A>
               </Flex>
             )}

--- a/components/Profile/index.tsx
+++ b/components/Profile/index.tsx
@@ -141,48 +141,64 @@ const Index = ({ account, isMyAccount = false, identity }: Props) => {
           </Flex>
           <Flex align="center" css={{ flexWrap: 'wrap' }}>
             {identity?.url && (
-              <Flex align="center" css={{ mt: "$2", mr: "$3" }}>
-                <Box as={GlobeIcon} css={{ mr: "$1" }} />
-                <A
-                  variant="contrast"
-                  css={{ fontSize: "$2" }}
-                  href={identity.url}
-                  target="__blank"
-                  rel="noopener noreferrer"
-                >
+              <A
+                variant="contrast"
+                css={{ fontSize: "$2" }}
+                href={identity.url}
+                target="__blank"
+                rel="noopener noreferrer"
+              >
+                <Flex align="center" css={{ mt: "$2", mr: "$3" }}>
+                  <Box as={GlobeIcon} css={{ mr: "$1" }} />
                   {identity.url.replace(/(^\w+:|^)\/\//, "")}
-                </A>
-              </Flex>
+                </Flex>
+              </A>
             )}
 
             {identity?.twitter && (
-              <Flex align="center" css={{ mt: "$2", mr: "$3" }}>
-                <Box as={TwitterLogoIcon} css={{ mr: "$1" }} />
-                <A
-                  variant="contrast"
-                  css={{ fontSize: "$2" }}
-                  href={`https://twitter.com/${identity.twitter}`}
-                  target="__blank"
-                  rel="noopener noreferrer"
-                >
-                  @{identity.twitter}
-                </A>
-              </Flex>
+              <A
+                variant="contrast"
+                css={{ fontSize: "$2" }}
+                href={`https://twitter.com/${identity.twitter}`}
+                target="__blank"
+                rel="noopener noreferrer"
+              >
+                <Flex align="center" css={{ mt: "$2", mr: "$3" }}>
+                  <Box as={TwitterLogoIcon} css={{ mr: "$1" }} />
+                  <Box
+                    css={{
+                      "@media (max-width: 400px)": {
+                        display: "none",
+                      },
+                    }}
+                  >
+                    @{identity.twitter}
+                  </Box>
+                </Flex>
+              </A>
             )}
 
             {identity?.github && (
-              <Flex align="center" css={{ mt: "$2", mr: "$3" }}>
-                <Box as={GitHubLogoIcon} css={{ mr: "$1" }} />
-                <A
-                  variant="contrast"
-                  css={{ fontSize: "$2" }}
-                  href={`https://github.com/${identity.github}`}
-                  target="__blank"
-                  rel="noopener noreferrer"
-                >
-                  {identity.github}
-                </A>
-              </Flex>
+              <A
+                variant="contrast"
+                css={{ fontSize: "$2" }}
+                href={`https://github.com/${identity.github}`}
+                target="__blank"
+                rel="noopener noreferrer"
+              >
+                <Flex align="center" css={{ mt: "$2", mr: "$3" }}>
+                  <Box as={GitHubLogoIcon} css={{ mr: "$1" }} />
+                  <Box
+                    css={{
+                      "@media (max-width: 400px)": {
+                        display: "none",
+                      },
+                    }}
+                  >
+                    {identity.github}
+                  </Box>
+                </Flex>
+              </A>
             )}
           </Flex>
         </Flex>

--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -30,6 +30,10 @@ const Index = ({ css = {}, ...props }) => {
             weight: 0.5,
           },
           {
+            name: "github",
+            weight: 0.5,
+          },
+          {
             name: "url",
             weight: 0.5,
           },

--- a/lib/api/ens.ts
+++ b/lib/api/ens.ts
@@ -58,10 +58,11 @@ export const getEnsForAddress = async (address: string | null | undefined) => {
 
   if (name) {
     const resolver = await l1Provider.getResolver(name);
-    const [description, url, twitter, avatar] = await Promise.all([
+    const [description, url, twitter, github, avatar] = await Promise.all([
       resolver?.getText("description"),
       resolver?.getText("url"),
       resolver?.getText("com.twitter"),
+      resolver?.getText("com.github"),
       resolver?.getAvatar(),
     ]);
 
@@ -72,6 +73,7 @@ export const getEnsForAddress = async (address: string | null | undefined) => {
       description: sanitizeHtml(nl2br(description), sanitizeOptions),
       url,
       twitter,
+      github,
       avatar: avatar?.url ? `/api/ens-data/image/${name}` : null,
     };
 

--- a/lib/api/types/get-ens.ts
+++ b/lib/api/types/get-ens.ts
@@ -5,5 +5,6 @@ export type EnsIdentity = {
   name?: string | null;
   url?: string | null;
   twitter?: string | null;
+  github?: string | null;
   description?: string | null;
 };


### PR DESCRIPTION
This pull request contains an alternative version of #246 in which the Twitter and Github social items' text is hidden on tiny screens (i.e. <400px).

**Visual Preview:**

![mobile_design_2](https://github.com/livepeer/explorer/assets/17570430/b4b414ce-de4f-4fe9-a879-dfa098070258)