### PR TITLE
feat: make delegation widget accessible from My Account view when wallet is connected

### DIFF
--- a/apollo/subgraph.ts
+++ b/apollo/subgraph.ts
@@ -9807,8 +9807,22 @@ export type AccountQuery = {
       __typename: "Transcoder";
       id: string;
       active: boolean;
+      feeShare: string;
+      rewardCut: string;
       status: TranscoderStatus;
       totalStake: string;
+      totalVolumeETH: string;
+      activationTimestamp: number;
+      activationRound: string;
+      deactivationRound: string;
+      thirtyDayVolumeETH: string;
+      ninetyDayVolumeETH: string;
+      lastRewardRound?: { __typename: "Round"; id: string } | null;
+      pools?: Array<{
+        __typename: "Pool";
+        rewardTokens?: string | null;
+      }> | null;
+      delegators?: Array<{ __typename: "Delegator"; id: string }> | null;
     } | null;
   } | null;
   transcoder?: {
@@ -10803,8 +10817,26 @@ export const AccountDocument = gql`
       delegate {
         id
         active
+        feeShare
+        rewardCut
         status
+        active
         totalStake
+        totalVolumeETH
+        activationTimestamp
+        activationRound
+        deactivationRound
+        thirtyDayVolumeETH
+        ninetyDayVolumeETH
+        lastRewardRound {
+          id
+        }
+        pools(first: 30, skip: 1, orderBy: id, orderDirection: desc) {
+          rewardTokens
+        }
+        delegators(first: 1000) {
+          id
+        }
       }
     }
     transcoder(id: $account) {

--- a/layouts/account.tsx
+++ b/layouts/account.tsx
@@ -98,6 +98,13 @@ const AccountLayout = ({
     [accountId, dataMyAccount]
   );
 
+  const isDelegatingAndIsMyAccountView = useMemo(
+    () =>
+      dataMyAccount?.delegator?.bondedAmount !== "0" &&
+      accountId === dataMyAccount?.delegator?.id.toLowerCase(),
+    [accountId, dataMyAccount]
+  );
+
   const tabs: Array<TabType> = useMemo(
     () =>
       getTabs(
@@ -144,7 +151,9 @@ const AccountLayout = ({
               },
             }}
           >
-            {(isOrchestrator || isMyDelegate) && (
+            {(isOrchestrator ||
+              isMyDelegate ||
+              isDelegatingAndIsMyAccountView) && (
               <Sheet>
                 <SheetTrigger asChild>
                   <Button variant="primary" css={{ mr: "$3" }} size="4">
@@ -156,7 +165,11 @@ const AccountLayout = ({
                     transcoders={sortedOrchestrators?.transcoders as any}
                     delegator={dataMyAccount?.delegator}
                     account={myIdentity}
-                    transcoder={account?.transcoder}
+                    transcoder={
+                      isDelegatingAndIsMyAccountView
+                        ? dataMyAccount?.delegator?.delegate
+                        : account?.transcoder
+                    }
                     protocol={account?.protocol}
                     delegateProfile={identity}
                   />
@@ -175,7 +188,11 @@ const AccountLayout = ({
                     transcoders={sortedOrchestrators?.transcoders}
                     delegator={dataMyAccount?.delegator}
                     account={myIdentity}
-                    transcoder={account?.transcoder}
+                    transcoder={
+                      isDelegatingAndIsMyAccountView
+                        ? dataMyAccount?.delegator?.delegate
+                        : account?.transcoder
+                    }
                     protocol={account?.protocol}
                     delegateProfile={identity}
                   />
@@ -232,7 +249,7 @@ const AccountLayout = ({
           )}
           {view === "history" && <HistoryView />}
         </Flex>
-        {(isOrchestrator || isMyDelegate) &&
+        {(isOrchestrator || isMyDelegate || isDelegatingAndIsMyAccountView) &&
           (width > 1020 ? (
             <Flex
               css={{
@@ -251,7 +268,11 @@ const AccountLayout = ({
                 transcoders={sortedOrchestrators?.transcoders}
                 delegator={dataMyAccount?.delegator}
                 account={myIdentity}
-                transcoder={account?.transcoder}
+                transcoder={
+                  isDelegatingAndIsMyAccountView
+                    ? dataMyAccount?.delegator?.delegate
+                    : account?.transcoder
+                }
                 protocol={account?.protocol}
                 delegateProfile={identity}
               />
@@ -262,7 +283,11 @@ const AccountLayout = ({
                 transcoders={sortedOrchestrators?.transcoders}
                 delegator={dataMyAccount?.delegator}
                 account={myIdentity}
-                transcoder={account?.transcoder}
+                transcoder={
+                  isDelegatingAndIsMyAccountView
+                    ? dataMyAccount?.delegator?.delegate
+                    : account?.transcoder
+                }
                 protocol={account?.protocol}
                 delegateProfile={identity}
               />

--- a/layouts/account.tsx
+++ b/layouts/account.tsx
@@ -151,6 +151,13 @@ const AccountLayout = ({
               },
             }}
           >
+            {/*
+              The delegation widget should only be displayed on the account page
+              under the following conditions:
+              a) the account page belongs to an orchestrator
+              b) the account page belongs to a deactivated orchestrator I am still delegated to
+              c) the account page belongs to me and I am a delegator
+            */}
             {(isOrchestrator ||
               isMyDelegate ||
               isDelegatingAndIsMyAccountView) && (

--- a/layouts/account.tsx
+++ b/layouts/account.tsx
@@ -163,7 +163,15 @@ const AccountLayout = ({
               isDelegatingAndIsMyAccountView) && (
               <Sheet>
                 <SheetTrigger asChild>
-                  <Button variant="primary" css={{ mr: "$3" }} size="4">
+                  <Button
+                    variant="primary"
+                    css={{ mr: "$3" }}
+                    size="4"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setSelectedStakingAction("delegate");
+                    }}
+                  >
                     Delegate
                   </Button>
                 </SheetTrigger>
@@ -183,29 +191,37 @@ const AccountLayout = ({
                 </SheetContent>
               </Sheet>
             )}
-            {isMyDelegate && (
-              <Sheet>
-                <SheetTrigger asChild>
-                  <Button variant="red" size="4">
-                    Undelegate
-                  </Button>
-                </SheetTrigger>
-                <SheetContent side="bottom" css={{ height: "initial" }}>
-                  <DelegatingWidget
-                    transcoders={sortedOrchestrators?.transcoders}
-                    delegator={dataMyAccount?.delegator}
-                    account={myIdentity}
-                    transcoder={
-                      isDelegatingAndIsMyAccountView
-                        ? dataMyAccount?.delegator?.delegate
-                        : account?.transcoder
-                    }
-                    protocol={account?.protocol}
-                    delegateProfile={identity}
-                  />
-                </SheetContent>
-              </Sheet>
-            )}
+            {isMyDelegate ||
+              (isDelegatingAndIsMyAccountView && (
+                <Sheet>
+                  <SheetTrigger asChild>
+                    <Button
+                      variant="red"
+                      size="4"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        setSelectedStakingAction("undelegate");
+                      }}
+                    >
+                      Undelegate
+                    </Button>
+                  </SheetTrigger>
+                  <SheetContent side="bottom" css={{ height: "initial" }}>
+                    <DelegatingWidget
+                      transcoders={sortedOrchestrators?.transcoders}
+                      delegator={dataMyAccount?.delegator}
+                      account={myIdentity}
+                      transcoder={
+                        isDelegatingAndIsMyAccountView
+                          ? dataMyAccount?.delegator?.delegate
+                          : account?.transcoder
+                      }
+                      protocol={account?.protocol}
+                      delegateProfile={identity}
+                    />
+                  </SheetContent>
+                </Sheet>
+              ))}
           </Flex>
           <Box
             css={{


### PR DESCRIPTION
This PR ensures that the delegation widget is accessible from the "My Account" view when a user's wallet is connected to the explorer. Resolves issue #243 