### PR TITLE
fix: fix ROI treasury reward cut bug

### DIFF
--- a/components/DelegatingWidget/Input.tsx
+++ b/components/DelegatingWidget/Input.tsx
@@ -4,7 +4,7 @@ import { useExplorerStore } from "hooks";
 import { useEffect, useMemo } from "react";
 import { useWindowSize } from "react-use";
 
-const Input = ({ transcoder, value, onChange, protocol, ...props }) => {
+const Input = ({ transcoder, value, onChange, protocol, treasury, ...props }) => {
   const { width } = useWindowSize();
 
   const pools = useMemo(() => transcoder?.pools ?? [], [transcoder]);
@@ -42,6 +42,7 @@ const Input = ({ transcoder, value, onChange, protocol, ...props }) => {
 
           rewardCallRatio,
           rewardCut: Number(transcoder.rewardCut) / 1000000,
+          treasuryRewardCut: treasury.treasuryRewardCutRate,
         },
       }),
     [protocol, transcoder, principle, rewardCallRatio]

--- a/components/DelegatingWidget/InputBox.tsx
+++ b/components/DelegatingWidget/InputBox.tsx
@@ -13,10 +13,15 @@ import {
 import { fromWei } from "@lib/utils";
 import { ConsoleView } from "react-device-detect";
 
+interface Treasury {
+  treasuryRewardCutRate: number;
+}
+
 interface Props {
   transcoder: NonNullable<AccountQueryResult["data"]>["transcoder"];
   delegator?: NonNullable<AccountQueryResult["data"]>["delegator"];
   protocol: NonNullable<AccountQueryResult["data"]>["protocol"];
+  treasury: Treasury;
   account: EnsIdentity;
   action?: StakingAction;
   delegateProfile?: EnsIdentity;
@@ -33,6 +38,7 @@ const InputBox = ({
   amount,
   setAmount,
   protocol,
+  treasury,
 }: Props) => {
   const walletAddress = useAccountAddress();
   const delegatorPendingStakeAndFees = usePendingFeesAndStakeData(
@@ -110,6 +116,7 @@ const InputBox = ({
                 setAmount(e.target.value ? e.target.value : "");
               }}
               protocol={protocol}
+              treasury={treasury}
             />
           </Flex>
         </Box>

--- a/components/DelegatingWidget/index.tsx
+++ b/components/DelegatingWidget/index.tsx
@@ -18,6 +18,7 @@ interface Props {
   transcoder: NonNullable<AccountQueryResult["data"]>["transcoder"] | undefined;
   delegator?: NonNullable<AccountQueryResult["data"]>["delegator"] | undefined;
   protocol: NonNullable<AccountQueryResult["data"]>["protocol"] | undefined;
+  treasury: { treasuryRewardCutRate: number };
   account: EnsIdentity;
   delegateProfile?: EnsIdentity;
 }
@@ -28,6 +29,7 @@ const Index = ({
   account,
   transcoder,
   protocol,
+  treasury,
   delegateProfile,
 }: Props) => {
   const [amount, setAmount] = useState("");
@@ -135,6 +137,7 @@ const Index = ({
               amount={amount}
               setAmount={setAmount}
               protocol={protocol}
+              treasury={treasury}
             />
             <Flex
               css={{

--- a/layouts/account.tsx
+++ b/layouts/account.tsx
@@ -1,7 +1,10 @@
 import DelegatingWidget from "@components/DelegatingWidget";
+import { bondingManager } from "@lib/api/abis/main/BondingManager";
 import Profile from "@components/Profile";
 import { getLayout, LAYOUT_MAX_WIDTH } from "@layouts/main";
 import { useRouter } from "next/router";
+import { useBondingManagerAddress } from "hooks/useContracts";
+import { useContractRead } from "wagmi";
 
 import BottomDrawer from "@components/BottomDrawer";
 import DelegatingView from "@components/DelegatingView";
@@ -75,6 +78,17 @@ const AccountLayout = ({
     skip: !accountAddress,
     pollInterval,
   });
+
+  const { data: bondingManagerAddress } = useBondingManagerAddress(); 
+  const { data: treasuryRewardCutRate = BigInt(0.0) } = useContractRead({
+    enabled: Boolean(bondingManagerAddress),
+    address: bondingManagerAddress,
+    abi: bondingManager,
+    functionName: "treasuryRewardCutRate",
+  });
+  const treasury = {
+    treasuryRewardCutRate: Number(treasuryRewardCutRate / BigInt(1e18)) / 1e9,
+  };
 
   // start polling when when transactions finish
   useEffect(() => {
@@ -186,6 +200,7 @@ const AccountLayout = ({
                         : account?.transcoder
                     }
                     protocol={account?.protocol}
+                    treasury={treasury}
                     delegateProfile={identity}
                   />
                 </SheetContent>
@@ -217,6 +232,7 @@ const AccountLayout = ({
                           : account?.transcoder
                       }
                       protocol={account?.protocol}
+                      treasury={treasury}
                       delegateProfile={identity}
                     />
                   </SheetContent>
@@ -297,6 +313,7 @@ const AccountLayout = ({
                     : account?.transcoder
                 }
                 protocol={account?.protocol}
+                treasury={treasury}
                 delegateProfile={identity}
               />
             </Flex>
@@ -312,6 +329,7 @@ const AccountLayout = ({
                     : account?.transcoder
                 }
                 protocol={account?.protocol}
+                treasury={treasury}
                 delegateProfile={identity}
               />
             </BottomDrawer>

--- a/lib/api/abis/bridge/L1BondingManager.ts
+++ b/lib/api/abis/bridge/L1BondingManager.ts
@@ -100,6 +100,21 @@ export const l1BondingManager = {
     {
       constant: true,
       inputs: [],
+      name: "treasuryRewardCutRate",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+      ],
+      payable: false,
+      stateMutability: "view",
+      type: "function",
+    },
+    {
+      constant: true,
+      inputs: [],
       name: "unbondingPeriod",
       outputs: [
         {

--- a/lib/api/abis/main/BondingManager.ts
+++ b/lib/api/abis/main/BondingManager.ts
@@ -1384,6 +1384,19 @@ export const bondingManager = [
   },
   {
     inputs: [],
+    name: "treasuryRewardCutRate",
+    outputs:[
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type:"function",
+  },
+  {
+    inputs: [],
     name: "unbondingPeriod",
     outputs: [
       {

--- a/lib/roi.ts
+++ b/lib/roi.ts
@@ -32,9 +32,10 @@ export type ROIParams = {
     totalSupply: number;
     totalActiveStake: number;
     roundLength: number;
-
+    
     rewardCallRatio: number;
     rewardCut: number;
+    treasuryRewardCut: number;
   };
 };
 
@@ -69,6 +70,7 @@ export function calculateROI({
 
     rewardCallRatio,
     rewardCut,
+    treasuryRewardCut,
   },
 }: ROIParams) {
   const combinedTotalStaked = principle + totalStake;
@@ -83,6 +85,9 @@ export function calculateROI({
   const roundsCount = Math.round(
     (monthsForTimeHorizon * SECONDS_IN_A_MONTH) / averageSecondsPerRound
   );
+  
+  // Subtract treasury reward cut from the inflation.
+  inflation = inflation * (1 - treasuryRewardCut);
 
   let totalInflationPercent =
     (inflationChange !== "none"


### PR DESCRIPTION
This pull request fixes a bug in which the treasuryRewardCutRate was not considered in the ROI calculation (see #257).

> [!IMPORTANT]\
> Don't merge this yet. This was a 30-minute draft I created that still needs to be improved.
