### PR TITLE
fix: improve desktop search dialog scrollbars

### DIFF
--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -74,7 +74,7 @@ const Index = ({ css = {}, ...props }) => {
           <Box as={MagnifyingGlassIcon} css={{ width: 18, height: 18 }} />
         </IconButton>
       </DialogTrigger>
-      <DialogContent css={{ overflow: "scroll", transition: "max-height 2s" }}>
+      <DialogContent css={{ overflow: "auto", transition: "max-height 2s" }}>
         <Box
           css={{
             borderRadius: 10,
@@ -135,7 +135,7 @@ const Index = ({ css = {}, ...props }) => {
           css={{
             maxHeight: searchMapping.length > 0 ? 400 : 30,
             transition: "max-height 0.2s",
-            overflow: "scroll",
+            overflow: "auto",
             mt: "$1",
           }}
         >


### PR DESCRIPTION
This pull request ensures the horizontal scrollbars in the search dialogue widget are not shown when the search content exceeds the parent element's width.

**before**

![scrollbar_bug](https://github.com/livepeer/explorer/assets/17570430/6bb3e344-a6ce-4595-a80f-492c94c48933)

**after**

![scrollbar_fix](https://github.com/livepeer/explorer/assets/17570430/fa95f48b-c480-4051-a4a5-aec14658f47c)
