### PR TITLE
Update contract addresses link

### DIFF
--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -848,7 +848,7 @@ const ContractAddressesPopover = ({ activeChain }: { activeChain?: Chain }) => {
 
             <Link
               passHref
-              href="https://docs.livepeer.org/protocol/reference/deployed"
+              href="https://docs.livepeer.org/references/contract-addresses"
             >
               <A>
                 <Flex


### PR DESCRIPTION
This change updates the link to contract addresses in Livepeer docs #264