### PR TITLE
feat: Add Markdown table support for treasury/poll

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "react-truncate": "^2.4.0",
     "react-use": "^17.4.0",
     "recharts": "^2.1.10",
+    "remark-gfm": "^3.0.1",
     "sanitize-html": "^2.7.3",
     "swr": "^1.3.0",
     "viem": "^1.2.12",

--- a/pages/treasury/[proposal].tsx
+++ b/pages/treasury/[proposal].tsx
@@ -1,6 +1,7 @@
 import { getLayout, LAYOUT_MAX_WIDTH } from "@layouts/main";
 import { useRouter } from "next/router";
 import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { abbreviateNumber, fromWei } from "../../lib/utils";
 
 import BottomDrawer from "@components/BottomDrawer";
@@ -600,7 +601,9 @@ const Proposal = () => {
                 >
                   Description
                 </Heading>
-                <ReactMarkdown>{proposal.description}</ReactMarkdown>
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {proposal.description}
+                </ReactMarkdown>
               </Card>
             </Box>
           </Flex>

--- a/pages/voting/[poll].tsx
+++ b/pages/voting/[poll].tsx
@@ -2,6 +2,7 @@ import VotingWidget from "@components/VotingWidget";
 import { getLayout, LAYOUT_MAX_WIDTH } from "@layouts/main";
 import { useRouter } from "next/router";
 import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { abbreviateNumber } from "../../lib/utils";
 
 import BottomDrawer from "@components/BottomDrawer";
@@ -329,7 +330,9 @@ const Poll = () => {
                   },
                 }}
               >
-                <ReactMarkdown>{pollData.attributes?.text ?? ""}</ReactMarkdown>
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {pollData.attributes?.text ?? ""}
+                </ReactMarkdown>
               </Card>
             </Box>
           </Flex>


### PR DESCRIPTION
This pull request ensures that the explorer markdown will render tables. For more information, see [react-markdown
plugin](https://github.com/remarkjs/react-markdown?tab=readme-ov-file#use-a-plugin).
