### PR TITLE
feat(markdown): enhance table rendering style

### DIFF
--- a/components/MarkdownRenderer/index.tsx
+++ b/components/MarkdownRenderer/index.tsx
@@ -1,0 +1,24 @@
+import { styled } from "@livepeer/design-system";
+import OriginalReactMarkdown from "react-markdown";
+
+/**
+ * A styled ReactMarkdown component for consistent markdown rendering in the
+ * Livepeer Explorer.
+ */
+const MarkdownRenderer = styled(OriginalReactMarkdown, {
+  // Improve table styling.
+  table: {
+    borderCollapse: "collapse",
+    borderSpacing: 0,
+    "th, td": {
+      padding: "$2 $4", // Use consistent padding units
+      borderBottom: "1px solid $neutral7",
+      textAlign: "left !important",
+    },
+    th: {
+      borderBottom: "3px solid $neutral7",
+    },
+  },
+});
+
+export default MarkdownRenderer;

--- a/pages/treasury/[proposal].tsx
+++ b/pages/treasury/[proposal].tsx
@@ -1,9 +1,9 @@
 import { getLayout, LAYOUT_MAX_WIDTH } from "@layouts/main";
 import { useRouter } from "next/router";
-import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { abbreviateNumber, fromWei } from "../../lib/utils";
 
+import MarkdownRenderer from "@components/MarkdownRenderer";
 import BottomDrawer from "@components/BottomDrawer";
 import Spinner from "@components/Spinner";
 import Stat from "@components/Stat";
@@ -601,9 +601,9 @@ const Proposal = () => {
                 >
                   Description
                 </Heading>
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                <MarkdownRenderer remarkPlugins={[remarkGfm]}>
                   {proposal.description}
-                </ReactMarkdown>
+                </MarkdownRenderer>
               </Card>
             </Box>
           </Flex>

--- a/pages/treasury/create-proposal.tsx
+++ b/pages/treasury/create-proposal.tsx
@@ -1,10 +1,9 @@
 import Spinner from "@components/Spinner";
+import MarkdownRenderer from "@components/MarkdownRenderer";
 import { livepeerGovernor } from "@lib/api/abis/main/LivepeerGovernor";
 import { livepeerToken } from "@lib/api/abis/main/LivepeerToken";
 import {
-  getLivepeerGovernorAddress,
   getLivepeerTokenAddress,
-  getTreasuryAddress,
 } from "@lib/api/contracts";
 import { abbreviateNumber, fromWei, toWei } from "@lib/utils";
 import {
@@ -17,6 +16,7 @@ import {
   TextField,
   Text,
   styled,
+  Card,
 } from "@livepeer/design-system";
 import {
   useAccountAddress,
@@ -31,32 +31,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Address, encodeFunctionData, isAddress } from "viem";
 import { useContractWrite, usePrepareContractWrite } from "wagmi";
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from "@reach/tabs";
-import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-
-const MarkdownPreview = styled(ReactMarkdown, {
-  minHeight: 360,
-  boxShadow: "inset 0 0 0 1px $colors$neutral7",
-  borderRadius: "$2",
-  borderTopLeftRadius: "0",
-  backgroundColor: "$panel",
-  p: "$4",
-  h2: {
-    fontWeight: 600,
-    "&:first-of-type": { mt: 0 },
-    mt: "$3",
-  },
-  h3: { fontWeight: 600, mt: "$3" },
-  h4: { fontWeight: 600, mt: "$3" },
-  h5: { fontWeight: 600, mt: "$3" },
-  lineHeight: 1.5,
-  a: {
-    color: "$primary11",
-  },
-  pre: {
-    whiteSpace: "pre-wrap",
-  },
-});
 
 const StyledTab = styled(Tab, {
   position: "relative",
@@ -259,10 +234,40 @@ const CreateProposal = () => {
                   size="3"
                 />
               </TabPanel>
-              <TabPanel style={{ paddingBottom: "4px" }}>
-                <MarkdownPreview remarkPlugins={[remarkGfm]}>
-                  {`# ${formTitle}\n${formDescription}`}
-                </MarkdownPreview>
+              <TabPanel style={{ paddingBottom: "3.32px" }}>
+                <Card
+                  css={{
+                    minHeight: 360,
+                    boxShadow: "inset 0 0 0 1px $colors$neutral7",
+                    borderRadius: "$2",
+                    borderTopLeftRadius: "0",
+                    backgroundColor: "$panel",
+
+                    // Apply same card styling as proposal page.
+                    p: "$4",
+                    // border: "1px solid $neutral4",
+                    // mb: "$3",
+                    h2: {
+                      fontWeight: 600,
+                      "&:first-of-type": { mt: 0 },
+                      mt: "$3",
+                    },
+                    h3: { fontWeight: 600, mt: "$3" },
+                    h4: { fontWeight: 600, mt: "$3" },
+                    h5: { fontWeight: 600, mt: "$3" },
+                    lineHeight: 1.5,
+                    a: {
+                      color: "$primary11",
+                    },
+                    pre: {
+                      whiteSpace: "pre-wrap",
+                    },
+                  }}
+                >
+                  <MarkdownRenderer remarkPlugins={[remarkGfm]}>
+                    {`# ${formTitle}\n${formDescription}`}
+                  </MarkdownRenderer>
+                </Card>
               </TabPanel>
             </TabPanels>
           </Tabs>

--- a/pages/voting/[poll].tsx
+++ b/pages/voting/[poll].tsx
@@ -1,7 +1,7 @@
 import VotingWidget from "@components/VotingWidget";
 import { getLayout, LAYOUT_MAX_WIDTH } from "@layouts/main";
 import { useRouter } from "next/router";
-import ReactMarkdown from "react-markdown";
+import MarkdownRenderer from "@components/MarkdownRenderer";
 import remarkGfm from "remark-gfm";
 import { abbreviateNumber } from "../../lib/utils";
 
@@ -330,9 +330,9 @@ const Poll = () => {
                   },
                 }}
               >
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                <MarkdownRenderer remarkPlugins={[remarkGfm]}>
                   {pollData.attributes?.text ?? ""}
-                </ReactMarkdown>
+                </MarkdownRenderer>
               </Card>
             </Box>
           </Flex>


### PR DESCRIPTION
This pull request improves the styling of tables when rendering markdown, ensuring better readability and a more polished appearance.

@victorges, we could also use [github-markdown-css](https://github.com/sindresorhus/github-markdown-css), as it's commonly used by [react-markdown](https://remarkjs.github.io/react-markdown/). However, I felt that adding such a large amount of CSS didn't make sense for our use case, so I implemented some custom styling instead.
