### PR TITLE
feat: add proposal support tooltip

### DIFF
--- a/pages/treasury/[proposal].tsx
+++ b/pages/treasury/[proposal].tsx
@@ -249,7 +249,7 @@ const Proposal = () => {
               >
                 <Stat
                   css={{ flex: 1, mb: 0 }}
-                  tooltip="Total support is calculated as the stake of 'for' votes divided by the sum of 'for' and 'against' votes. Abstain votes are excluded."
+                  tooltip="Total support is calculated as the 'for' votes divided by the sum of 'for' and 'against' votes. Abstain votes are excluded."
                   label={
                     <Box>
                       Total Support ({formatPercent(+proposal.quota / 1000000)}

--- a/pages/treasury/[proposal].tsx
+++ b/pages/treasury/[proposal].tsx
@@ -249,6 +249,7 @@ const Proposal = () => {
               >
                 <Stat
                   css={{ flex: 1, mb: 0 }}
+                  tooltip="Total support is calculated as the stake of 'for' votes divided by the sum of 'for' and 'against' votes. Abstain votes are excluded."
                   label={
                     <Box>
                       Total Support ({formatPercent(+proposal.quota / 1000000)}

--- a/pages/treasury/[proposal].tsx
+++ b/pages/treasury/[proposal].tsx
@@ -326,6 +326,7 @@ const Proposal = () => {
 
                 <Stat
                   css={{ flex: 1, mb: 0 }}
+                  tooltip="Total participation counts all voters who have voted 'for', 'against', or 'abstain'."
                   label={
                     <Box>
                       Total Participation (
@@ -583,9 +584,7 @@ const Proposal = () => {
                 >
                   Description
                 </Heading>
-                <MarkdownRenderer>
-                  {proposal.description}
-                </MarkdownRenderer>
+                <MarkdownRenderer>{proposal.description}</MarkdownRenderer>
               </Card>
             </Box>
           </Flex>

--- a/pages/treasury/[proposal].tsx
+++ b/pages/treasury/[proposal].tsx
@@ -249,7 +249,10 @@ const Proposal = () => {
               >
                 <Stat
                   css={{ flex: 1, mb: 0 }}
-                  tooltip="Total support is calculated as the 'for' votes divided by the sum of 'for' and 'against' votes. Abstain votes are excluded."
+                  tooltip={`
+                    Total Support = (For votes) ÷ (For votes + Against votes).
+                    Abstentions are not included in the Total Support calculation.
+                  `}
                   label={
                     <Box>
                       Total Support ({formatPercent(+proposal.quota / 1000000)}
@@ -326,7 +329,10 @@ const Proposal = () => {
 
                 <Stat
                   css={{ flex: 1, mb: 0 }}
-                  tooltip="Total participation counts all voters who have voted 'for', 'against', or 'abstain'."
+                  tooltip={`
+                    Total Participation = (For votes + Against votes + Abstain votes) ÷
+                    (Voters + Nonvoters).
+                  `}
                   label={
                     <Box>
                       Total Participation (


### PR DESCRIPTION
This pull request adds a tooltip to the treasury proposal page explaining how total support is calculated. This helps prevent confusion for users who see the support percentage being higher than the "For" percentage.