### PR TITLE
fix: ensure one public RPC client is used

### DIFF
--- a/lib/chains.ts
+++ b/lib/chains.ts
@@ -18,14 +18,14 @@ export const WALLET_CONNECT_PROJECT_ID =
 
 export const INFURA_KEY = process.env.NEXT_PUBLIC_INFURA_KEY;
 const NETWORK = process.env.NEXT_PUBLIC_NETWORK;
+const L1_RPC_URL = process.env.NEXT_PUBLIC_L1_RPC_URL;
+const L2_RPC_URL = process.env.NEXT_PUBLIC_L2_RPC_URL;
 
 const SUBGRAPH_KEY = process.env.NEXT_PUBLIC_SUBGRAPH_API_KEY;
 const SUBGRAPH_ID = process.env.NEXT_PUBLIC_SUBGRAPH_ID;
 
-if (typeof INFURA_KEY === "undefined" || typeof NETWORK === "undefined") {
-  throw new Error(
-    `NEXT_PUBLIC_INFURA_KEY and NETWORK must be defined environment variables`
-  );
+if (!INFURA_KEY && (!L1_RPC_URL || !L2_RPC_URL)) {
+  throw new Error("Missing environment variables: NEXT_PUBLIC_INFURA_KEY or both NEXT_PUBLIC_L1_RPC_URL and NEXT_PUBLIC_L2_RPC_URL must be defined");
 }
 
 export const AVERAGE_L1_BLOCK_TIME = 12; // ethereum blocks come in at exactly 12s +99% of the time
@@ -125,9 +125,9 @@ export const ALL_SUPPORTED_CHAIN_IDS = [
  * configured in the environment variables.
  */
 export const INFURA_NETWORK_URLS = {
-  [chain.mainnet.id]: process.env.NEXT_PUBLIC_L1_RPC_URL || `https://mainnet.infura.io/v3/${INFURA_KEY}`,
+  [chain.mainnet.id]: L1_RPC_URL || `https://mainnet.infura.io/v3/${INFURA_KEY}`,
   // [chain.goerli.id]: `https://rinkeby.infura.io/v3/${INFURA_KEY}`,
-  [chain.arbitrum.id]: process.env.NEXT_PUBLIC_L2_RPC_URL || `https://arbitrum-mainnet.infura.io/v3/${INFURA_KEY}`,
+  [chain.arbitrum.id]: L2_RPC_URL || `https://arbitrum-mainnet.infura.io/v3/${INFURA_KEY}`,
   // [chain.arbitrumGoerli
   //   .id]: `https://arbitrum-rinkeby.infura.io/v3/${INFURA_KEY}`,
 };

--- a/lib/utils.tsx
+++ b/lib/utils.tsx
@@ -5,10 +5,6 @@ import { StakingAction } from "hooks";
 import { CHAIN_INFO, DEFAULT_CHAIN_ID, INFURA_NETWORK_URLS } from "lib/chains";
 import Numeral from "numeral";
 
-export const provider = new ethers.providers.JsonRpcProvider(
-  INFURA_NETWORK_URLS[DEFAULT_CHAIN_ID]
-);
-
 export function avg(obj, key) {
   const arr = Object.values(obj);
   const sum = (prev, cur) => ({ [key]: prev[key] + cur[key] });

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,15 +6,13 @@ import "@rainbow-me/rainbowkit/styles.css";
 import rainbowTheme from "constants/rainbowTheme";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import Layout from "layouts/main";
-import { DEFAULT_CHAIN, WALLET_CONNECT_PROJECT_ID, INFURA_KEY, L1_CHAIN } from "lib/chains";
+import { DEFAULT_CHAIN, WALLET_CONNECT_PROJECT_ID, L1_CHAIN, l1PublicClient, l2PublicClient} from "lib/chains";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useMemo } from "react";
 import { CookiesProvider } from "react-cookie";
 import { SWRConfig } from "swr";
-import { configureChains, createConfig, WagmiConfig } from "wagmi";
-import { infuraProvider } from "wagmi/providers/infura";
-import { publicProvider } from "wagmi/providers/public";
+import { createConfig, WagmiConfig } from "wagmi";
 import { useApollo } from "../apollo";
 
 function App({ Component, pageProps, fallback = null }) {
@@ -25,10 +23,8 @@ function App({ Component, pageProps, fallback = null }) {
   const isMigrateRoute = useMemo(() => route.includes("/migrate"), [route]);
 
   const { config, chains, layoutKey } = useMemo(() => {
-    const { chains, publicClient } = configureChains(
-      [isMigrateRoute ? L1_CHAIN : DEFAULT_CHAIN],
-      [infuraProvider({ apiKey: INFURA_KEY ?? "" }), publicProvider()]
-    );
+    const chains = [isMigrateRoute ? L1_CHAIN : DEFAULT_CHAIN];
+    const publicClient = isMigrateRoute ? l1PublicClient : l2PublicClient;
 
     const { connectors } = getDefaultWallets({
       appName: "Livepeer Explorer",


### PR DESCRIPTION
This pull request ensures that only one public rpc client is used on the explorer.
