### PR TITLE
docs: replace temporary Discord invite URL with permanent URL

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,16 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
   "prettier.printWidth": 80,
-  "editor.formatOnSaveMode": "modifications"
+  "editor.formatOnSaveMode": "modifications",
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#29a578",
+    "activityBar.background": "#29a578",
+    "activityBar.foreground": "#e7e7e7",
+    "activityBar.inactiveForeground": "#e7e7e799",
+    "activityBarBadge.background": "#e4ccf2",
+    "activityBarBadge.foreground": "#15202b",
+    "sash.hoverBorder": "#29a578",
+    "tab.activeBorder": "#29a578"
+  },
+  "peacock.color": "#1f7c5a"
 }

--- a/components/Claim/index.tsx
+++ b/components/Claim/index.tsx
@@ -239,7 +239,7 @@ const Claim = () => {
           )}
           <Button
             as="a"
-            href="https://discord.gg/XYJ7aVNqkS"
+            href="https://discord.gg/livepeer"
             target="_blank"
             size="3"
             variant="transparentWhite"

--- a/components/Drawer/index.tsx
+++ b/components/Drawer/index.tsx
@@ -163,7 +163,7 @@ const Index = ({ items = [], open, onDrawerOpen, onDrawerClose }: any) => {
               </UniswapModal>
               <A
                 css={{ fontSize: "$2", mb: "$2", display: "block" }}
-                href="https://discord.gg/uaPhtyrWsF"
+                href="https://discord.gg/livepeer"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -630,7 +630,7 @@ const Layout = ({ children, title = "Livepeer Explorer" }) => {
                                 </PopoverLink>
                                 <PopoverLink
                                   newWindow={true}
-                                  href={`https://discord.gg/uaPhtyrWsF`}
+                                  href={`https://discord.gg/livepeer`}
                                 >
                                   Discord
                                 </PopoverLink>

--- a/pages/migrate/broadcaster.tsx
+++ b/pages/migrate/broadcaster.tsx
@@ -794,7 +794,7 @@ const MigrateBroadcaster = () => {
           <Button
             css={{ bottom: 20, right: 20 }}
             as="a"
-            href="https://discord.gg/XYJ7aVNqkS"
+            href="https://discord.gg/livepeer"
             target="_blank"
             size="3"
             ghost

--- a/pages/migrate/delegator/index.tsx
+++ b/pages/migrate/delegator/index.tsx
@@ -780,7 +780,7 @@ const MigrateUndelegatedStake = () => {
           <Button
             css={{ bottom: 20, right: 20 }}
             as="a"
-            href="https://discord.gg/XYJ7aVNqkS"
+            href="https://discord.gg/livepeer"
             target="_blank"
             size="3"
             ghost

--- a/pages/migrate/orchestrator.tsx
+++ b/pages/migrate/orchestrator.tsx
@@ -784,7 +784,7 @@ const MigrateOrchestrator = () => {
           <Button
             css={{ bottom: 20, right: 20 }}
             as="a"
-            href="https://discord.gg/XYJ7aVNqkS"
+            href="https://discord.gg/livepeer"
             target="_blank"
             size="3"
             ghost


### PR DESCRIPTION
This pull request updates the Discord invite URL from a temporary (expiring) link to a fixed (permanent) one to ensure long-term accessibility.
