### PR TITLE
api/ens-data: properly handle errors

### DIFF
--- a/pages/api/ens-data/index.tsx
+++ b/pages/api/ens-data/index.tsx
@@ -50,7 +50,7 @@ const handler = async (
         await Promise.all(
           addresses.map(async (address) => {
             try {
-              return getEnsForAddress(address as Address);
+              return await getEnsForAddress(address as Address);
             } catch (e) {}
 
             return null;


### PR DESCRIPTION
The `return` was causing the catch block never to fire and crash all of https://explorer.livepeer.org/api/ens-data, `return await` fixes that.