### PR TITLE
chore: fix a syntax bug with the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: Report a bug or unexpected behavior in our project.
-title: ""
 labels: ["needs-triage"]
 type: bug
 

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,5 @@
 name: Feature Request
 description: Suggest an idea or enhancement for this project.
-title: ""
 labels: ["needs-triage"]
 type: feature
 


### PR DESCRIPTION
This pull request fixes a bug in the issue template which break due to a empty title key to be included.