### PR TITLE
chore: add ECWireless as repo-wide code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repo
+* @ECWireless


### PR DESCRIPTION
Add @ECWireless as the repository wide code-owner so people are aware they need an approval from him before merging things in to not disrupt the https://github.com/orgs/livepeer/projects/6 project.