### PR TITLE
fix: revert manual useActiveChain detection

### DIFF
--- a/hooks/wallet.tsx
+++ b/hooks/wallet.tsx
@@ -1,5 +1,5 @@
 import { Signer } from "ethers";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useAccount, useDisconnect } from "wagmi";
 import { ALL_SUPPORTED_CHAIN_IDS } from "@lib/chains";
 
@@ -9,7 +9,7 @@ const useIsChainSupported = () => {
   return useMemo(
     () =>
       activeChain
-        ? ALL_SUPPORTED_CHAIN_IDS.map((chain) => chain.id).includes(
+        ? ALL_SUPPORTED_CHAIN_IDS.map((chain) => chain.id as number).includes(
             activeChain.id
           )
         : false,
@@ -48,35 +48,8 @@ export const useAccountSigner = () => {
 };
 
 export const useActiveChain = () => {
-  const { connector, status } = useAccount();
-  const [chainId, setChainId] = useState<number | null>(null);
-
-  useEffect(() => {
-    let provider: any;
-    let unsub: (() => void) | undefined;
-
-    (async () => {
-      provider = await connector?.getProvider?.();
-      if (!provider?.request) return;
-
-      const hex = await provider.request({ method: "eth_chainId" });
-      setChainId(parseInt(hex, 16));
-
-      const onChainChanged = (nextHex: string) =>
-        setChainId(parseInt(nextHex, 16));
-      provider.on?.("chainChanged", onChainChanged);
-      unsub = () => provider.removeListener?.("chainChanged", onChainChanged);
-    })();
-
-    return () => unsub?.();
-  }, [connector, status]);
-
-  const activeChain = useMemo(
-    () => ALL_SUPPORTED_CHAIN_IDS.find((chain) => chain.id === chainId),
-    [chainId]
-  );
-
-  return activeChain;
+  const { chain } = useAccount();
+  return chain;
 };
 
 export function useDisconnectWallet() {


### PR DESCRIPTION
Closes #375 

Ultimately, this hook was having an effect on the stability of account injection for WalletConnect connections. Moving to a simpler solutions works fine, but it means `mainnet` is considered the "Wrong Network" until you go to the migrate page (which is the only place it can be used anyway).

### AI Summary

This pull request refactors the `useActiveChain` hook in `hooks/wallet.tsx` to simplify chain detection logic and improve reliability by leveraging the `chain` property from `useAccount` instead of manually tracking chain changes. It also makes a minor type adjustment to ensure compatibility with TypeScript.

**Wallet hook refactoring:**

* Replaced the custom chain detection logic in `useActiveChain` with a direct return of the `chain` property from `useAccount`, removing the need for manual event listeners and state management.

**Type improvements:**

* Updated the mapping in `useIsChainSupported` to explicitly cast `chain.id` to `number` to ensure type safety.

**Code cleanup:**

* Removed unused `useEffect` import after eliminating the manual chain detection logic.