### PR TITLE
refactor: replace deprecated QRCode default export

### DIFF
--- a/components/AccountCell/index.tsx
+++ b/components/AccountCell/index.tsx
@@ -1,4 +1,4 @@
-import QRCode from "qrcode.react";
+import { QRCodeCanvas } from "qrcode.react";
 import { textTruncate } from "@lib/utils";
 import { Box, Flex } from "@livepeer/design-system";
 import { useEnsData } from "hooks";
@@ -46,7 +46,7 @@ const Index = ({ active, address }) => {
             src={identity.avatar}
           />
         ) : (
-          <QRCode
+          <QRCodeCanvas
             style={{
               borderRadius: 1000,
               width: 24,

--- a/components/DelegatingWidget/Header.tsx
+++ b/components/DelegatingWidget/Header.tsx
@@ -1,4 +1,4 @@
-import QRCode from "qrcode.react";
+import { QRCodeCanvas } from "qrcode.react";
 import { Heading, Box, Flex } from "@livepeer/design-system";
 import { EnsIdentity } from "@lib/api/types/get-ens";
 
@@ -35,7 +35,7 @@ const Header = ({
             src={delegateProfile.avatar}
           />
         ) : (
-          <QRCode
+          <QRCodeCanvas
             style={{
               borderRadius: 1000,
               width: 40,

--- a/components/OrchestratorList/index.tsx
+++ b/components/OrchestratorList/index.tsx
@@ -27,7 +27,7 @@ import {
 import dayjs from "@lib/dayjs";
 import Link from "next/link";
 import numeral from "numeral";
-import QRCode from "qrcode.react";
+import { QRCodeCanvas } from "qrcode.react";
 import { useCallback, useMemo, useState } from "react";
 import { useBondingManagerAddress } from "hooks/useContracts";
 
@@ -296,7 +296,7 @@ const OrchestratorList = ({
                         overflow: "hidden",
                       }}
                     >
-                      <QRCode
+                      <QRCodeCanvas
                         fgColor={`#${row.values.id.substr(2, 6)}`}
                         size={24}
                         value={row.values.id}

--- a/components/PerformanceList/index.tsx
+++ b/components/PerformanceList/index.tsx
@@ -5,7 +5,7 @@ import { QuestionMarkCircledIcon } from "@modulz/radix-icons";
 import { ExplorerTooltip } from "@components/ExplorerTooltip";
 import Link from "next/link";
 import { useMemo } from "react";
-import QRCode from "qrcode.react";
+import { QRCodeCanvas } from "qrcode.react";
 import { useAllScoreData, useEnsData } from "hooks";
 import { OrchestratorsQueryResult } from "apollo";
 import numeral from "numeral";
@@ -135,7 +135,7 @@ const PerformanceList = ({
                       overflow: "hidden",
                     }}
                   >
-                    <QRCode
+                    <QRCodeCanvas
                       fgColor={`#${row.values.id.substr(2, 6)}`}
                       size={24}
                       value={row.values.id}

--- a/components/Profile/index.tsx
+++ b/components/Profile/index.tsx
@@ -8,7 +8,7 @@ import {
   TwitterLogoIcon,
   GitHubLogoIcon,
 } from "@modulz/radix-icons";
-import QRCode from "qrcode.react";
+import { QRCodeCanvas } from "qrcode.react";
 import { useEffect, useState } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import ShowMoreText from "react-show-more-text";
@@ -82,7 +82,7 @@ const Index = ({ account, isMyAccount = false, identity }: Props) => {
                   width: "100%",
                 }}
               >
-                <QRCode
+                <QRCodeCanvas
                   fgColor={`#${account.substr(2, 6)}`}
                   size={60}
                   value={account}


### PR DESCRIPTION
This commit replaces the old default QRCode import with QRCodeCanvas everywhere,
matching the v4 qrcode.react API.
