### PR TITLE
refactor: improve small-value formatting

### DIFF
--- a/components/DelegatingView/index.tsx
+++ b/components/DelegatingView/index.tsx
@@ -187,10 +187,11 @@ const Index = ({ delegator, transcoders, protocol, currentRound }: Props) => {
                   fontSize: 26,
                 }}
               >
-                {`${numbro(pendingStake).format({
-                  mantissa: 2,
-                  average: true
-                })} LPT`}
+                {`${numbro(pendingStake).format(
+                  pendingStake > 0 && pendingStake < 0.01
+                    ? { mantissa: 4, trimMantissa: true }
+                    : { mantissa: 2, average: true, lowPrecision: false }
+                )} LPT`}
               </Box>
             ) : null
           }

--- a/components/TransactionsList/index.tsx
+++ b/components/TransactionsList/index.tsx
@@ -16,20 +16,26 @@ export const FILTERED_EVENT_TYPENAMES = [
 ];
 
 const getLptAmount = (number: number | string | undefined) => {
+  const amount = Number(number ?? 0) || 0;
   return (
-    <Badge size="1">{`${numbro(number || 0).format({
-      mantissa: 2,
-      average: true
-    })} LPT`}</Badge>
+    <Badge size="1">{`${numbro(amount).format(
+      amount > 0 && amount < 0.01
+        ? { mantissa: 4, trimMantissa: true }
+        : { mantissa: 2, average: true, lowPrecision: false }
+    )} LPT`}</Badge>
   );
 };
 
-const getEthAmount = (number: number | string | undefined) => {
+const getEthAmount = (number?: number | string) => {
+  const amount = Number(number ?? 0) || 0;
   return (
-    <Badge size="1">{`${numbro(number || 0).format({
-      mantissa: 2,
-      average: true
-    })} ETH`}</Badge>
+    <Badge size="1">
+      {`${numbro(amount).format(
+        amount > 0 && amount < 0.01
+          ? { mantissa: 4, trimMantissa: true }
+          : { mantissa: 2, average: true, lowPrecision: false  }
+      )} ETH`}
+    </Badge>
   );
 };
 


### PR DESCRIPTION
This pull request ensures ETH/LPT amounts below 0.01 stay readable while larger values keep the
existing abbreviated style across Delegating and Transactions views.