### PR TITLE
fix: update main layout image style to resolve Next warning

### DIFF
--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -756,7 +756,7 @@ const ContractAddressesPopover = ({ activeChain }: { activeChain?: Chain }) => {
           }}
         >
           <Image
-            objectFit="contain"
+            style={{ objectFit: "contain" }}
             width={18}
             height={18}
             alt={


### PR DESCRIPTION
This PR replaces the legacy objectFit prop with new syntax to satisfy Next.js 13 image API
and silence the warning.
