### PR TITLE
refactor: rename broadcaster to gateway in tooltip

### DIFF
--- a/components/OrchestratingView/index.tsx
+++ b/components/OrchestratingView/index.tsx
@@ -169,7 +169,7 @@ const Index = ({ currentRound, transcoder, isActive }: Props) => {
         <Stat
           className="masonry-grid_item"
           label="Price / Pixel"
-          tooltip="The most recent price for transcoding which the orchestrator is currently advertising off-chain to broadcasters. This may be different from on-chain pricing."
+          tooltip="The most recent price for transcoding which the orchestrator is currently advertising off-chain to gateways. This may be different from on-chain pricing."
           value={
             scores
               ? `${numbro(


### PR DESCRIPTION
This pull request ensures the orch price tooltip adheres to the new naming convention.
