### PR TITLE
fix: use notFound in getStaticProps instead of returning null

### DIFF
--- a/pages/accounts/[account]/delegating.tsx
+++ b/pages/accounts/[account]/delegating.tsx
@@ -44,7 +44,7 @@ export const getStaticProps = async (context) => {
       await getSortedOrchestrators(client);
 
     if (!sortedOrchestrators.data) {
-      return null;
+      return { notFound: true, revalidate: 300 };
     }
 
     const props: PageProps = {
@@ -64,7 +64,7 @@ export const getStaticProps = async (context) => {
     console.error(e);
   }
 
-  return null;
+  return { notFound: true, revalidate: 300 };
 };
 
 export default Delegating;

--- a/pages/accounts/[account]/history.tsx
+++ b/pages/accounts/[account]/history.tsx
@@ -44,7 +44,7 @@ export const getStaticProps = async (context) => {
       await getSortedOrchestrators(client);
 
     if (!account.data || !sortedOrchestrators.data) {
-      return null;
+      return { notFound: true, revalidate: 300 };
     }
 
     const props: PageProps = {
@@ -64,7 +64,7 @@ export const getStaticProps = async (context) => {
     console.error(e);
   }
 
-  return null;
+  return { notFound: true, revalidate: 300 };
 };
 
 export default History;

--- a/pages/accounts/[account]/orchestrating.tsx
+++ b/pages/accounts/[account]/orchestrating.tsx
@@ -44,7 +44,7 @@ export const getStaticProps = async (context) => {
       await getSortedOrchestrators(client);
 
     if (!account.data || !sortedOrchestrators.data) {
-      return null;
+      return { notFound: true, revalidate: 300 };
     }
 
     const props: PageProps = {
@@ -64,7 +64,7 @@ export const getStaticProps = async (context) => {
     console.error(e);
   }
 
-  return null;
+  return { notFound: true, revalidate: 300 };
 };
 
 export default Orchestrating;


### PR DESCRIPTION
This pull request ensures we return { notFound: true } (with revalidate) instead of null in GetStaticProps when account or sorted orchestrator data is missing. This brings the account page in line with Next.js expectations and prevents runtime errors during static generation. See the [docs](https://nextjs.org/docs/pages/api-reference/functions/get-static-props#notfound).