### PR TITLE
fix: correct orchestrators nav highlight when logged out

### DIFF
--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -444,7 +444,8 @@ const Layout = ({ children, title = "Livepeer Explorer" }) => {
                               css={{
                                 marginLeft: "$2",
                                 backgroundColor:
-                                  !asPath.includes(accountAddress ?? "") &&
+                                  (!accountAddress ||
+                                    !asPath.includes(accountAddress)) &&
                                   (asPath.includes("/accounts") ||
                                     asPath.includes("/orchestrators"))
                                     ? "hsla(0,100%,100%,.05)"


### PR DESCRIPTION
This pull request ensures the orchestrators button has the right background when the `/orchestrators` page is selected and the user is logged out
