### PR TITLE
refactor/improve history ticket formatting

### DIFF
--- a/components/DelegatingView/index.tsx
+++ b/components/DelegatingView/index.tsx
@@ -187,11 +187,10 @@ const Index = ({ delegator, transcoders, protocol, currentRound }: Props) => {
                   fontSize: 26,
                 }}
               >
-                {`${numbro(pendingStake).format(
-                  pendingStake > 0 && pendingStake < 0.01
-                    ? { mantissa: 4, trimMantissa: true }
-                    : { mantissa: 2, average: true, lowPrecision: false }
-                )} LPT`}
+                {`${numbro(pendingStake).format({
+                  mantissa: 2,
+                  average: true
+                })} LPT`}
               </Box>
             ) : null
           }

--- a/components/HistoryView/index.tsx
+++ b/components/HistoryView/index.tsx
@@ -666,7 +666,7 @@ function renderSwitch(event: any, i: number) {
               {" "}
               <Box as="span" css={{ fontWeight: 600 }}>
                 {numbro(event.amount).format({
-                  mantissa: 3,
+                  mantissa: 4,
                   average: true,
                 })}
               </Box>{" "}
@@ -728,7 +728,7 @@ function renderSwitch(event: any, i: number) {
               {" "}
               <Box as="span" css={{ fontWeight: 600 }}>
                 +{numbro(event.faceValue).format({
-                  mantissa: 3,
+                  mantissa: 4,
                   average: true,
                 })}
               </Box>{" "}

--- a/components/TransactionsList/index.tsx
+++ b/components/TransactionsList/index.tsx
@@ -16,26 +16,20 @@ export const FILTERED_EVENT_TYPENAMES = [
 ];
 
 const getLptAmount = (number: number | string | undefined) => {
-  const amount = Number(number ?? 0) || 0;
   return (
-    <Badge size="1">{`${numbro(amount).format(
-      amount > 0 && amount < 0.01
-        ? { mantissa: 4, trimMantissa: true }
-        : { mantissa: 2, average: true, lowPrecision: false }
-    )} LPT`}</Badge>
+    <Badge size="1">{`${numbro(number || 0).format({
+      mantissa: 2,
+      average: true
+    })} LPT`}</Badge>
   );
 };
 
-const getEthAmount = (number?: number | string) => {
-  const amount = Number(number ?? 0) || 0;
+const getEthAmount = (number: number | string | undefined) => {
   return (
-    <Badge size="1">
-      {`${numbro(amount).format(
-        amount > 0 && amount < 0.01
-          ? { mantissa: 4, trimMantissa: true }
-          : { mantissa: 2, average: true, lowPrecision: false  }
-      )} ETH`}
-    </Badge>
+    <Badge size="1">{`${numbro(number || 0).format({
+      mantissa: 2,
+      average: true
+    })} ETH`}</Badge>
   );
 };
 


### PR DESCRIPTION
The previous logic I added was overly tailored to small numbers. This update adopts a more consistent and general formatting approach. @Jipperism The main trade-off is that very small numbers now round to 0.0, but this provides a more reliable overall experience.