### PR TITLE
feat: add year toggle for inflation rate chart

### DIFF
--- a/components/ExplorerChart/index.tsx
+++ b/components/ExplorerChart/index.tsx
@@ -53,12 +53,7 @@ const CustomizedXAxisTick = ({ x, y, payload }) => {
   );
 };
 
-export enum Group {
-  DAY = "day",
-  WEEK = "week",
-  YEAR = "year",
-  ALL = "all",
-}
+export type Group = "day" | "week" | "year" | "all";
 
 const ExplorerChart = ({
   title,
@@ -68,7 +63,7 @@ const ExplorerChart = ({
   basePercentChange,
   unit = "none",
   type,
-  grouping = Group.DAY,
+  grouping = "day",
   onToggleGrouping,
 }: {
   title: string;
@@ -342,16 +337,16 @@ const ExplorerChart = ({
           }}
         >
           <Button
-            onClick={() => onToggleGrouping?.(Group.DAY)}
+            onClick={() => onToggleGrouping?.("day")}
             size="1"
-            variant={grouping === Group.DAY ? "primary" : "neutral"}
+            variant={grouping === "day" ? "primary" : "neutral"}
           >
             D
           </Button>
           <Button
-            onClick={() => onToggleGrouping?.(Group.WEEK)}
+            onClick={() => onToggleGrouping?.("week")}
             size="1"
-            variant={grouping === Group.WEEK ? "primary" : "neutral"}
+            variant={grouping === "week" ? "primary" : "neutral"}
             css={{ marginLeft: "$1" }}
           >
             W
@@ -367,16 +362,16 @@ const ExplorerChart = ({
           }}
         >
           <Button
-            onClick={() => onToggleGrouping(Group.YEAR)}
+            onClick={() => onToggleGrouping("year")}
             size="1"
-            variant={grouping === Group.YEAR ? "primary" : "neutral"}
+            variant={grouping === "year" ? "primary" : "neutral"}
           >
             Y
           </Button>
           <Button
-            onClick={() => onToggleGrouping(Group.ALL)}
+            onClick={() => onToggleGrouping("all")}
             size="1"
-            variant={grouping === Group.ALL ? "primary" : "neutral"}
+            variant={grouping === "all" ? "primary" : "neutral"}
             css={{ marginLeft: "$1" }}
           >
             All

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,8 @@
 import "react-circular-progressbar/dist/styles.css";
 
 import ErrorComponent from "@components/Error";
+import type { Group } from "@components/ExplorerChart";
 import ExplorerChart from "@components/ExplorerChart";
-import { Group } from "@components/ExplorerChart";
 import OrchestratorList from "@components/OrchestratorList";
 import RoundStatus from "@components/RoundStatus";
 import Spinner from "@components/Spinner";
@@ -53,10 +53,10 @@ const Panel = ({ children }) => (
 );
 
 const Charts = ({ chartData }: { chartData: HomeChartData | null }) => {
-  const [feesPaidGrouping, setFeesPaidGrouping] = useState<Group>(Group.WEEK);
+  const [feesPaidGrouping, setFeesPaidGrouping] = useState<Group>("week");
   const feesPaidData = useMemo(
     () =>
-      (feesPaidGrouping === Group.DAY
+      (feesPaidGrouping === "day"
         ? chartData?.dayData?.map((day) => ({
             x: Number(day.dateS),
             y: Number(day.volumeUsd),
@@ -68,10 +68,10 @@ const Charts = ({ chartData }: { chartData: HomeChartData | null }) => {
     [feesPaidGrouping, chartData]
   );
 
-  const [usageGrouping, setUsageGrouping] = useState<Group>(Group.WEEK);
+  const [usageGrouping, setUsageGrouping] = useState<Group>("week");
   const usageData = useMemo(
     () =>
-      (usageGrouping === Group.DAY
+      (usageGrouping === "day"
         ? chartData?.dayData?.map((day) => ({
             x: Number(day.dateS),
             y: Number(day.feeDerivedMinutes),
@@ -92,18 +92,15 @@ const Charts = ({ chartData }: { chartData: HomeChartData | null }) => {
     [chartData]
   );
 
-  const [inflationGrouping, setInflationGrouping] = useState<Group>(Group.ALL);
+  const [inflationGrouping, setInflationGrouping] = useState<Group>("all");
   const inflationRateData = useMemo(
     () =>
-      (inflationGrouping === Group.YEAR
-        ? chartData?.dayData?.slice(-365).map((day) => ({
-            x: Number(day.dateS),
-            y: Number(day?.inflation ?? 0) / 1000000000,
-          }))
-        : chartData?.dayData?.slice(1)?.map((day) => ({
-            x: Number(day.dateS),
-            y: Number(day?.inflation ?? 0) / 1000000000,
-          }))) ?? [],
+      chartData?.dayData
+        ?.slice(inflationGrouping === "year" ? -365 : 1)
+        .map((day) => ({
+          x: Number(day.dateS),
+          y: Number(day?.inflation ?? 0) / 1000000000,
+        })) ?? [],
     [chartData, inflationGrouping]
   );
 


### PR DESCRIPTION
This pull request refactors the chart grouping logic in the `ExplorerChart` component and its usage on the homepage. It introduces a new `Group` enum to standardize grouping options, updates all relevant code to use this enum, and adds new grouping options ("year" and "all") for line charts. This improves code maintainability and expands chart functionality.

**Refactoring and Standardization:**

* Introduced a `Group` enum (`day`, `week`, `year`, `all`) in `ExplorerChart` and updated all grouping-related props and state to use this enum instead of string literals. [[1]](diffhunk://#diff-54e2f529e1169b54d98ef2f94cfffe2c160318a61e3b7b1a6a69a0bcead17949R56-R62) [[2]](diffhunk://#diff-54e2f529e1169b54d98ef2f94cfffe2c160318a61e3b7b1a6a69a0bcead17949L64-R71) [[3]](diffhunk://#diff-54e2f529e1169b54d98ef2f94cfffe2c160318a61e3b7b1a6a69a0bcead17949L81-R89) [[4]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3R5) [[5]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3L55-R59) [[6]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3L72-R74)

**Feature Enhancements:**

* Added "year" and "all" grouping buttons for line charts in `ExplorerChart`, allowing users to view data aggregated by year or all available data.
* Implemented new grouping logic for the "Inflation Rate" chart, enabling users to toggle between yearly and all-time views. [[1]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3R94-R109) [[2]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3R177-R178)

**Code Consistency:**

* Updated all chart data selectors and grouping state in the homepage charts to use the new `Group` enum for consistency and type safety. [[1]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3L55-R59) [[2]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3L72-R74) [[3]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3R94-R109) [[4]](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3R118)