### PR TITLE
refactor: temporarily hide minute usage data with warning overlay

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -169,31 +169,63 @@ const Charts = ({ chartData }: { chartData: HomeChartData | null }) => {
         />
       </Panel>
       <Panel>
-        <ExplorerChart
-          tooltip={`The ${
-            usageGrouping === "day" ? "daily" : "weekly"
-          } usage of the network in minutes.`}
-          data={
-            usageGrouping === "week"
-              ? usageData.slice(-26)
-              : usageData.slice(-183)
-          }
-          base={Number(
-            (usageGrouping === "day"
-              ? chartData?.oneDayUsage
-              : chartData?.oneWeekUsage) ?? 0
-          )}
-          basePercentChange={Number(
-            (usageGrouping === "day"
-              ? chartData?.dailyUsageChange
-              : chartData?.weeklyUsageChange) ?? 0
-          )}
-          title={`Estimated Usage ${usageGrouping === "day" ? "(1d)" : "(7d)"}`}
-          unit="minutes"
-          type="bar"
-          grouping={usageGrouping}
-          onToggleGrouping={setUsageGrouping}
-        />
+        {/* // TODO: Remove when we finished our investigation. */}
+        <Flex css={{ position: "relative", width: "100%", height: "100%" }}>
+          <Box
+            css={{
+              width: "100%",
+              height: "100%",
+              opacity: 0.45,
+              filter: "grayscale(1)",
+              pointerEvents: "none",
+            }}
+          >
+            <ExplorerChart
+              tooltip={`The ${
+                usageGrouping === "day" ? "daily" : "weekly"
+              } usage of the network in minutes.`}
+              data={
+                usageGrouping === "week"
+                  ? usageData.slice(-26)
+                  : usageData.slice(-183)
+              }
+              base={Number(
+                (usageGrouping === "day"
+                  ? chartData?.oneDayUsage
+                  : chartData?.oneWeekUsage) ?? 0
+              )}
+              basePercentChange={Number(
+                (usageGrouping === "day"
+                  ? chartData?.dailyUsageChange
+                  : chartData?.weeklyUsageChange) ?? 0
+              )}
+              title={`Estimated Usage ${
+                usageGrouping === "day" ? "(1d)" : "(7d)"
+              }`}
+              unit="minutes"
+              type="bar"
+              grouping={usageGrouping}
+              onToggleGrouping={setUsageGrouping}
+            />
+          </Box>
+          <Box
+            css={{
+              position: "absolute",
+              inset: 0,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              textAlign: "center",
+              padding: "$4",
+              fontSize: "$1",
+              fontWeight: 500,
+              pointerEvents: "none",
+              maxWidth: 260,
+            }}
+          >
+            Data temporarily unavailable while we check the data source.
+          </Box>
+        </Flex>
       </Panel>
       <Panel>
         <ExplorerChart


### PR DESCRIPTION
As discussed internally we are not sure that last week usage minutes are correct. This pull request hides the minute-level usage data while investigating issues with the data source, and display a warning overlay in its place.

<img width="407" height="275" alt="image" src="https://github.com/user-attachments/assets/ffe7f1fe-664e-43e7-aaa6-2da6f87da855" />

