### PR TITLE
fix: make create proposal page mobile compatible

### DIFF
--- a/pages/treasury/create-proposal.tsx
+++ b/pages/treasury/create-proposal.tsx
@@ -301,9 +301,9 @@ const CreateProposal = () => {
                 },
               }}
             >
-              <Text variant="neutral" size="3">
+                <Text variant="neutral" size="3" css={{ flexShrink: 0 }}>
                 LPT receiver:
-              </Text>
+                </Text>
               <TextField
                 css={{
                   width: "100%",


### PR DESCRIPTION
Ensure that the create proposal page is formatted correctly on devices with a smaller screen size.
