### PR TITLE
fix: reverse order of internal transaction events

### DIFF
--- a/components/HistoryView/index.tsx
+++ b/components/HistoryView/index.tsx
@@ -41,7 +41,6 @@ const Index = () => {
   const events = useMemo(() => {
     // First reverse the order of the array of events per transaction to have events in descending order
     const reversedEvents = data?.transactions?.map((tx) => {
-      if (!tx.events) return tx;
       return {
         ...tx,
         events: tx.events ? tx.events.slice().reverse() : [],


### PR DESCRIPTION
This pull request updates the way events are processed in the `HistoryView` component to ensure that events within each transaction are displayed in descending order. This improves the chronological clarity of the event list for users.

**Event ordering improvements:**

* Modified the `events` memoized value in `components/HistoryView/index.tsx` to reverse the order of events within each transaction before flattening, ensuring events are shown in descending order.