### PR TITLE
refactor: add loading skeleton to treasury balance

### DIFF
--- a/pages/treasury/create-proposal.tsx
+++ b/pages/treasury/create-proposal.tsx
@@ -197,7 +197,7 @@ const CreateProposal = () => {
             }}
           >
             Treasury Balance:{" "}
-            {treasuryBalance ? (
+            {treasuryBalance !== undefined && treasuryBalance !== null ? (
               <>{formatLPT(treasuryBalance)}</>
             ) : (
               <Skeleton


### PR DESCRIPTION
Ensure that the treasury balance page has a loading skeleton for showcasing the balance so that on mobile the layout doesn't shift on load.
