### PR TITLE
chore: add codegen warning header

### DIFF
--- a/apollo/subgraph.ts
+++ b/apollo/subgraph.ts
@@ -1,3 +1,9 @@
+/**
+ * @generated
+ * This file was automatically generated and should not be edited.
+ * To add new queries, mutations, or subscriptions, create or update files in the queries folder.
+ */
+
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;

--- a/codegen.yml
+++ b/codegen.yml
@@ -4,6 +4,13 @@ documents: ./queries/**/*.graphql
 generates:
   ./apollo/subgraph.ts:
     plugins:
+      - add:
+          content: |
+            /**
+             * @generated
+             * This file was automatically generated and should not be edited.
+             * To add new queries, mutations, or subscriptions, create or update files in the queries folder.
+             */
       - typescript
       - typescript-operations
       - typescript-react-apollo


### PR DESCRIPTION
Ensure developers are aware that the `apollo/subgraph.ts` file is autogenerated.
