### PR TITLE
fix: bring back revalidateOnFocus for SWR

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -56,7 +56,6 @@ function App({ Component, pageProps, fallback = null }) {
                   fetcher: fetcher,
                   keepPreviousData: true,
                   loadingTimeout: 40000,
-                  revalidateOnFocus: false,
                 }}
               >
                 <CookiesProvider>


### PR DESCRIPTION
`revalidateOnFocus: false` was causing user balances to remain stale after transactions (like delegation) were made.