### PR TITLE
refactor: adjust round status spinner position

### DIFF
--- a/components/RoundStatus/index.tsx
+++ b/components/RoundStatus/index.tsx
@@ -163,6 +163,7 @@ const Index = ({
           <Flex
             css={{
               width: "100%",
+              minHeight: 240,
               justifyContent: "center",
               alignItems: "center",
             }}


### PR DESCRIPTION
Lower the spinner to account for the real size of the status widget.

**old:**

<img width="431" height="507" alt="image" src="https://github.com/user-attachments/assets/783c3c69-b292-4094-a3e4-3424683f9f7b" />

**new:**

<img width="431" height="507" alt="image" src="https://github.com/user-attachments/assets/d9b0dbbe-3000-43db-a581-274b3dbf7480" />
