### PR TITLE
chore: bump sanitize-html to 2.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "recharts": "^2.15.4",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "4.0.1",
-    "sanitize-html": "^2.12.1",
+    "sanitize-html": "^2.17.0",
     "swr": "^2.3.7",
     "viem": "^2.38.5",
     "wagmi": "^2.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,8 +235,8 @@ importers:
         specifier: 4.0.1
         version: 4.0.1
       sanitize-html:
-        specifier: ^2.12.1
-        version: 2.12.1
+        specifier: ^2.17.0
+        version: 2.17.0
       swr:
         specifier: ^2.3.7
         version: 2.3.7(react@19.2.1)
@@ -8875,8 +8875,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sanitize-html@2.12.1:
-    resolution: {integrity: sha512-Plh+JAn0UVDpBRP/xEjsk+xDCoOvMBwQUf/K+/cBAVuTbtX8bj2VB7S1sL1dssVpykqp0/KPSesHrqXtokVBpA==}
+  sanitize-html@2.17.0:
+    resolution: {integrity: sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -21995,7 +21995,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanitize-html@2.12.1:
+  sanitize-html@2.17.0:
     dependencies:
       deepmerge: 4.3.1
       escape-string-regexp: 4.0.0


### PR DESCRIPTION
Replaces https://github.com/livepeer/explorer/pull/262