### PR TITLE
fix: improve error handling in account data fetching

### DIFF
--- a/pages/accounts/[account]/history.tsx
+++ b/pages/accounts/[account]/history.tsx
@@ -53,11 +53,23 @@ export const getStaticProps = async (context: {
       context.params?.account?.toString().toLowerCase()
     );
 
+    // If we couldn't fetch account data, treat it as a temporary error
+    if (!account.data) {
+      throw new Error("Failed to fetch account data");
+    }
+
     const { sortedOrchestrators, fallback: sortedOrchestratorsFallback } =
       await getSortedOrchestrators(client);
 
-    if (!account.data || !sortedOrchestrators.data) {
-      return { notFound: true, revalidate: 300 };
+    // If we couldn't fetch orchestrators data, treat it as a temporary error
+    if (!sortedOrchestrators.data) {
+      throw new Error("Failed to fetch orchestrators data");
+    }
+
+    // Only return 404 if the account truly doesn't exist (no delegator AND no transcoder)
+    // Don't cache 404s to avoid stale 404 responses from transient failures
+    if (!account.data?.delegator && !account.data?.transcoder) {
+      return { notFound: true };
     }
 
     const props: PageProps = {

--- a/pages/accounts/[account]/orchestrating.tsx
+++ b/pages/accounts/[account]/orchestrating.tsx
@@ -57,11 +57,23 @@ export const getStaticProps = async (context: {
       context.params?.account?.toString().toLowerCase()
     );
 
+    // If we couldn't fetch account data, treat it as a temporary error
+    if (!account.data) {
+      throw new Error("Failed to fetch account data");
+    }
+
     const { sortedOrchestrators, fallback: sortedOrchestratorsFallback } =
       await getSortedOrchestrators(client);
 
-    if (!account.data || !sortedOrchestrators.data) {
-      return { notFound: true, revalidate: 300 };
+    // If we couldn't fetch orchestrators data, treat it as a temporary error
+    if (!sortedOrchestrators.data) {
+      throw new Error("Failed to fetch orchestrators data");
+    }
+
+    // Only return 404 if the account truly doesn't exist (no delegator AND no transcoder)
+    // Don't cache 404s to avoid stale 404 responses from transient failures
+    if (!account.data?.delegator && !account.data?.transcoder) {
+      return { notFound: true };
     }
 
     const props: PageProps = {


### PR DESCRIPTION
* Added error handling for account and orchestrators data fetching in the getStaticProps function across multiple account pages.
* Updated logic to return 404 only if the account truly doesn't exist, avoiding stale responses from transient failures.

Closes #195 