### PR TITLE
feat: add account data revalidation after undelegation

### DIFF
--- a/components/DelegatingWidget/Undelegate.tsx
+++ b/components/DelegatingWidget/Undelegate.tsx
@@ -12,7 +12,6 @@ import { useAccountAddress } from "hooks";
 import { useBondingManagerAddress } from "hooks/useContracts";
 import { useHandleTransaction } from "hooks/useHandleTransaction";
 import { useState } from "react";
-import { useSWRConfig } from "swr";
 import { parseEther } from "viem";
 import { useSimulateContract, useWriteContract } from "wagmi";
 
@@ -61,17 +60,11 @@ const Undelegate = ({
     wasDeactivated: willDeactivate,
   });
 
-  const { mutate } = useSWRConfig();
   const handleUndelegate = () => {
     if (willDeactivate) {
       setShowConfirmDialog(true);
     } else if (config) {
       writeContract(config.request);
-      if (accountAddress) {
-        setTimeout(() => {
-          mutate(`/api/ssr/account/${accountAddress.toLowerCase()}`);
-        }, 15000);
-      }
     }
   };
 

--- a/layouts/account.tsx
+++ b/layouts/account.tsx
@@ -90,6 +90,18 @@ const AccountLayout = ({
     pollInterval,
   });
 
+  // Fetch fresh account data client-side, using static props as fallback
+  const { data: dataViewedAccount } = useAccountQuery({
+    variables: {
+      account: accountId ?? "",
+    },
+    skip: !accountId,
+    pollInterval,
+  });
+
+  // Prefer client-fetched data over static props
+  const viewedAccount = dataViewedAccount ?? account;
+
   const { data: bondingManagerAddress } = useBondingManagerAddress();
   const { data: treasuryRewardCutRate = BigInt(0.0) } = useReadContract({
     query: { enabled: Boolean(bondingManagerAddress) },
@@ -109,15 +121,18 @@ const AccountLayout = ({
   }, [latestTransaction?.step]);
 
   const isActive = useMemo(
-    () => Boolean(account?.transcoder?.active),
-    [account?.transcoder]
+    () => Boolean(viewedAccount?.transcoder?.active),
+    [viewedAccount?.transcoder]
   );
 
   const isMyAccount = useMemo(
     () => checkAddressEquality(accountAddress ?? "", accountId ?? ""),
     [accountAddress, accountId]
   );
-  const isOrchestrator = useMemo(() => Boolean(account?.transcoder), [account]);
+  const isOrchestrator = useMemo(
+    () => Boolean(viewedAccount?.transcoder),
+    [viewedAccount]
+  );
   const isMyDelegate = useMemo(
     () => accountId === dataMyAccount?.delegator?.delegate?.id.toLowerCase(),
     [accountId, dataMyAccount]
@@ -214,9 +229,9 @@ const AccountLayout = ({
                     transcoder={
                       isDelegatingAndIsMyAccountView
                         ? dataMyAccount?.delegator?.delegate
-                        : account?.transcoder
+                        : viewedAccount?.transcoder
                     }
-                    protocol={account?.protocol}
+                    protocol={viewedAccount?.protocol}
                     treasury={treasury}
                     delegateProfile={identity}
                   />
@@ -252,9 +267,9 @@ const AccountLayout = ({
                       transcoder={
                         isDelegatingAndIsMyAccountView
                           ? dataMyAccount?.delegator?.delegate
-                          : account?.transcoder
+                          : viewedAccount?.transcoder
                       }
-                      protocol={account?.protocol}
+                      protocol={viewedAccount?.protocol}
                       treasury={treasury}
                       delegateProfile={identity}
                     />
@@ -298,16 +313,16 @@ const AccountLayout = ({
           {view === "orchestrating" && (
             <OrchestratingView
               isActive={isActive}
-              currentRound={account?.protocol?.currentRound}
-              transcoder={account?.transcoder}
+              currentRound={viewedAccount?.protocol?.currentRound}
+              transcoder={viewedAccount?.transcoder}
             />
           )}
           {view === "delegating" && (
             <DelegatingView
               transcoders={sortedOrchestrators?.transcoders}
-              delegator={account?.delegator}
-              protocol={account?.protocol}
-              currentRound={account?.protocol?.currentRound}
+              delegator={viewedAccount?.delegator}
+              protocol={viewedAccount?.protocol}
+              currentRound={viewedAccount?.protocol?.currentRound}
             />
           )}
           {view === "history" && <HistoryView />}
@@ -334,9 +349,9 @@ const AccountLayout = ({
                 transcoder={
                   isDelegatingAndIsMyAccountView
                     ? dataMyAccount?.delegator?.delegate
-                    : account?.transcoder
+                    : viewedAccount?.transcoder
                 }
-                protocol={account?.protocol}
+                protocol={viewedAccount?.protocol}
                 treasury={treasury}
                 delegateProfile={identity}
               />
@@ -350,9 +365,9 @@ const AccountLayout = ({
                 transcoder={
                   isDelegatingAndIsMyAccountView
                     ? dataMyAccount?.delegator?.delegate
-                    : account?.transcoder
+                    : viewedAccount?.transcoder
                 }
-                protocol={account?.protocol}
+                protocol={viewedAccount?.protocol}
                 treasury={treasury}
                 delegateProfile={identity}
               />


### PR DESCRIPTION
Enhances the Undelegate component by introducing a revalidation mechanism for account data using SWR. After a successful undelegation, the account data is refreshed after a 15-second delay to ensure the UI reflects the latest state.