### PR TITLE
fix: Update poll choice name in confirmation text

### DIFF
--- a/components/VoteButton/index.tsx
+++ b/components/VoteButton/index.tsx
@@ -66,8 +66,8 @@ const Index = ({
   useHandleTransaction("vote", data, error, isPending, isSuccess, {
     choiceId,
     choiceName: proposalId
-      ? { 0: "Against", 1: "For", 2: "Abstain" }[choiceId]
-      : { 0: "No", 1: "Yes" }[choiceId],
+      ? { 0: "Against", 1: "For", 2: "Abstain" }[choiceId] // TreasuryVoteSupport on treasury proposals
+      : { 0: "Yes", 1: "No" }[choiceId], // PollChoice on governance polls
     reason,
   });
 


### PR DESCRIPTION
This pull request makes a minor update to the vote button `useHandleTransaction` logic to ensure that the correct choice name is displayed in the transaction confirmation modal.

- Updated the mapping for choice names in governance polls so that `0` now maps to "Yes" and `1` to "No", aligning with the expected order for PollChoice.