### PR TITLE
feat: render treasury cut in OrchestratorList

### DIFF
--- a/components/OrchestratorList/index.tsx
+++ b/components/OrchestratorList/index.tsx
@@ -140,7 +140,7 @@ const OrchestratorList = ({
           "days"
         );
 
-        const treasuryCutNumber = Number(
+        const treasuryCutDecimal = Number(
           formatUnits(treasuryRewardCutRate, 27)
         );
 
@@ -169,7 +169,7 @@ const OrchestratorList = ({
 
             rewardCallRatio,
             rewardCut: Number(row.rewardCut) / 1000000,
-            treasuryRewardCut: treasuryCutNumber,
+            treasuryRewardCut: treasuryCutDecimal,
           },
         });
 
@@ -186,7 +186,7 @@ const OrchestratorList = ({
                 .divide(pools.length)
                 .format({ mantissa: 0, output: "percent" })}`
             : "0%";
-        const formattedTreasuryCut = numbro(treasuryCutNumber).format({
+        const formattedTreasuryCut = numbro(treasuryCutDecimal).format({
           mantissa: 0,
           output: "percent",
         });


### PR DESCRIPTION
This pull request enhances the display and calculation of the "Treasury cut" in the `OrchestratorList` component, ensuring it is accurately computed, formatted, and surfaced in the UI. The changes focus on improving the correctness of the treasury cut calculation and making this protocol data visible to users.

<img width="452" height="607" alt="Screenshot 2026-01-16 at 8 19 11 AM" src="https://github.com/user-attachments/assets/912244fe-071b-4a19-921e-cba5e6d40ea8" />


**Treasury cut calculation and formatting improvements:**

* Updated the calculation of `treasuryRewardCut` to use `Number(formatUnits(treasuryRewardCutRate, 27));`, ensuring correct handling of BigInt division and scaling.
* Added a formatted version of the treasury cut (`formattedTreasuryCut`) using the `numbro` library for percentage display.
* Included the formatted treasury cut in the row data returned by the list mapping logic.

**UI enhancements for protocol data:**

* Passed the formatted treasury cut value through the table row rendering logic for display.
* Added a new "Protocol Data" section to the UI, displaying the "Treasury cut" value for each orchestrator in a clearly separated and styled box.