### PR TITLE
fix: tweak StakeTransactions component for mobile

### DIFF
--- a/components/Redelegate/index.tsx
+++ b/components/Redelegate/index.tsx
@@ -25,7 +25,13 @@ const Index = ({ unbondingLockId, newPosPrev, newPosNext }) => {
   return (
     <>
       <Button
-        css={{ marginRight: "$3" }}
+        css={{
+          marginRight: "$3",
+          width: "100%",
+          "@bp2": {
+            width: "auto",
+          },
+        }}
         disabled={!config}
         onClick={() => config && writeContract(config.request)}
         size="3"

--- a/components/RedelegateFromUndelegated/index.tsx
+++ b/components/RedelegateFromUndelegated/index.tsx
@@ -40,7 +40,13 @@ const Index = ({ unbondingLockId, delegate, newPosPrev, newPosNext }) => {
   return (
     <>
       <Button
-        css={{ marginRight: "$3" }}
+        css={{
+          marginRight: "$3",
+          width: "100%",
+          "@bp2": {
+            width: "auto",
+          },
+        }}
         disabled={!config}
         onClick={() => config && writeContract(config.request)}
         size="3"

--- a/components/StakeTransactions/index.tsx
+++ b/components/StakeTransactions/index.tsx
@@ -125,9 +125,13 @@ const Index = ({ delegator, transcoders, currentRound, isMyAccount }) => {
                     <Box
                       css={{
                         alignSelf: "flex-end",
+                        fontWeight: 700,
+                        marginTop: "$1",
                         "@bp2": {
                           alignSelf: "auto",
+                          fontWeight: 400,
                           marginLeft: "$4",
+                          marginTop: 0,
                         },
                       }}
                     >
@@ -202,8 +206,12 @@ const Index = ({ delegator, transcoders, currentRound, isMyAccount }) => {
                       <Flex
                         css={{
                           justifyContent: "flex-start",
+                          flexDirection: "column",
+                          gap: "$2",
                           width: "100%",
                           "@bp2": {
+                            flexDirection: "row",
+                            gap: 0,
                             width: "auto",
                           },
                         }}
@@ -228,9 +236,13 @@ const Index = ({ delegator, transcoders, currentRound, isMyAccount }) => {
                     <Box
                       css={{
                         alignSelf: "flex-end",
+                        fontWeight: 700,
+                        marginTop: "$1",
                         "@bp2": {
                           alignSelf: "auto",
+                          fontWeight: 400,
                           marginLeft: "$4",
+                          marginTop: 0,
                         },
                       }}
                     >

--- a/components/WithdrawStake/index.tsx
+++ b/components/WithdrawStake/index.tsx
@@ -30,7 +30,15 @@ const Index = ({ unbondingLockId }) => {
   return (
     <>
       <Button
-        css={{ paddingTop: "$2", paddingBottom: "$2", marginRight: "$3" }}
+        css={{
+          paddingTop: "$2",
+          paddingBottom: "$2",
+          marginRight: "$3",
+          width: "100%",
+          "@bp2": {
+            width: "auto",
+          },
+        }}
         disabled={!config}
         onClick={() => config && writeContract(config.request)}
         size="3"


### PR DESCRIPTION
Closes #390 

### Before

<img width="321" height="549" alt="Screenshot 2026-01-18 at 12 12 23 PM" src="https://github.com/user-attachments/assets/5d46867b-95ce-46ee-8c20-e785b463df86" />

### After

<img width="316" height="485" alt="Screenshot 2026-01-18 at 12 12 13 PM" src="https://github.com/user-attachments/assets/896a7ef6-cf5a-4d12-95c9-4834a6b5c602" />
