### PR TITLE
fix: make wallet modal accent text more readable

### DIFF
--- a/components/ConnectButton/index.tsx
+++ b/components/ConnectButton/index.tsx
@@ -2,18 +2,7 @@ import { ConnectButton as ConnectButtonRainbowKit } from "@rainbow-me/rainbowkit
 import { ConnectButtonProps } from "@rainbow-me/rainbowkit/dist/components/ConnectButton/ConnectButton";
 
 const ConnectButton = (props: ConnectButtonProps) => {
-  return (
-    <>
-      <style>{`
-        [data-rk] button[data-testid="rk-connect-button"] {
-          background-color: #113123 !important;
-          color: #4cc38a !important;
-        }
-      `}</style>
-
-      <ConnectButtonRainbowKit chainStatus="name" {...props} />
-    </>
-  );
+  return <ConnectButtonRainbowKit chainStatus="name" {...props} />;
 };
 
 export default ConnectButton;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,5 @@
 import "@rainbow-me/rainbowkit/styles.css";
+import "../styles/globals.css";
 
 import { ApolloProvider } from "@apollo/client";
 import { fetcher } from "@lib/axios";

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,5 @@
+/* Counteracts RainbowKit default accent styles for Wallet Connect button */
+[data-rk] button[data-testid="rk-connect-button"] {
+  background-color: #113123;
+  color: #4cc38a;
+}


### PR DESCRIPTION
Rainbowkit's theming is relatively frustrating since `accentColor` and `accentColorForeground` are used automatically for the connect button styles, and wallet modal accent text, and wallet modal button styles, rather than being set separately. This is the best mix I could find, but it also involved forcing the connect wallet button styles to be different via grabbing it with CSS by the attribute.

### Wallet connect button stays the same as before

<img width="409" height="57" alt="Screenshot 2026-01-20 at 7 58 05 PM" src="https://github.com/user-attachments/assets/bebe9632-1b54-44d4-8bd3-2c65dd9a8144" />

### Wallet modal before

<img width="783" height="551" alt="Screenshot 2026-01-20 at 8 06 19 PM" src="https://github.com/user-attachments/assets/6838d542-5f76-4fa1-8fe2-45f3217ecb63" />

### Wallet modal after

<img width="766" height="535" alt="Screenshot 2026-01-20 at 7 57 51 PM" src="https://github.com/user-attachments/assets/d6a9a776-6b17-4bf0-9dcc-9abf8621fb67" />

### Transaction history before

<img width="432" height="555" alt="Screenshot 2026-01-20 at 8 06 02 PM" src="https://github.com/user-attachments/assets/9037f4d7-8095-471c-a5db-1e3efe7cc65e" />

### Transaction history after

<img width="488" height="566" alt="Screenshot 2026-01-20 at 8 06 09 PM" src="https://github.com/user-attachments/assets/9cf31b99-709b-405f-8cff-5752c586acfc" />
