### PR TITLE
fix: switch to network-only with getTotalStake

### DIFF
--- a/lib/api/polls.ts
+++ b/lib/api/polls.ts
@@ -172,6 +172,7 @@ const getTotalStake = async (l2BlockNumber?: number | undefined) => {
           },
         }
       : undefined,
+    fetchPolicy: "network-only",
   });
 
   return protocolResponse?.data?.protocol?.totalActiveStake;


### PR DESCRIPTION
When the user selects the voting/governance page, the last poll in the array's stake is cached and used as in calculations for the next individual poll page that is selected. This obviously causes inaccurate data to display. The fix switches the Apollo `fetchPolicy` to `network-only`.