### PR TITLE
fix: elevate tooltip box

### DIFF
--- a/pages/treasury/[proposal].tsx
+++ b/pages/treasury/[proposal].tsx
@@ -353,7 +353,6 @@ const Proposal = () => {
                           paddingBottom: "$2",
                           marginBottom: "-1px",
                           position: "relative",
-                          zIndex: 2,
                           borderBottom: "3px solid",
                           borderColor: tab.isActive
                             ? "$primary11"
@@ -376,6 +375,8 @@ const Proposal = () => {
                   <Box
                     css={{
                       display: "grid",
+                      position: "relative",
+                      zIndex: 10,
                       gridGap: "$3",
                       gridTemplateColumns: "100%",
                       marginBottom: "$3",


### PR DESCRIPTION
## Description
This PR fixes a UI rendering issue on the Treasury Proposal page where the "Total Support" tooltip inside the Stats section were being clipped or obscured by the adjacent Tabs component (specifically the "Votes" count badge).

The collision occurred because the Tabs and Stats components shared the same stacking context level, and the tooltips inside the Stats component did not use Portals (mobile version of ExplorerTooltip component has portal), causing them to be rendered "below" the Tabs.

## Type of Change

<!-- Check all that apply -->

- [ ] feat: New feature
- [X] fix: Bug fix
- [ ] docs: Documentation update
- [ ] style: Code style/formatting changes (no logic changes)
- [ ] refactor: Code refactoring (no behavior change)
- [ ] perf: Performance improvement
- [ ] test: Adding or updating tests
- [ ] build: Build system or dependency changes
- [ ] ci: CI/CD changes
- [ ] chore: Other changes

## Related Issue(s)

<!--
Link issues this PR addresses.
Use "Closes #123" or "Fixes #123" to auto-close issues on merge.
-->

Fixes: #544 

## Changes Made
- Created a new stacking context for the Stats grid container by adding position: relative.
- Elevated the Stats container using zIndex: 10

## Testing

<!-- Check all that apply and add notes if useful -->

- [X] Tested locally
- [ ] Added/updated tests
- [ ] All tests passing

### How to test (optional unless test is not trivial)
Visit: https://explorer.livepeer.org/treasury/66006623481122611164055448787310685219437663991315059574912127986740690984549?view=overview

Assure there is a vote count available and hover over the Total Support tooltip.

## Impact / Risk
<!-- Required for all non-trivial PRs. Helps reviewers understand blast radius and safety. -->

Risk level: Low

Impacted areas: UI

User impact: Removes visual bug

Rollback plan: PR revert

## Screenshots / Recordings (if applicable)
None
<!--
Include before/after screenshots, videos, or gifs for UI changes.
-->

## Additional Notes
None
<!--
Anything else reviewers should know:
- tradeoffs
- follow-up work
- limitations
- context that didn’t fit elsewhere
-->
