### PR TITLE
fix: apply top padding to search bar dialog

### DIFF
--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -83,10 +83,6 @@ const Index = ({ css = {}, ...props }) => {
         css={{
           overflow: "auto",
           transition: "max-height 2s",
-          paddingTop: "$3",
-          "& > button:last-child": {
-            top: "$1",
-          },
         }}
         onPointerEnterCapture={undefined}
         onPointerLeaveCapture={undefined}
@@ -100,6 +96,7 @@ const Index = ({ css = {}, ...props }) => {
             width: "80vw",
             maxWidth: 700,
             position: "relative",
+            marginTop: "$4",
             ...css,
           }}
           {...props}


### PR DESCRIPTION
## Description

Ensure that the close icon does not overlap with the input field.

## Type of Change

<!-- Check all that apply -->

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [ ] style: Code style/formatting changes (no logic changes)
- [ ] refactor: Code refactoring (no behavior change)
- [ ] perf: Performance improvement
- [ ] test: Adding or updating tests
- [ ] build: Build system or dependency changes
- [ ] ci: CI/CD changes
- [ ] chore: Other changes

## Related Issue(s)

<!--
Link issues this PR addresses.
Use "Closes #123" or "Fixes #123" to auto-close issues on merge.
-->

Related: #497
Closes: #494 

## Changes Made

<!--
List the key changes in this PR.
Keep this high-level and scannable.
-->

- Added top padding to search dialog.


## Testing

<!-- Check all that apply and add notes if useful -->

- [x] Tested locally
- [ ] ~Added/updated tests~
- [x] All tests passing

### How to test (optional unless test is not trivial)

<!--
Describe how this was tested, edge cases covered, or things reviewers should try.
-->

## Impact / Risk
<!-- Required for all non-trivial PRs. Helps reviewers understand blast radius and safety. -->

Risk level: Low
Impacted areas: UI
User impact: Easier interaction with search dialog.
Rollback plan: Revert

## Screenshots / Recordings (if applicable)

<!--
Include before/after screenshots, videos, or gifs for UI changes.
-->

**Before**

<img width="463" height="727" alt="image" src="https://github.com/user-attachments/assets/10bf9576-ac74-488b-96e8-1eb7ea089d35" />

<img width="1241" height="1001" alt="image" src="https://github.com/user-attachments/assets/71b319f4-3370-47bb-aa8f-7008306b7c1d" />

**After**

<img width="461" height="727" alt="image" src="https://github.com/user-attachments/assets/25711671-355c-479f-81a4-3b5698f2e500" />

<img width="1240" height="1006" alt="image" src="https://github.com/user-attachments/assets/5c4c3f16-3266-475f-82e5-7d6bcd7e23dd" />

## Additional Notes

<!--
Anything else reviewers should know:
- tradeoffs
- follow-up work
- limitations
- context that didn’t fit elsewhere
-->
