### PR TITLE
fix: path capitalization mismatch in address

### DIFF
--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -329,6 +329,11 @@ const Layout = ({ children, title = "Livepeer Explorer" }) => {
     }
   }, []);
 
+  const isMyAccountPage = useMemo(() => {
+    if (!accountAddress) return false;
+    return asPath.toLowerCase().includes(accountAddress.toLowerCase());
+  }, [accountAddress, asPath]);
+
   return (
     <DesignSystemProviderTyped>
       <ThemeProvider
@@ -462,8 +467,7 @@ const Layout = ({ children, title = "Livepeer Explorer" }) => {
                               css={{
                                 marginLeft: "$2",
                                 backgroundColor:
-                                  (!accountAddress ||
-                                    !asPath.includes(accountAddress)) &&
+                                  (!accountAddress || !isMyAccountPage) &&
                                   (asPath.includes("/accounts") ||
                                     asPath.includes("/orchestrators"))
                                     ? "hsla(0,100%,100%,.05)"
@@ -560,9 +564,7 @@ const Layout = ({ children, title = "Livepeer Explorer" }) => {
                                 size="3"
                                 css={{
                                   marginLeft: "$2",
-                                  backgroundColor: asPath
-                                    .toLowerCase()
-                                    .includes(accountAddress.toLowerCase())
+                                  backgroundColor: isMyAccountPage
                                     ? "hsla(0,100%,100%,.05)"
                                     : "transparent",
                                   color: "white",


### PR DESCRIPTION
## Description

Changes the My Account URL <> wallet address navigation check to be all lowercase, in case the address is checksummed.

## Type of Change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [ ] style: Code style/formatting changes (no logic changes)
- [ ] refactor: Code refactoring (no behavior change)
- [ ] perf: Performance improvement
- [ ] test: Adding or updating tests
- [ ] build: Build system or dependency changes
- [ ] ci: CI/CD changes
- [ ] chore: Other changes

## Related Issue(s)

Closes: # #415 

## Changes Made

- Layout nav styling on My Account originally broke with capitalization mismatch
- This PR changes the My Account navigation URL check to use all lowercase text

## Testing

<!-- Check all that apply and add notes if useful -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] All tests passing

### How to test (optional unless test is not trivial)

NA

## Impact / Risk

Risk level: Low

Impacted areas: UI

User impact: User sees the My Account nav button as active even if the address in the URL is checksummed

## Screenshots / Recordings

NA

## Additional Notes

NA
