### PR TITLE
feat: replace Livepeer logo with new uppercase wordmark

### DIFF
--- a/components/Drawer/index.tsx
+++ b/components/Drawer/index.tsx
@@ -82,7 +82,7 @@ const Index = ({
         }}
       >
         <Box css={{ marginBottom: "$5" }}>
-          <Logo isDark id="drawer" />
+          <Logo isDark />
         </Box>
         <Box css={{ marginBottom: "auto" }}>
           {items.map((item, i) => (

--- a/components/Logo/index.tsx
+++ b/components/Logo/index.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 type Props = {
   isDark?: boolean;
   isLink?: boolean;
-  id?: string;
 };
 
 const LivepeerLogo = ({ isDark, isLink = true }: Props) => {

--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -433,7 +433,7 @@ const Layout = ({ children, title = "Livepeer Explorer" }) => {
                           },
                         }}
                       >
-                        <Logo isDark id="main" />
+                        <Logo isDark />
 
                         <Box css={{ marginLeft: "$7" }}>
                           <Link passHref href="/">


### PR DESCRIPTION
## Summary
- Replace the old animated lowercase Livepeer logo (with GSAP hover effects and grid icon) with the new static uppercase LIVEPEER wordmark SVG
- Adjust header layout: vertically center logo with nav items, tune spacing between logo and nav, tighten gaps between nav items
- Add spacing below logo in mobile drawer menu

## Test plan
- [ ] Verify new LIVEPEER wordmark renders white on dark header (desktop)
- [ ] Verify logo is vertically centered with nav items
- [ ] Verify spacing between logo and nav items looks balanced
- [ ] Verify mobile drawer shows logo with proper spacing above nav items
- [ ] Verify logo links to home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)