### PR TITLE
feat: add CLI voting instructions to treasury proposals

### DIFF
--- a/components/CliVotingInstructionsDialog/index.tsx
+++ b/components/CliVotingInstructionsDialog/index.tsx
@@ -14,7 +14,6 @@ import Check from "../../public/img/check.svg";
 import Copy from "../../public/img/copy.svg";
 
 type Props = {
-  isActive: boolean;
   voteId: string;
   idLabel: string;
   cliOptionName: string;
@@ -22,14 +21,13 @@ type Props = {
 };
 
 const CliVotingInstructionsDialog = ({
-  isActive,
   voteId,
   idLabel,
   cliOptionName,
   voteInstructions,
 }: Props) => {
-  const [modalOpen, setModalOpen] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
   const [openSnackbar] = useSnackbar();
 
   useEffect(() => {
@@ -43,42 +41,40 @@ const CliVotingInstructionsDialog = ({
 
   return (
     <>
-      {isActive && (
-        <Box
-          css={{
-            display: "none",
-            marginTop: "$3",
-            fontSize: "$1",
-            borderRadius: "$4",
-            border: "1px solid $neutral4",
-            padding: "$3",
-            "@bp3": {
-              display: "block",
-            },
-          }}
-        >
-          <Box css={{ lineHeight: 1.8 }}>
-            Are you an orchestrator?{" "}
-            <Box
-              as="button"
-              type="button"
-              onClick={() => setModalOpen(true)}
-              css={{
-                color: "$primary11",
-                cursor: "pointer",
-                background: "none",
-                border: "none",
-                padding: 0,
-                font: "inherit",
-                textDecoration: "underline",
-              }}
-            >
-              Follow these instructions
-            </Box>{" "}
-            if you prefer to vote with the Livepeer CLI.
-          </Box>
+      <Box
+        css={{
+          display: "none",
+          marginTop: "$3",
+          fontSize: "$1",
+          borderRadius: "$4",
+          border: "1px solid $neutral4",
+          padding: "$3",
+          "@bp3": {
+            display: "block",
+          },
+        }}
+      >
+        <Box css={{ lineHeight: 1.8 }}>
+          Are you an orchestrator?{" "}
+          <Box
+            as="button"
+            type="button"
+            onClick={() => setModalOpen(true)}
+            css={{
+              color: "$primary11",
+              cursor: "pointer",
+              background: "none",
+              border: "none",
+              padding: 0,
+              font: "inherit",
+              textDecoration: "underline",
+            }}
+          >
+            Follow these instructions
+          </Box>{" "}
+          if you prefer to vote with the Livepeer CLI.
         </Box>
-      )}
+      </Box>
       <Dialog onOpenChange={setModalOpen} open={modalOpen}>
         <DialogContent
           onPointerEnterCapture={undefined}

--- a/components/PollVotingWidget/index.tsx
+++ b/components/PollVotingWidget/index.tsx
@@ -343,13 +343,14 @@ const Index = ({ data }: { data: Props }) => {
         )}
       </Box>
 
-      <CliVotingInstructionsDialog
-        isActive={data.poll.status === "active"}
-        voteId={data.poll.id}
-        idLabel="poll's contract address"
-        cliOptionName="Vote on a poll"
-        voteInstructions='Enter 0 to vote "For" or 1 to vote "Against".'
-      />
+      {data.poll.status === "active" && (
+        <CliVotingInstructionsDialog
+          voteId={data.poll.id}
+          idLabel="poll's contract address"
+          cliOptionName="Vote on a poll"
+          voteInstructions='Enter 0 to vote "For" or 1 to vote "Against".'
+        />
+      )}
     </Box>
   );
 };

--- a/components/Treasury/TreasuryVotingWidget/index.tsx
+++ b/components/Treasury/TreasuryVotingWidget/index.tsx
@@ -548,13 +548,14 @@ const TreasuryVotingWidget = ({ proposal, vote, ...props }: Props) => {
           </Box>
         )}
       </Box>
-      <CliVotingInstructionsDialog
-        isActive={proposal.state === "Active"}
-        voteId={proposal.id}
-        idLabel="proposal's ID"
-        cliOptionName="Vote on a treasury proposal"
-        voteInstructions='Enter 0 to vote "Against", 1 to vote "For", or 2 to vote "Abstain".'
-      />
+      {proposal.state === "Active" && (
+        <CliVotingInstructionsDialog
+          voteId={proposal.id}
+          idLabel="proposal's ID"
+          cliOptionName="Vote on a treasury proposal"
+          voteInstructions='Enter 0 to vote "Against", 1 to vote "For", or 2 to vote "Abstain".'
+        />
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- Extracts the CLI voting instructions dialog from `PollVotingWidget` into a shared `CliVotingInstructionsDialog` component
- Adds CLI voting instructions to the treasury proposal page (`TreasuryVotingWidget`), so orchestrators can see how to vote on treasury proposals via the go-livepeer CLI
- Refactors `PollVotingWidget` to use the shared component, reducing ~130 lines of duplicated code

Closes #309

## Test plan
- [ ] Navigate to an active governance poll — verify CLI instructions trigger and dialog still work as before
- [ ] Navigate to an active treasury proposal — verify CLI instructions box appears on desktop
- [ ] Click "Follow these instructions" — verify dialog shows correct proposal ID and vote numbering (0=Against, 1=For, 2=Abstain)
- [ ] Verify copy-to-clipboard works with snackbar confirmation
- [ ] Verify trigger box is hidden on mobile viewports
- [ ] Verify trigger box is hidden for non-Active proposals

🤖 Generated with [Claude Code](https://claude.com/claude-code)