### PR TITLE
refactor: remove redundant localEnsCache and add TTL expiration

### DIFF
--- a/components/Treasury/TreasuryVoteTable/index.tsx
+++ b/components/Treasury/TreasuryVoteTable/index.tsx
@@ -14,7 +14,10 @@ import { MobileVoteCards } from "./Views/MobileVoteTable";
 // Bound size keeps memory usage predictable during long sessions.
 const ENS_CACHE_MAX_ENTRIES = 2000;
 const ENS_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
-const ensCache = new Map<string, { name: string; timestamp: number }>();
+const ensCache = new Map<
+  string,
+  { nameOrAddress: string; timestamp: number }
+>();
 const ensLookupInFlight = new Map<string, Promise<string>>();
 
 const getCachedEns = (address: string) => {
@@ -30,14 +33,14 @@ const getCachedEns = (address: string) => {
   ensCache.delete(address);
   ensCache.set(address, cached);
 
-  return cached.name;
+  return cached.nameOrAddress;
 };
 
 const setCachedEns = (address: string, ensName: string) => {
   if (ensCache.has(address)) {
     ensCache.delete(address);
   }
-  ensCache.set(address, { name: ensName, timestamp: Date.now() });
+  ensCache.set(address, { nameOrAddress: ensName, timestamp: Date.now() });
 
   if (ensCache.size > ENS_CACHE_MAX_ENTRIES) {
     const oldestKey = ensCache.keys().next().value;

--- a/components/Treasury/TreasuryVoteTable/index.tsx
+++ b/components/Treasury/TreasuryVoteTable/index.tsx
@@ -117,7 +117,7 @@ const useVotes = (proposalId: string) => {
       await Promise.all(
         uniqueVoters.map(async (address) => {
           try {
-            await resolveEnsName(address);
+            await resolveEnsName(address.toLowerCase());
           } catch (e) {
             console.warn(`Failed to fetch ENS for ${address}`, e);
           }

--- a/components/Treasury/TreasuryVoteTable/index.tsx
+++ b/components/Treasury/TreasuryVoteTable/index.tsx
@@ -13,25 +13,31 @@ import { MobileVoteCards } from "./Views/MobileVoteTable";
 // Module-level cache to avoid repeated ENS lookups across renders/navigations.
 // Bound size keeps memory usage predictable during long sessions.
 const ENS_CACHE_MAX_ENTRIES = 2000;
-const ensCache = new Map<string, string>();
+const ENS_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const ensCache = new Map<string, { name: string; timestamp: number }>();
 const ensLookupInFlight = new Map<string, Promise<string>>();
 
 const getCachedEns = (address: string) => {
   if (!ensCache.has(address)) return undefined;
   const cached = ensCache.get(address)!;
 
+  if (Date.now() - cached.timestamp > ENS_CACHE_TTL_MS) {
+    ensCache.delete(address);
+    return undefined;
+  }
+
   // Refresh insertion order so frequently used addresses stay cached.
   ensCache.delete(address);
   ensCache.set(address, cached);
 
-  return cached;
+  return cached.name;
 };
 
 const setCachedEns = (address: string, ensName: string) => {
   if (ensCache.has(address)) {
     ensCache.delete(address);
   }
-  ensCache.set(address, ensName);
+  ensCache.set(address, { name: ensName, timestamp: Date.now() });
 
   if (ensCache.size > ENS_CACHE_MAX_ENTRIES) {
     const oldestKey = ensCache.keys().next().value;
@@ -107,12 +113,11 @@ const useVotes = (proposalId: string) => {
       const uniqueVoters = Array.from(
         new Set(treasuryVotesData?.treasuryVotes?.map((v) => v.voter.id) ?? [])
       );
-      const localEnsCache: { [address: string]: string } = {};
 
       await Promise.all(
         uniqueVoters.map(async (address) => {
           try {
-            localEnsCache[address] = await resolveEnsName(address);
+            await resolveEnsName(address);
           } catch (e) {
             console.warn(`Failed to fetch ENS for ${address}`, e);
           }
@@ -125,7 +130,7 @@ const useVotes = (proposalId: string) => {
             .sort((a, b) => b.timestamp - a.timestamp);
 
           const latestEvent = events[0];
-          const ensName = localEnsCache[vote.voter.id] ?? "";
+          const ensName = getCachedEns(vote.voter.id.toLowerCase()) ?? "";
 
           return {
             ...vote,


### PR DESCRIPTION
## Summary
- Removed the redundant `localEnsCache` object — results are already stored in the module-level `ensCache`, so we read directly from it via `getCachedEns` instead of maintaining a duplicate
- Added 30-minute TTL expiration (`ENS_CACHE_TTL_MS`) so stale ENS names are automatically refreshed rather than persisting indefinitely within a session

## Test plan
- [ ] Navigate to a treasury proposal and verify ENS names still load correctly in the vote table
- [ ] Navigate away and back — names should load instantly from cache
- [ ] Confirm no regressions in vote display

🤖 Generated with [Claude Code](https://claude.com/claude-code)