### PR TITLE
feat: use cache-and-network fetch policy for treasury votes

### DIFF
--- a/components/Treasury/TreasuryVoteTable/index.tsx
+++ b/components/Treasury/TreasuryVoteTable/index.tsx
@@ -109,7 +109,9 @@ const useVotes = (proposalId: string) => {
       !treasuryVoteEventsData?.treasuryVoteEvents
     ) {
       setVotes([]);
+      return;
     }
+
     const decorateVotes = async () => {
       setVotesLoading(true);
       const uniqueVoters = Array.from(
@@ -206,7 +208,7 @@ const Index: React.FC<TreasuryVoteTableProps> = ({ proposalId }) => {
       </Flex>
     );
   }
-  if (error)
+  if (error && !votes.length)
     return (
       <Text css={{ textAlign: "center", color: "$red9", marginTop: "$4" }}>
         Error loading votes: {error.message}

--- a/components/Treasury/TreasuryVoteTable/index.tsx
+++ b/components/Treasury/TreasuryVoteTable/index.tsx
@@ -84,6 +84,7 @@ const useVotes = (proposalId: string) => {
         proposal: proposalId,
       },
     },
+    fetchPolicy: "cache-and-network",
   });
 
   const {
@@ -97,6 +98,7 @@ const useVotes = (proposalId: string) => {
         proposal: proposalId,
       },
     },
+    fetchPolicy: "cache-and-network",
   });
 
   const [votes, setVotes] = useState<Vote[]>([]);


### PR DESCRIPTION
## Summary
- Adds `fetchPolicy: "cache-and-network"` to both `useTreasuryVotesQuery` and `useTreasuryVoteEventsQuery`
- Apollo serves cached vote data instantly on navigation (no loading spinner on revisit) and silently refetches in the background to pick up new votes

## Stack
This is part of a stacked PR chain:
1. [#561](https://github.com/livepeer/explorer/pull/561) `feat/improve-treasury-votes-caching-behavior` — ENS caching
2. [#569](https://github.com/livepeer/explorer/pull/569) `feat/ens-cache-improvements` — remove redundant localEnsCache + add TTL
3. **This PR** `feat/apollo-cache-and-network-votes` — Apollo fetch policy for vote data

## Test plan
- [ ] Navigate to a treasury proposal — votes should load normally
- [ ] Navigate away and back — vote table should render instantly from cache (no spinner), then update if new votes arrived

🤖 Generated with [Claude Code](https://claude.com/claude-code)