### PR TITLE
refactor: use lazy useEnsData for treasury vote ENS resolution

### DIFF
--- a/components/Treasury/TreasuryVoteTable/TreasuryVotePopover.tsx
+++ b/components/Treasury/TreasuryVoteTable/TreasuryVotePopover.tsx
@@ -7,6 +7,7 @@ import {
   TreasuryVoteSupport,
   useTreasuryVoteEventsQuery,
 } from "apollo";
+import { useEnsData } from "hooks";
 import React from "react";
 
 import TreasuryVoteDetail from "./TreasuryVoteDetail";
@@ -14,17 +15,17 @@ import TreasuryVoteHistoryModal from "./TreasuryVoteHistoryModal";
 
 interface TreasuryVotePopoverProps {
   voter: string;
-  ensName?: string;
   onClose: () => void;
   formatWeight: (weight: string) => string;
 }
 
 const Index: React.FC<TreasuryVotePopoverProps> = ({
   voter,
-  ensName,
   onClose,
   formatWeight,
 }) => {
+  const ensIdentity = useEnsData(voter);
+  const ensName = ensIdentity?.name || ensIdentity?.idShort || "";
   const { data: votesData, loading: isLoading } = useTreasuryVoteEventsQuery({
     variables: {
       where: {

--- a/components/Treasury/TreasuryVoteTable/Views/DesktopVoteTable.tsx
+++ b/components/Treasury/TreasuryVoteTable/Views/DesktopVoteTable.tsx
@@ -12,7 +12,6 @@ import { Column } from "react-table";
 import { VoteReasonPopover } from "./VoteReasonPopover";
 
 export type Vote = TreasuryVote & {
-  ensName?: string;
   transactionHash?: string;
   timestamp?: number;
 };
@@ -20,7 +19,7 @@ export type Vote = TreasuryVote & {
 export interface TreasuryVoteTableProps {
   votes: Vote[];
   formatWeight: (weight: string) => string;
-  onSelect: (voter: { address: string; ensName?: string }) => void;
+  onSelect: (voter: { address: string }) => void;
   pageSize?: number;
   totalPages?: number;
   currentPage?: number;
@@ -37,7 +36,7 @@ export const DesktopVoteTable: React.FC<TreasuryVoteTableProps> = ({
     () => [
       {
         Header: "Voter",
-        accessor: "ensName",
+        accessor: "voter",
         id: "voter",
         Cell: ({ row }) => (
           <Box css={{ minWidth: 120 }}>
@@ -206,7 +205,6 @@ export const DesktopVoteTable: React.FC<TreasuryVoteTableProps> = ({
                   e.stopPropagation();
                   onSelect({
                     address: row.original.voter.id,
-                    ensName: row.original.ensName,
                   });
                 }}
                 css={{

--- a/components/Treasury/TreasuryVoteTable/Views/VoteItem.tsx
+++ b/components/Treasury/TreasuryVoteTable/Views/VoteItem.tsx
@@ -18,6 +18,7 @@ import {
   CounterClockwiseClockIcon,
 } from "@radix-ui/react-icons";
 import { TreasuryVoteSupport } from "apollo/subgraph";
+import { useEnsData } from "hooks";
 import { useState } from "react";
 
 import { Vote } from "./DesktopVoteTable";
@@ -25,7 +26,7 @@ import { VoteReasonPopover } from "./VoteReasonPopover";
 
 interface VoteViewProps {
   vote: Vote;
-  onSelect: (voter: { address: string; ensName?: string }) => void;
+  onSelect: (voter: { address: string }) => void;
   formatWeight: (weight: string) => string;
   isMobile?: boolean;
 }
@@ -53,6 +54,8 @@ export function VoteView({
 
 function MobileVoteView({ vote, onSelect, formatWeight }: VoteViewProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const ensIdentity = useEnsData(vote.voter.id);
+  const displayName = ensIdentity?.name || ensIdentity?.idShort || "";
   const support =
     VOTING_SUPPORT_MAP[vote.support] ||
     VOTING_SUPPORT_MAP[TreasuryVoteSupport.Abstain];
@@ -113,12 +116,12 @@ function MobileVoteView({ vote, onSelect, formatWeight }: VoteViewProps) {
                 },
               }}
             >
-              {vote.ensName}
+              {displayName}
             </Link>
           </Heading>
           <Box
             as="button"
-            aria-label={`See ${vote.ensName || vote.voter.id}'s voting history`}
+            aria-label={`See ${displayName || vote.voter.id}'s voting history`}
             css={{
               display: "flex",
               alignItems: "center",
@@ -141,9 +144,7 @@ function MobileVoteView({ vote, onSelect, formatWeight }: VoteViewProps) {
                 color: "$primary11",
               },
             }}
-            onClick={() =>
-              onSelect({ address: vote.voter.id, ensName: vote.ensName })
-            }
+            onClick={() => onSelect({ address: vote.voter.id })}
           >
             <Text size="1" css={{ fontWeight: 600, color: "inherit" }}>
               History
@@ -277,6 +278,8 @@ function MobileVoteView({ vote, onSelect, formatWeight }: VoteViewProps) {
 }
 
 function DesktopVoteView({ vote, onSelect, formatWeight }: VoteViewProps) {
+  const ensIdentity = useEnsData(vote.voter.id);
+  const displayName = ensIdentity?.name || ensIdentity?.idShort || "";
   const support =
     VOTING_SUPPORT_MAP[vote.support] ||
     VOTING_SUPPORT_MAP[TreasuryVoteSupport.Abstain];
@@ -330,7 +333,7 @@ function DesktopVoteView({ vote, onSelect, formatWeight }: VoteViewProps) {
             }}
             size="2"
           >
-            {vote.ensName}
+            {displayName}
           </Text>
         </Link>
       </Box>
@@ -492,7 +495,7 @@ function DesktopVoteView({ vote, onSelect, formatWeight }: VoteViewProps) {
             as="button"
             onClick={(e) => {
               e.stopPropagation();
-              onSelect({ address: vote.voter.id, ensName: vote.ensName });
+              onSelect({ address: vote.voter.id });
             }}
             css={{
               display: "inline-flex",

--- a/components/Treasury/TreasuryVoteTable/index.tsx
+++ b/components/Treasury/TreasuryVoteTable/index.tsx
@@ -1,9 +1,8 @@
 import Spinner from "@components/Spinner";
-import { getEnsForVotes } from "@lib/api/ens";
-import { formatAddress, lptFormatter } from "@lib/utils";
+import { lptFormatter } from "@lib/utils";
 import { Flex, Text } from "@livepeer/design-system";
 import { useTreasuryVoteEventsQuery, useTreasuryVotesQuery } from "apollo";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useWindowSize } from "react-use";
 
 import TreasuryVotePopover from "./TreasuryVotePopover";
@@ -40,69 +39,33 @@ const useVotes = (proposalId: string) => {
     },
   });
 
-  const [votes, setVotes] = useState<Vote[]>([]);
-  const [votesLoading, setVotesLoading] = useState(false);
-  useEffect(() => {
-    if (
-      !treasuryVotesData?.treasuryVotes ||
-      !treasuryVoteEventsData?.treasuryVoteEvents
-    ) {
-      setVotes([]);
+  const votes = useMemo(() => {
+    const votesList = treasuryVotesData?.treasuryVotes;
+    const eventsList = treasuryVoteEventsData?.treasuryVoteEvents;
+
+    if (!votesList || !eventsList) {
+      return [];
     }
-    const decorateVotes = async () => {
-      setVotesLoading(true);
-      const uniqueVoters = Array.from(
-        new Set(treasuryVotesData?.treasuryVotes?.map((v) => v.voter.id) ?? [])
-      );
-      const localEnsCache: { [address: string]: string } = {};
 
-      await Promise.all(
-        uniqueVoters.map(async (address) => {
-          try {
-            if (localEnsCache[address]) {
-              return;
-            }
-            const ensAddress = await getEnsForVotes(address);
+    return votesList.map((vote) => {
+      const events = eventsList
+        .filter((event) => event.voter.id === vote.voter.id)
+        .sort((a, b) => b.timestamp - a.timestamp);
 
-            if (ensAddress && ensAddress.name) {
-              localEnsCache[address] = ensAddress.name;
-            } else {
-              localEnsCache[address] = formatAddress(address);
-            }
-          } catch (e) {
-            console.warn(`Failed to fetch ENS for ${address}`, e);
-          }
-        })
-      );
-      const votes =
-        treasuryVotesData?.treasuryVotes?.map((vote) => {
-          const events = (treasuryVoteEventsData?.treasuryVoteEvents ?? [])
-            .filter((event) => event.voter.id === vote.voter.id)
-            .sort((a, b) => b.timestamp - a.timestamp);
+      const latestEvent = events[0];
 
-          const latestEvent = events[0];
-          const ensName = localEnsCache[vote.voter.id] ?? "";
-
-          return {
-            ...vote,
-            reason: latestEvent?.reason || vote.reason || "",
-            ensName,
-            transactionHash: latestEvent?.transaction.id ?? "",
-            timestamp: latestEvent?.timestamp,
-          };
-        }) ?? [];
-      setVotes(votes as Vote[]);
-      setVotesLoading(false);
-    };
-    decorateVotes();
-  }, [
-    treasuryVotesData?.treasuryVotes,
-    treasuryVoteEventsData?.treasuryVoteEvents,
-  ]);
+      return {
+        ...vote,
+        reason: latestEvent?.reason || vote.reason || "",
+        transactionHash: latestEvent?.transaction.id ?? "",
+        timestamp: latestEvent?.timestamp,
+      };
+    }) as Vote[];
+  }, [treasuryVotesData, treasuryVoteEventsData]);
 
   return {
     votes,
-    loading: loading || votesLoading || treasuryVoteEventsLoading,
+    loading: loading || treasuryVoteEventsLoading,
     error: error || treasuryVoteEventsError,
   };
 };
@@ -113,7 +76,6 @@ const Index: React.FC<TreasuryVoteTableProps> = ({ proposalId }) => {
 
   const [selectedVoter, setSelectedVoter] = useState<{
     address: string;
-    ensName?: string;
   } | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
   const pageSize = 10;
@@ -191,7 +153,6 @@ const Index: React.FC<TreasuryVoteTableProps> = ({ proposalId }) => {
       {selectedVoter && (
         <TreasuryVotePopover
           voter={selectedVoter.address}
-          ensName={selectedVoter.ensName}
           onClose={() => setSelectedVoter(null)}
           formatWeight={formatWeight}
         />


### PR DESCRIPTION
## Summary
- Replaces the blocking ENS cache pattern (module-level Map + `Promise.all` in `useEffect`) in https://github.com/livepeer/explorer/pull/561 with the existing `useEnsData` SWR hook used across the rest of the app
- Votes render instantly with truncated addresses while ENS names resolve lazily per-row, matching the OrchestratorList pattern
- Removes ~60 lines of custom ENS cache code, the async `decorateVotes` function, and the `votesLoading` state

## What changed
- **`TreasuryVoteTable/index.tsx`** — removed ENS cache, replaced `useEffect`/`decorateVotes` with synchronous `useMemo`
- **`Views/VoteItem.tsx`** — `MobileVoteView` and `DesktopVoteView` now call `useEnsData()` per-row for lazy ENS
- **`Views/DesktopVoteTable.tsx`** — removed `ensName` from `Vote` type and `onSelect` signature
- **`TreasuryVotePopover.tsx`** — resolves ENS internally via `useEnsData()` instead of receiving it as a prop

## Why
The previous approach blocked the entire vote table render behind `Promise.all()` of ENS lookups — even on revisits, every voter's ENS name had to re-resolve before anything displayed. This made the table feel slow despite having the vote data ready.

Replaces #561

## Test plan
- [ ] Visit a treasury proposal page — votes table should render immediately with truncated addresses
- [ ] ENS names should pop in lazily as they resolve (no spinner for ENS)
- [ ] Click the history icon — popover should show voter's ENS name
- [ ] Mobile view should show ENS names lazily in vote cards
- [ ] Navigating away and back should show cached ENS names instantly (SWR cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)