### PR TITLE
fix: restore default drop shadow on BottomDrawer

### DIFF
--- a/components/BottomDrawer/index.tsx
+++ b/components/BottomDrawer/index.tsx
@@ -20,7 +20,6 @@ const Index = ({ children }) => {
         css={{
           height: "initial",
           backgroundColor: "transparent",
-          boxShadow: "none",
         }}
         onPointerEnterCapture={undefined}
         onPointerLeaveCapture={undefined}


### PR DESCRIPTION
## Summary
- Remove the `boxShadow: "none"` override on the BottomDrawer's `SheetContent` so the Sheet's default drop shadow is used
- Provides better visual separation between the drawer and the dark page background

## Test plan
- [ ] Open a voting proposal on mobile viewport (< 1020px)
- [ ] Verify the bottom drawer has a visible drop shadow separating it from the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)