### PR TITLE
fix: match orchestrators page header spacing with home page

### DIFF
--- a/pages/orchestrators.tsx
+++ b/pages/orchestrators.tsx
@@ -61,14 +61,13 @@ const OrchestratorsPage = ({
           }}
         >
           <Flex
-            align="center"
             css={{
-              marginBottom: "$3",
-              justifyContent: "center",
-              flexWrap: "wrap",
-              gap: "$3",
+              flexDirection: "column",
+              justifyContent: "space-between",
+              marginBottom: "$4",
+              alignItems: "center",
               "@bp1": {
-                justifyContent: "space-between",
+                flexDirection: "row",
               },
             }}
           >


### PR DESCRIPTION
## Summary
- Aligns the orchestrators page header layout with the home page by switching from a `flex-wrap` + `gap` layout to a `flex-direction: column` (mobile) / `row` (desktop) layout
- Reduces excessive vertical padding between the "Orchestrators" heading and the "Performance Leaderboard" link on mobile, keeping them visually grouped as a single section header

## Why
The orchestrators page used `flex-wrap: wrap` with `gap: $3` and centered justification, which created more vertical space between the title and navigation link on mobile compared to the home page. This made the link feel disconnected from the heading it belongs to. The home page's column-based layout keeps these elements tightly grouped, reinforcing their semantic relationship.

## Test plan
- [ ] Verify on mobile that the "Orchestrators" title and "Performance Leaderboard" link have tight vertical spacing, matching the home page
- [ ] Verify on desktop that the title and link are spaced apart on the same row

🤖 Generated with [Claude Code](https://claude.com/claude-code)