### PR TITLE
fix: align BottomDrawer breakpoint with @bp3 (1200px)

### DIFF
--- a/components/BottomDrawer/index.tsx
+++ b/components/BottomDrawer/index.tsx
@@ -9,7 +9,7 @@ const Index = ({ children }) => {
 
   return (
     <Sheet
-      open={bottomDrawerOpen && width < 1020}
+      open={bottomDrawerOpen && width < 1200}
       onOpenChange={(open) => {
         if (!open) setBottomDrawerOpen(false);
       }}

--- a/components/DelegatingWidget/Input.tsx
+++ b/components/DelegatingWidget/Input.tsx
@@ -88,7 +88,7 @@ const Input = ({
         type="number"
         min="0"
         step="any"
-        autoFocus={width > 1020}
+        autoFocus={width >= 1200}
         value={value}
         onChange={onChange}
         css={{

--- a/layouts/account.tsx
+++ b/layouts/account.tsx
@@ -290,7 +290,7 @@ const AccountLayout = ({
           {view === "history" && <HistoryView />}
         </Flex>
         {(isOrchestrator || isMyDelegate || isDelegatingAndIsMyAccountView) &&
-          (width > 1020 ? (
+          (width >= 1200 ? (
             <Flex
               css={{
                 display: "none",

--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -209,11 +209,11 @@ const Layout = ({ children, title = "Livepeer Explorer" }) => {
   }, [isReady, isBannerDisabledByQuery]);
 
   useEffect(() => {
-    if (width > 1020) {
+    if (width >= 1200) {
       document.body.removeAttribute("style");
     }
 
-    if (width < 1020 && drawerOpen) {
+    if (width < 1200 && drawerOpen) {
       document.body.style.overflow = "hidden";
     }
   }, [drawerOpen, width]);

--- a/pages/voting/[poll].tsx
+++ b/pages/voting/[poll].tsx
@@ -340,7 +340,7 @@ const Poll = () => {
             </Box>
           </Flex>
 
-          {width > 1200 ? (
+          {width >= 1200 ? (
             <Flex
               css={{
                 display: "none",


### PR DESCRIPTION
## Summary

- Aligns the hardcoded 1020px BottomDrawer breakpoint with the design system's `@bp3` (1200px)
- Fixes a dead zone at 1020-1199px where mobile action buttons (delegate, undelegate, vote) were visible but tapping them did nothing because the drawer wouldn't open

Closes #578

## Changed files

| File | Change |
|---|---|
| `components/BottomDrawer/index.tsx` | Drawer open condition: `width < 1020` → `width < 1200` |
| `layouts/account.tsx` | Desktop widget condition: `width > 1020` → `width > 1200` |
| `layouts/main.tsx` | Body scroll lock/reset: `1020` → `1200` |
| `components/DelegatingWidget/Input.tsx` | Autofocus condition: `width > 1020` → `width > 1200` |

## Test plan

- [ ] At 1020-1199px: verify delegate/undelegate buttons open the bottom drawer
- [ ] At 1020-1199px: verify vote buttons open the bottom drawer
- [ ] At 1200px+: verify desktop widget renders inline (no drawer)
- [ ] Below 1020px: verify drawer still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)