### PR TITLE
refactor: use shared POLL_VOTES constant for vote badge styling

### DIFF
--- a/components/TransactionsList/index.tsx
+++ b/components/TransactionsList/index.tsx
@@ -2,7 +2,7 @@ import EthAddressBadge from "@components/EthAddressBadge";
 import Table from "@components/Table";
 import TransactionBadge from "@components/TransactionBadge";
 import { parseProposalText } from "@lib/api/treasury";
-import { VOTING_SUPPORT_MAP } from "@lib/api/types/votes";
+import { POLL_VOTES, VOTING_SUPPORT_MAP } from "@lib/api/types/votes";
 import dayjs from "@lib/dayjs";
 import { Badge, Box, Flex, Link as A, Text } from "@livepeer/design-system";
 import { EventsQueryResult, TreasuryProposal } from "apollo";
@@ -344,24 +344,19 @@ const TransactionsList = ({
               event?.param ?? "unknown"
             }, has been updated`}</Box>
           );
-        case "VoteEvent":
+        case "VoteEvent": {
+          const vote = POLL_VOTES[event?.choiceID];
           return (
             <Box>
               {`Voted `}
-              <Badge
-                css={{
-                  backgroundColor:
-                    +event?.choiceID === 0 ? "$grass3" : "$tomato9",
-                  color: +event?.choiceID === 0 ? "$grass11" : "$tomato11",
-                }}
-                size="1"
-              >
-                {+event?.choiceID === 0 ? '"For"' : '"Against"'}
+              <Badge css={vote.style} size="1">
+                {`"${vote.text}"`}
               </Badge>
               {` on a proposal`}
               {renderEmoji("👩‍⚖️")}
             </Box>
           );
+        }
         case "PollCreatedEvent":
           return (
             <Box>


### PR DESCRIPTION
## Description

Refactors the "Against" vote badge in the transactions list to use the shared `POLL_VOTES` constant instead of inline styles. This ensures consistent vote badge styling across the app (matching the Voting page) and fixes the "Against" badge appearance.

## Type of Change

- [x] refactor: Code refactoring (no behavior change)

## Related Issue(s)

N/A

## Changes Made

- Replaced inline `backgroundColor`/`color` styling for vote badges in `TransactionsList` with the shared `POLL_VOTES` constant from `@lib/api/types/votes`
- Reuses `POLL_VOTES[].style` and `POLL_VOTES[].text` so "For" and "Against" badges render consistently with other vote displays
- Simplified the ternary logic into a single vote lookup

## Testing

- [x] Tested locally
- [x] All tests passing

### How to test

1. Navigate to the Explorer transactions list
2. Find a Vote transaction with an "Against" choice
3. Verify the badge now has proper styling consistent with vote badges elsewhere in the app

## Impact / Risk

Risk level: Low

Impacted areas: UI

User impact: "Against" vote badges in the transactions list now render with consistent styling matching the rest of the app.

Rollback plan: Revert PR

## Screenshots / Recordings

### Before

<img width="3063" height="546" alt="image" src="https://github.com/user-attachments/assets/ca333def-206f-4cf9-aae0-89631ec5ffbc" />

### After

<img width="3063" height="546" alt="image" src="https://github.com/user-attachments/assets/95ffa8b2-caae-4072-97df-7e8e7d909a24" />

## Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)