### PR TITLE
fix: show negative sign for inflation change dropdown option

### DIFF
--- a/components/OrchestratorList/index.tsx
+++ b/components/OrchestratorList/index.tsx
@@ -88,7 +88,10 @@ const OrchestratorList = ({
             mantissa: 3,
             output: "percent",
           })}`
-        : `${numbro(Number(protocolData?.inflationChange) / 1000000000).format({
+        : `${numbro(
+            (change === "negative" ? -1 : 1) *
+              (Number(protocolData?.inflationChange) / 1000000000)
+          ).format({
             mantissa: 5,
             output: "percent",
             forceSign: true,


### PR DESCRIPTION
## Summary
- Fixed the "Inflation change" dropdown on the Orchestrators page showing two identical "+0.00005% per round" options
- The negative option now correctly displays "-0.00005% per round" by negating the value when the "negative" change type is selected

Closes #582

## Test plan
- [x] Verify the dropdown shows three distinct options: "Fixed at 0.063%", "+0.00005% per round", "-0.00005% per round"
- [x] Verify selecting the negative option correctly applies negative inflation change to ROI calculations

🤖 Generated with [Claude Code](https://claude.com/claude-code)