### PR TITLE
fix: handle unset fee/reward change timestamps in orchestrator list

### DIFF
--- a/components/OrchestratorList/index.tsx
+++ b/components/OrchestratorList/index.tsx
@@ -134,13 +134,9 @@ const OrchestratorList = ({
 
         const isNewlyActive = dayjs().diff(activation, "days") < 45;
 
-        const feeShareDaysSinceChange = dayjs().diff(
-          dayjs.unix(row.feeShareUpdateTimestamp),
-          "days"
-        );
-        const rewardCutDaysSinceChange = dayjs().diff(
-          dayjs.unix(row.rewardCutUpdateTimestamp),
-          "days"
+        const latestChangeTimestamp = Math.max(
+          row.feeShareUpdateTimestamp ?? 0,
+          row.rewardCutUpdateTimestamp ?? 0
         );
 
         const treasuryCutDecimal = Number(
@@ -196,14 +192,12 @@ const OrchestratorList = ({
 
         return {
           ...row,
-          daysSinceChangeParams:
-            (feeShareDaysSinceChange < rewardCutDaysSinceChange
-              ? feeShareDaysSinceChange
-              : rewardCutDaysSinceChange) ?? 0,
-          daysSinceChangeParamsFormatted:
-            (feeShareDaysSinceChange < rewardCutDaysSinceChange
-              ? dayjs.unix(row.feeShareUpdateTimestamp).fromNow()
-              : dayjs.unix(row.rewardCutUpdateTimestamp).fromNow()) ?? "",
+          daysSinceChangeParams: latestChangeTimestamp
+            ? dayjs().diff(dayjs.unix(latestChangeTimestamp), "days")
+            : null,
+          daysSinceChangeParamsFormatted: latestChangeTimestamp
+            ? dayjs.unix(latestChangeTimestamp).fromNow()
+            : null,
           earningsComputed: {
             roi,
             activation,
@@ -681,7 +675,9 @@ const OrchestratorList = ({
                           }}
                           size="2"
                         >
-                          {row?.original?.daysSinceChangeParams} days ago
+                          {row?.original?.daysSinceChangeParams != null
+                            ? `${row.original.daysSinceChangeParams} days ago`
+                            : "Never"}
                         </Text>
                       </Flex>
                     </Box>


### PR DESCRIPTION
## Summary
- Fix orchestrators with unset fee/reward timestamps showing ~20521 days ago (days since Unix epoch) instead of "Never"
- Use the latest non-zero timestamp between `feeShareUpdateTimestamp` and `rewardCutUpdateTimestamp`, treating `0` as unset
- Display "Never" when neither timestamp has been set

Closes #585

## Test plan
- [x] Verify orchestrators that have never changed params show "Never" for latest fee/reward change
- [x] Verify orchestrators that changed params today show "0 days ago" (not "Never")
- [x] Verify orchestrators with valid timestamps still show correct "X days ago" values

🤖 Generated with [Claude Code](https://claude.com/claude-code)