### PR TITLE
fix: squished account page info on mobile

### DIFF
--- a/components/EditProfile/index.tsx
+++ b/components/EditProfile/index.tsx
@@ -18,18 +18,7 @@ const Index = () => {
     <>
       <Dialog>
         <DialogTrigger asChild>
-          <Button
-            css={{
-              flexBasis: "100%",
-              justifyContent: "center",
-              alignSelf: "flex-start",
-              "@bp2": {
-                flexBasis: "auto",
-              },
-            }}
-            variant="primary"
-            size="1"
-          >
+          <Button variant="primary" size="1">
             Edit Profile
           </Button>
         </DialogTrigger>

--- a/components/Profile/index.tsx
+++ b/components/Profile/index.tsx
@@ -203,7 +203,18 @@ const Index = ({ account, isMyAccount = false, identity }: Props) => {
                 </Flex>
               </ExplorerTooltip>
             </Flex>
-            {isMyAccount && <EditProfile />}
+            {isMyAccount && (
+              <Box
+                css={{
+                  width: "100%",
+                  "@bp2": {
+                    width: "auto",
+                  },
+                }}
+              >
+                <EditProfile />
+              </Box>
+            )}
           </Flex>
           <Flex align="center" css={{ flexWrap: "wrap" }}>
             {identity?.url && (


### PR DESCRIPTION
## Description

Improves spacing around the address and "Edit Profile" button on the account page.

## Type of Change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [x] style: Code style/formatting changes (no logic changes)
- [ ] refactor: Code refactoring (no behavior change)
- [ ] perf: Performance improvement
- [ ] test: Adding or updating tests
- [ ] build: Build system or dependency changes
- [ ] ci: CI/CD changes
- [ ] chore: Other changes

## Related Issue(s)

Closes: #549 

## Changes Made

- Moved the "Edit Profile" button beyond address on mobile

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests passing

### How to test

View account page on mobile, and see that address is not squished.

## Impact / Risk

Risk level: Low

Impacted areas: UI

## Screenshots / Recordings

Before:

<img width="420" height="366" alt="Screenshot 2026-03-17 at 3 35 51 PM" src="https://github.com/user-attachments/assets/73fef1c6-09ae-4fe9-9021-e47637a042dc" />

After:

<img width="422" height="347" alt="Screenshot 2026-03-17 at 4 03 14 PM" src="https://github.com/user-attachments/assets/00da9e4a-9310-438e-b09b-0bfb5eeaf1f7" />

