### PR TITLE
chore: ignore .claude/ in git, eslint, and prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ next-env.d.ts
 .vscode/*
 !.vscode/settings.json
 .code-workspace
+.claude/
 
 # debug
 npm-debug.log*

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,6 +8,7 @@ out
 node_modules
 
 # misc
+.claude
 .github
 .vscode
 @types

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,7 @@ const eslintConfig = defineConfig([
     },
   },
   globalIgnores([
+    ".claude/**",
     "apollo/**",
     "@types/**",
     ".next/**",


### PR DESCRIPTION
## Summary
- Adds `.claude/` to `.gitignore`, `.prettierignore`, and `eslint.config.mjs`
- Prevents local Claude Code tooling state (worktrees, settings) from being tracked or linted

## Test plan
- [ ] Verify `prettier . --check` passes without scanning `.claude/` worktrees
- [ ] Verify `eslint .` passes without scanning `.claude/` worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)