### PR TITLE
fix: add alt tags, aria-labels, and aria-hidden for accessibility

### DIFF
--- a/components/AccountCell/index.tsx
+++ b/components/AccountCell/index.tsx
@@ -49,6 +49,9 @@ const Index = ({ active, address }) => {
               borderColor: "$neutral5",
             }}
             src={identity.avatar}
+            alt={
+              identity?.name ? `${identity.name} avatar` : `${address} avatar`
+            }
           />
         ) : (
           <QRCodeCanvas

--- a/components/DelegatingWidget/Header.tsx
+++ b/components/DelegatingWidget/Header.tsx
@@ -42,6 +42,11 @@ const Header = ({
               height: 40,
             }}
             src={delegateProfile.avatar}
+            alt={
+              delegateProfile?.name
+                ? `${delegateProfile.name} avatar`
+                : `${delegateProfile?.id || "delegate"} avatar`
+            }
           />
         ) : (
           <QRCodeCanvas

--- a/components/IdentityAvatar/index.tsx
+++ b/components/IdentityAvatar/index.tsx
@@ -82,6 +82,7 @@ const IdentityAvatar = ({ identity, address, size = 24, css = {} }: Props) => {
           transition: "opacity 150ms ease",
         }}
         src={avatarSrc}
+        alt={`${address} avatar`}
         onLoad={() => setImageLoaded(true)}
         onError={() => setHasAvatarError(true)}
       />

--- a/components/Logo/index.tsx
+++ b/components/Logo/index.tsx
@@ -57,7 +57,7 @@ const LivepeerLogo = ({ isDark, isLink = true }: Props) => {
   if (!isLink) return markup;
   return (
     <Link href="/" passHref>
-      {markup}
+      <a aria-label="Livepeer Explorer home">{markup}</a>
     </Link>
   );
 };

--- a/components/Profile/index.tsx
+++ b/components/Profile/index.tsx
@@ -78,6 +78,9 @@ const Index = ({ account, isMyAccount = false, identity }: Props) => {
                 height: "100%",
               }}
               src={identity.avatar}
+              alt={
+                identity?.name ? `${identity.name} avatar` : `${account} avatar`
+              }
             />
           ) : (
             <Box
@@ -224,12 +227,13 @@ const Index = ({ account, isMyAccount = false, identity }: Props) => {
                 href={identity.url}
                 target="__blank"
                 rel="noopener noreferrer"
+                aria-label={`Visit ${identity.url.replace(/(^\w+:|^)\/\//, "")}`}
               >
                 <Flex
                   align="center"
                   css={{ marginTop: "$2", marginRight: "$3" }}
                 >
-                  <Box as={GlobeIcon} css={{ marginRight: "$1" }} />
+                  <Box as={GlobeIcon} css={{ marginRight: "$1" }} aria-hidden="true" />
                   {identity.url.replace(/(^\w+:|^)\/\//, "")}
                 </Flex>
               </A>
@@ -242,12 +246,13 @@ const Index = ({ account, isMyAccount = false, identity }: Props) => {
                 href={`https://twitter.com/${identity.twitter}`}
                 target="__blank"
                 rel="noopener noreferrer"
+                aria-label={`View ${identity.twitter} on Twitter`}
               >
                 <Flex
                   align="center"
                   css={{ marginTop: "$2", marginRight: "$3" }}
                 >
-                  <Box as={TwitterLogoIcon} css={{ marginRight: "$1" }} />
+                  <Box as={TwitterLogoIcon} css={{ marginRight: "$1" }} aria-hidden="true" />
                   <Box
                     css={{
                       "@media (max-width: 400px)": {
@@ -268,12 +273,13 @@ const Index = ({ account, isMyAccount = false, identity }: Props) => {
                 href={`https://github.com/${identity.github}`}
                 target="__blank"
                 rel="noopener noreferrer"
+                aria-label={`View ${identity.github} on GitHub`}
               >
                 <Flex
                   align="center"
                   css={{ marginTop: "$2", marginRight: "$3" }}
                 >
-                  <Box as={GitHubLogoIcon} css={{ marginRight: "$1" }} />
+                  <Box as={GitHubLogoIcon} css={{ marginRight: "$1" }} aria-hidden="true" />
                   <Box
                     css={{
                       "@media (max-width: 400px)": {

--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -620,6 +620,7 @@ const Layout = ({ children, title = "Livepeer Explorer" }) => {
                                 <Box
                                   css={{ marginLeft: "$1" }}
                                   as={ChevronDownIcon}
+                                  aria-hidden="true"
                                 />
                               </Button>
                             </PopoverTrigger>
@@ -859,6 +860,12 @@ const ContractAddressesPopover = ({ activeChain }: { activeChain?: Chain }) => {
                           marginBottom: "$1",
                         }}
                         target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label={`View ${
+                          contractAddresses?.[
+                            key as keyof typeof contractAddresses
+                          ]?.name ?? "contract"
+                        } on block explorer`}
                         href={
                           contractAddresses?.[
                             key as keyof typeof contractAddresses
@@ -900,7 +907,11 @@ const ContractAddressesPopover = ({ activeChain }: { activeChain?: Chain }) => {
               passHref
               href="https://docs.livepeer.org/references/contract-addresses"
             >
-              <A>
+              <A
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Learn more about these contracts (opens in new tab)"
+              >
                 <Flex
                   css={{
                     marginTop: "$2",
@@ -922,6 +933,7 @@ const ContractAddressesPopover = ({ activeChain }: { activeChain?: Chain }) => {
                       height: 15,
                     }}
                     as={ArrowTopRightIcon}
+                    aria-hidden="true"
                   />
                 </Flex>
               </A>

--- a/pages/migrate/broadcaster.tsx
+++ b/pages/migrate/broadcaster.tsx
@@ -740,7 +740,7 @@ const MigrateBroadcaster = () => {
 
             {state.image && (
               <Box css={{ textAlign: "center", marginBottom: "$5" }}>
-                <Box as="img" src={state.image} />
+                <Box as="img" src={state.image} alt="Migration diagram" />
               </Box>
             )}
 

--- a/pages/migrate/delegator/index.tsx
+++ b/pages/migrate/delegator/index.tsx
@@ -734,7 +734,7 @@ const MigrateUndelegatedStake = () => {
 
             {state.image && (
               <Box css={{ textAlign: "center", marginBottom: "$5" }}>
-                <Box as="img" src={state.image} />
+                <Box as="img" src={state.image} alt="Migration diagram" />
               </Box>
             )}
 

--- a/pages/migrate/orchestrator.tsx
+++ b/pages/migrate/orchestrator.tsx
@@ -711,7 +711,7 @@ const MigrateOrchestrator = () => {
 
             {state.image && (
               <Box css={{ textAlign: "center", marginBottom: "$5" }}>
-                <Box as="img" src={state.image} />
+                <Box as="img" src={state.image} alt="Migration diagram" />
               </Box>
             )}
 


### PR DESCRIPTION
## Summary
- Add descriptive `alt` text to all avatar images and migration diagrams
- Add `aria-label` attributes to logo, social media links, and contract address links  
- Add `aria-hidden="true"` to decorative icons (Globe, Twitter, GitHub, ChevronDown, ArrowTopRight)
- Add `rel="noopener noreferrer"` to external links for security

Extracted from #509 by @Roaring30s — Lighthouse accessibility improvements.

Partially addresses #433.

## Test plan
- [ ] Verify all images have meaningful alt text via browser dev tools
- [ ] Test with screen reader that aria-labels are announced correctly
- [ ] Confirm decorative icons are hidden from assistive technology
- [ ] Check external links have proper rel attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)