### PR TITLE
fix: add meta description and enable production source maps

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  productionBrowserSourceMaps: true,
+
   turbopack: {
     rules: {
       "*.svg": {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -39,6 +39,10 @@ function App({ Component, pageProps, fallback = null }) {
     <>
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+          name="description"
+          content="Explore Livepeer network statistics, orchestrators, delegators, and protocol data. Track performance, stake, and earnings on the Livepeer decentralized video infrastructure network."
+        />
         <title>Livepeer Explorer</title>
       </Head>
 


### PR DESCRIPTION
## Summary
- Add meta description tag to resolve Lighthouse SEO warning, boosting SEO score to near 100
- Enable `productionBrowserSourceMaps` in Next.js config to resolve Lighthouse Best Practices warning for unminified first-party JS

Extracted from #509 by @Roaring30s — Lighthouse SEO and Best Practices improvements.

Partially addresses #433.

## Test plan
- [ ] Verify meta description appears in page source
- [ ] Run Lighthouse SEO audit and confirm score improvement
- [ ] Verify source maps are generated in production build
- [ ] Confirm source maps don't increase client-side bundle size (they're loaded on-demand by dev tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)