### PR TITLE
feat: optimize ENS avatar images with Sharp

### DIFF
--- a/lib/api/image-optimization.ts
+++ b/lib/api/image-optimization.ts
@@ -1,0 +1,92 @@
+import sharp from "sharp";
+
+export interface OptimizeImageResult {
+  buffer: Buffer;
+  contentType: string;
+  originalSize: number;
+  optimizedSize: number;
+  originalDimensions?: { width: number; height: number };
+  optimizedDimensions?: { width: number; height: number };
+  format?: string;
+}
+
+export interface OptimizeImageOptions {
+  width?: number;
+  height?: number;
+  quality?: number;
+  effort?: number;
+}
+
+/**
+ * Optimizes an image by resizing and converting to WebP format
+ * @param imageBuffer - The original image buffer
+ * @param options - Optimization options
+ * @returns Optimized image buffer and metadata, or original buffer if optimization fails
+ */
+export async function optimizeImage(
+  imageBuffer: ArrayBuffer,
+  options: OptimizeImageOptions = {}
+): Promise<OptimizeImageResult> {
+  const { width = 96, height = 96, quality = 75, effort = 6 } = options;
+
+  const originalSize = imageBuffer.byteLength;
+  const originalBuffer = Buffer.from(imageBuffer);
+
+  // Get original image metadata
+  let originalMetadata;
+  try {
+    originalMetadata = await sharp(originalBuffer).metadata();
+  } catch {
+    // Metadata extraction failed, but we can still proceed with optimization
+    originalMetadata = undefined;
+  }
+
+  // Optimize image: resize and convert to WebP
+  try {
+    const optimizedBuffer = await sharp(originalBuffer)
+      .resize(width, height, {
+        fit: "cover",
+        withoutEnlargement: true, // Don't upscale small images
+      })
+      .webp({ quality, effort })
+      .toBuffer();
+
+    const optimizedMetadata = await sharp(optimizedBuffer).metadata();
+
+    return {
+      buffer: optimizedBuffer,
+      contentType: "image/webp",
+      originalSize,
+      optimizedSize: optimizedBuffer.length,
+      originalDimensions: originalMetadata
+        ? {
+            width: originalMetadata.width || 0,
+            height: originalMetadata.height || 0,
+          }
+        : undefined,
+      optimizedDimensions: optimizedMetadata
+        ? {
+            width: optimizedMetadata.width || 0,
+            height: optimizedMetadata.height || 0,
+          }
+        : undefined,
+      format: optimizedMetadata?.format,
+    };
+  } catch {
+    // Fallback to original image if optimization fails
+    // This is expected for some edge cases (unsupported formats, corrupted images, etc.
+    // Return original image as fallback
+    return {
+      buffer: originalBuffer,
+      contentType: "image/jpeg", // Default fallback
+      originalSize,
+      optimizedSize: originalSize,
+      originalDimensions: originalMetadata
+        ? {
+            width: originalMetadata.width || 0,
+            height: originalMetadata.height || 0,
+          }
+        : undefined,
+    };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "4.0.1",
     "sanitize-html": "^2.17.0",
+    "sharp": "^0.34.5",
     "swr": "^2.3.7",
     "viem": "^2.38.5",
     "wagmi": "^2.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       sanitize-html:
         specifier: ^2.17.0
         version: 2.17.1
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       swr:
         specifier: ^2.3.7
         version: 2.4.1(react@19.2.1)
@@ -13143,8 +13146,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -19034,8 +19036,7 @@ snapshots:
 
   detect-indent@6.1.0: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
 
@@ -23779,7 +23780,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Add reusable `optimizeImage` utility in `lib/api/image-optimization.ts`
- Integrate Sharp-based optimization into `/api/ens-data/image/[name]` endpoint
- Resize ENS avatars from 704×704 to 96×96 and convert to WebP format (~95% size reduction)
- Graceful fallback to original image if optimization fails
- Add `sharp` dependency

Extracted from #509 by @Roaring30s — Lighthouse performance improvements.

Partially addresses #433.

## Test plan
- [ ] Visit an orchestrator profile with an ENS avatar
- [ ] Verify image loads correctly in WebP format (check network tab)
- [ ] Verify image dimensions are 96×96
- [ ] Test with an ENS name that has no avatar (should still return 404 gracefully)
- [ ] Test with corrupted/unsupported image format (should fallback to original)

🤖 Generated with [Claude Code](https://claude.com/claude-code)