### PR TITLE
fix: replace useWindowSize with useMediaQuery to prevent scroll jumps

### DIFF
--- a/components/BottomDrawer/index.tsx
+++ b/components/BottomDrawer/index.tsx
@@ -1,15 +1,14 @@
 import { Sheet, SheetContent } from "@livepeer/design-system";
-import { useExplorerStore } from "hooks";
-import { useWindowSize } from "react-use";
+import { useExplorerStore, useIsDesktop } from "hooks";
 
 const Index = ({ children }) => {
-  const { width } = useWindowSize();
+  const isDesktop = useIsDesktop();
 
   const { bottomDrawerOpen, setBottomDrawerOpen } = useExplorerStore();
 
   return (
     <Sheet
-      open={bottomDrawerOpen && width < 1200}
+      open={bottomDrawerOpen && !isDesktop}
       onOpenChange={(open) => {
         if (!open) setBottomDrawerOpen(false);
       }}

--- a/components/DelegatingWidget/Input.tsx
+++ b/components/DelegatingWidget/Input.tsx
@@ -1,8 +1,7 @@
 import { calculateROI } from "@lib/roi";
 import { Box } from "@livepeer/design-system";
-import { useExplorerStore } from "hooks";
+import { useExplorerStore, useIsDesktop } from "hooks";
 import { useEffect, useMemo } from "react";
-import { useWindowSize } from "react-use";
 
 const Input = ({
   transcoder,
@@ -12,7 +11,7 @@ const Input = ({
   treasury,
   ...props
 }) => {
-  const { width } = useWindowSize();
+  const isDesktop = useIsDesktop();
 
   const pools = useMemo(() => transcoder?.pools ?? [], [transcoder]);
   const rewardCallRatio = useMemo(
@@ -88,7 +87,7 @@ const Input = ({
         type="number"
         min="0"
         step="any"
-        autoFocus={width >= 1200}
+        autoFocus={isDesktop}
         value={value}
         onChange={onChange}
         css={{

--- a/components/Treasury/TreasuryVoteTable/index.tsx
+++ b/components/Treasury/TreasuryVoteTable/index.tsx
@@ -3,8 +3,8 @@ import { getEnsForVotes } from "@lib/api/ens";
 import { formatAddress, lptFormatter } from "@lib/utils";
 import { Flex, Text } from "@livepeer/design-system";
 import { useTreasuryVoteEventsQuery, useTreasuryVotesQuery } from "apollo";
+import { useIsTablet } from "hooks";
 import React, { useEffect, useMemo, useState } from "react";
-import { useWindowSize } from "react-use";
 
 import TreasuryVotePopover from "./TreasuryVotePopover";
 import { DesktopVoteTable, Vote } from "./Views/DesktopVoteTable";
@@ -108,8 +108,7 @@ const useVotes = (proposalId: string) => {
 };
 
 const Index: React.FC<TreasuryVoteTableProps> = ({ proposalId }) => {
-  const { width } = useWindowSize();
-  const isDesktop = width >= 900;
+  const isDesktop = useIsTablet();
 
   const [selectedVoter, setSelectedVoter] = useState<{
     address: string;

--- a/hooks/index.tsx
+++ b/hooks/index.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 
 // DO NOT IMPORT useHandleTransaction due to @rainbow-me/rainbowkit issues with SSR
 export * from "./useExplorerStore";
+export * from "./useMediaQuery";
 export * from "./useSwr";
 export * from "./wallet";
 

--- a/hooks/useMediaQuery.ts
+++ b/hooks/useMediaQuery.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Uses window.matchMedia to track a CSS media query.
+ * Only fires when the breakpoint threshold is crossed,
+ * unlike useWindowSize which fires on every resize pixel.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    setMatches(mql.matches);
+
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}
+
+/** Matches Stitches @bp3: (min-width: 1200px) */
+export const useIsDesktop = () => useMediaQuery("(min-width: 1200px)");
+
+/** Matches Stitches @bp2: (min-width: 900px) */
+export const useIsTablet = () => useMediaQuery("(min-width: 900px)");

--- a/layouts/account.tsx
+++ b/layouts/account.tsx
@@ -24,10 +24,14 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
-import { useWindowSize } from "react-use";
 import { useReadContract } from "wagmi";
 
-import { useAccountAddress, useEnsData, useExplorerStore } from "../hooks";
+import {
+  useAccountAddress,
+  useEnsData,
+  useExplorerStore,
+  useIsDesktop,
+} from "../hooks";
 
 const DelegatingView = dynamic(() => import("../components/DelegatingView"), {
   ssr: false,
@@ -58,7 +62,7 @@ const AccountLayout = ({
   sortedOrchestrators: OrchestratorsSortedQueryResult["data"];
 }) => {
   const accountAddress = useAccountAddress();
-  const { width } = useWindowSize();
+  const isDesktop = useIsDesktop();
   const router = useRouter();
   const { query, asPath } = router;
   const view = useMemo(
@@ -290,7 +294,7 @@ const AccountLayout = ({
           {view === "history" && <HistoryView />}
         </Flex>
         {(isOrchestrator || isMyDelegate || isDelegatingAndIsMyAccountView) &&
-          (width >= 1200 ? (
+          (isDesktop ? (
             <Flex
               css={{
                 display: "none",

--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -57,7 +57,6 @@ import React, {
 } from "react";
 import { isMobile } from "react-device-detect";
 import ReactGA from "react-ga";
-import { useWindowSize } from "react-use";
 import { Chain } from "viem";
 
 import {
@@ -134,7 +133,6 @@ const Layout = ({ children, title = "Livepeer Explorer" }) => {
   const activeChain = useActiveChain();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [bannerActive, setBannerActive] = useState<boolean>(false);
-  const { width } = useWindowSize();
   const ref = useRef(null);
   const currentRound = useCurrentRoundData();
   const pendingFeesAndStake = usePendingFeesAndStakeData(accountAddress);
@@ -207,16 +205,6 @@ const Layout = ({ children, title = "Livepeer Explorer" }) => {
     window.addEventListener("storage", onStorage);
     return () => window.removeEventListener("storage", onStorage);
   }, [isReady, isBannerDisabledByQuery]);
-
-  useEffect(() => {
-    if (width >= 1200) {
-      document.body.removeAttribute("style");
-    }
-
-    if (width < 1200 && drawerOpen) {
-      document.body.style.overflow = "hidden";
-    }
-  }, [drawerOpen, width]);
 
   useEffect(() => {
     ReactGA.set({

--- a/pages/treasury/[proposal].tsx
+++ b/pages/treasury/[proposal].tsx
@@ -40,8 +40,7 @@ import { BigNumber } from "ethers";
 import Head from "next/head";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { useWindowSize } from "react-use";
+import { useCallback, useMemo } from "react";
 import { formatPercent } from "utils/voting";
 import { decodeFunctionData } from "viem";
 
@@ -51,6 +50,7 @@ import {
   useCurrentRoundData,
   useEnsData,
   useExplorerStore,
+  useMediaQuery,
   useProposalVotingPowerData,
   useTreasuryProposalState,
 } from "../../hooks";
@@ -70,8 +70,8 @@ const formatDateTime = (date: dayjs.Dayjs) => {
 
 const Proposal = () => {
   const router = useRouter();
-  const { width } = useWindowSize();
-  const [isDesktop, setIsDesktop] = useState(false);
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const isSmallMobile = useMediaQuery("(max-width: 640px)");
   const { setBottomDrawerOpen } = useExplorerStore();
 
   const { query } = router;
@@ -108,10 +108,6 @@ const Proposal = () => {
     },
     fetchPolicy: "cache-first",
   });
-
-  useEffect(() => {
-    setIsDesktop(width >= 768);
-  }, [width]);
 
   const proposal = useMemo(() => {
     if (!proposalQuery || !state || !protocolQuery || !currentRound) {
@@ -634,7 +630,7 @@ const Proposal = () => {
                                   }}
                                   size="2"
                                 >
-                                  {width <= 640
+                                  {isSmallMobile
                                     ? formatAddress(action.lptTransfer.receiver)
                                     : action.lptTransfer.receiver}
                                 </Text>

--- a/pages/voting/[poll].tsx
+++ b/pages/voting/[poll].tsx
@@ -29,13 +29,13 @@ import { sentenceCase } from "change-case";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
-import { useWindowSize } from "react-use";
 import { formatPercent } from "utils/voting";
 
 import {
   useAccountAddress,
   useCurrentRoundData,
   useExplorerStore,
+  useIsDesktop,
 } from "../../hooks";
 import { abbreviateNumber } from "../../lib/utils";
 import FourZeroFour from "../404";
@@ -44,7 +44,7 @@ const Poll = () => {
   const router = useRouter();
   const accountAddress = useAccountAddress();
 
-  const { width } = useWindowSize();
+  const isDesktop = useIsDesktop();
 
   const [pollData, setPollData] = useState<PollExtended | null>(null);
   const { query } = router;
@@ -340,7 +340,7 @@ const Poll = () => {
             </Box>
           </Flex>
 
-          {width >= 1200 ? (
+          {isDesktop ? (
             <Flex
               css={{
                 display: "none",


### PR DESCRIPTION
## Summary

Replace `useWindowSize` from `react-use` with a custom `useMediaQuery` hook across all 7 files that used it. This fixes the scroll-jump-to-top bug reported in #602.

### Root cause

`useWindowSize` listens to every browser `resize` event and triggers a React re-render. On mobile, scrolling causes the address bar to show/hide, which changes `window.innerHeight` and fires resize events — causing constant re-renders that reset scroll position.

### Fix

The new `useMediaQuery` hook uses `window.matchMedia`, which only fires when a breakpoint threshold is actually crossed (e.g., screen width goes from below 1200px to above it). Mobile address bar changes only affect height, never crossing width breakpoints, so no unnecessary re-renders occur.

### Changes per file

| File | Before | After |
|------|--------|-------|
| `layouts/main.tsx` | `width >= 1200` + overflow `useEffect` | Removed entirely (overflow already handled by drawer callbacks + `routeChangeComplete`) |
| `layouts/account.tsx` | `width >= 1200` | `useIsDesktop()` |
| `pages/voting/[poll].tsx` | `width >= 1200` | `useIsDesktop()` |
| `pages/treasury/[proposal].tsx` | `width >= 768`, `width <= 640` | `useMediaQuery("(min-width: 768px)")`, `useMediaQuery("(max-width: 640px)")` |
| `components/BottomDrawer/index.tsx` | `width < 1200` | `!useIsDesktop()` |
| `components/DelegatingWidget/Input.tsx` | `width >= 1200` | `useIsDesktop()` |
| `components/Treasury/TreasuryVoteTable/index.tsx` | `width >= 900` | `useIsTablet()` |

### New hook: `hooks/useMediaQuery.ts`

Convenience hooks match Stitches breakpoints:
- `useIsDesktop()` → `@bp3: (min-width: 1200px)`
- `useIsTablet()` → `@bp2: (min-width: 900px)`

Closes #602.

## Test plan
- [ ] **Mobile Safari + Chrome**: Scroll long pages (orchestrators, account, voting, treasury). Verify no scroll jump when address bar toggles
- [ ] **Desktop**: Click tabs on account pages, links in lists — no unexpected scroll-to-top
- [ ] **Breakpoints**: Resize browser across 1200px, 900px, 640px — responsive layout switches correctly
- [ ] **BottomDrawer**: Opens/closes at correct breakpoint on mobile
- [ ] **Treasury proposal**: Address formatting switches correctly on small screens