### PR TITLE
fix: remove scrollIntoView for tabs

### DIFF
--- a/components/HorizontalScrollContainer/index.tsx
+++ b/components/HorizontalScrollContainer/index.tsx
@@ -11,12 +11,64 @@ type HorizontalScrollContainerProps = {
   children: ReactNode;
   ariaLabel?: string;
   role?: "navigation";
+  activeItemKey?: string | number;
+};
+
+const getTabs = (container: HTMLDivElement) =>
+  Array.from(
+    container.querySelectorAll<HTMLElement>(
+      '[role="tab"], [data-tab], button, a, [data-active="true"]'
+    )
+  ).filter((node) => container.contains(node));
+
+const scrollActiveTabIntoView = (container: HTMLDivElement) => {
+  const activeTab = container.querySelector(
+    '[data-active="true"]'
+  ) as HTMLElement | null;
+
+  if (!activeTab) return;
+
+  const tabs = getTabs(container);
+
+  if (tabs.length === 0) return;
+
+  const lastTab = tabs[tabs.length - 1];
+  const isLastActive = lastTab === activeTab;
+
+  if (isLastActive) {
+    const end = container.scrollWidth - container.clientWidth;
+    container.scrollLeft = Math.max(0, end);
+    return;
+  }
+
+  const activeLeft = activeTab.offsetLeft;
+  const activeRight = activeLeft + activeTab.offsetWidth;
+  const visibleLeft = container.scrollLeft;
+  const visibleRight = visibleLeft + container.clientWidth;
+
+  let nextScrollLeft = container.scrollLeft;
+
+  if (activeLeft < visibleLeft) {
+    nextScrollLeft = activeLeft;
+  } else if (activeRight > visibleRight) {
+    nextScrollLeft = activeRight - container.clientWidth;
+  }
+
+  const maxScrollLeft = container.scrollWidth - container.clientWidth;
+  const clampedScrollLeft = Math.max(
+    0,
+    Math.min(nextScrollLeft, maxScrollLeft)
+  );
+
+  if (Math.abs(clampedScrollLeft - container.scrollLeft) > 1) {
+    container.scrollLeft = clampedScrollLeft;
+  }
 };
 
 const HorizontalScrollContainer = forwardRef<
   HTMLDivElement,
   HorizontalScrollContainerProps
->(({ children, ariaLabel, role }, ref) => {
+>(({ children, ariaLabel, role, activeItemKey }, ref) => {
   const innerRef = useRef<HTMLDivElement | null>(null);
   const [hasOverflow, setHasOverflow] = useState(false);
 
@@ -52,37 +104,24 @@ const HorizontalScrollContainer = forwardRef<
     const el = innerRef.current;
     if (!el) return;
 
-    const raf = requestAnimationFrame(() => {
-      const activeTab = el.querySelector(
-        '[data-active="true"]'
-      ) as HTMLElement | null;
+    const syncActiveTab = () => scrollActiveTabIntoView(el);
 
-      if (!activeTab) return;
+    const raf = requestAnimationFrame(syncActiveTab);
+    const observer = new ResizeObserver(syncActiveTab);
+    observer.observe(el);
 
-      const tabs = Array.from(
-        el.querySelectorAll<HTMLElement>(
-          '[role="tab"], [data-tab], button, a, [data-active="true"]'
-        )
-      ).filter((node) => el.contains(node));
+    const activeTab = el.querySelector(
+      '[data-active="true"]'
+    ) as HTMLElement | null;
+    if (activeTab) {
+      observer.observe(activeTab);
+    }
 
-      if (tabs.length === 0) {
-        activeTab.scrollIntoView({ block: "nearest", inline: "nearest" });
-        return;
-      }
-
-      const lastTab = tabs[tabs.length - 1];
-      const isLastActive = lastTab === activeTab;
-
-      if (isLastActive) {
-        const end = el.scrollWidth - el.clientWidth;
-        el.scrollLeft = Math.max(0, end);
-      } else {
-        activeTab.scrollIntoView({ block: "nearest", inline: "nearest" });
-      }
-    });
-
-    return () => cancelAnimationFrame(raf);
-  }, [children]);
+    return () => {
+      cancelAnimationFrame(raf);
+      observer.disconnect();
+    };
+  }, [activeItemKey]);
 
   const setRefs = (node: HTMLDivElement | null) => {
     innerRef.current = node;

--- a/layouts/account.tsx
+++ b/layouts/account.tsx
@@ -255,6 +255,7 @@ const AccountLayout = ({
           <HorizontalScrollContainer
             role="navigation"
             ariaLabel="Account navigation tabs"
+            activeItemKey={view ?? "delegating"}
           >
             {tabs.map((tab: TabType, i: number) => (
               <A

--- a/pages/treasury/[proposal].tsx
+++ b/pages/treasury/[proposal].tsx
@@ -315,6 +315,7 @@ const Proposal = () => {
               <HorizontalScrollContainer
                 role="navigation"
                 ariaLabel="Proposal navigation tabs"
+                activeItemKey={view}
               >
                 {tabs.map((tab, i) => (
                   <NextLink


### PR DESCRIPTION
## Description

Remove the `scrollIntoView()` function that was used in `HorizontalScrollContainer` in favor of custom function. `scrollIntoView()` was causing a vertical scroll when the data refreshed.

## Type of Change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [ ] style: Code style/formatting changes (no logic changes)
- [ ] refactor: Code refactoring (no behavior change)
- [ ] perf: Performance improvement
- [ ] test: Adding or updating tests
- [ ] build: Build system or dependency changes
- [ ] ci: CI/CD changes
- [ ] chore: Other changes

## Related Issue(s)
Related: #603 
Closes: #602 

## Changes Made

- Swapped out `scrollIntoView()` in favor of custom function

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests passing

### How to test

- Go to a treasury proposal page and wait for 20 seconds
- If it doesn't auto-scroll to the top tabs, then it works!
- Make sure tabs auto-scroll horizontally still though

## Impact / Risk

Risk level: Low

Impacted areas: UI
