### PR TITLE
fix: infinite scroll pagination for gateway accounts

### DIFF
--- a/components/HistoryView/index.tsx
+++ b/components/HistoryView/index.tsx
@@ -223,7 +223,7 @@ const Index = () => {
     <InfiniteScroll
       css={{ overflow: "hidden !important" }}
       scrollThreshold={0.5}
-      dataLength={totalLoaded}
+      dataLength={mergedEvents.length}
       next={async () => {
         stopPolling();
         if (!loading && totalLoaded >= 10) {


### PR DESCRIPTION
## Summary

- Fix infinite scroll not loading more events on the history page for gateway accounts
- Use `Math.max(transactions.length, winningTicketRedeemedEvents.length)` for pagination guard, skip offset, and `dataLength` so both data sources drive pagination correctly

Fixes #607

## Root Cause

The pagination guard checked `data.transactions.length >= 10` before fetching more. Gateway accounts have very few transactions (2 deposit/reserve events) but many winning ticket events from a separate query. The guard always failed (`2 >= 10`), so `fetchMore` never ran.

## Test plan

- [ ] Visit `/accounts/0xca3331d67e87816adb30d9562a6e8c0623fb7fef/history` (gateway account)
- [ ] Scroll down — verify more winning ticket events load
- [ ] Visit an orchestrator account history page — verify pagination still works
- [ ] Verify no duplicate events appear after loading more

🤖 Generated with [Claude Code](https://claude.com/claude-code)