### PR TITLE
feat: add dev container and .npmrc for supply chain security

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "livepeer-explorer",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "remoteUser": "node",
+  "containerUser": "node",
+  "postCreateCommand": "sudo corepack enable && pnpm install",
+  "forwardPorts": [3000],
+  "customizations": {
+    "vscode": {
+      "extensions": ["dbaeumer.vscode-eslint"],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ next-env.d.ts
 !.vscode/settings.json
 .code-workspace
 .claude/
+.pnpm-store/
 
 # debug
 npm-debug.log*

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+frozen-lockfile=true
+ignore-scripts=true

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,7 @@ node_modules
 
 # misc
 .claude
+.pnpm-store
 .github
 .vscode
 @types

--- a/README.md
+++ b/README.md
@@ -9,9 +9,40 @@ Before getting started, ensure you have the following installed on your system:
 
 - [Node.js 22.x](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) (includes npm)
 - [pnpm v9.15.x](https://pnpm.io/installation) - you can install it with `npm install -g pnpm` or `corepack enable`
+- [Docker](https://docs.docker.com/get-docker/) (optional) — required for the dev container
 
 > [!TIP]
 > Use `nvm install` or `asdf install` to automatically switch to the correct versions.
+
+## Dev Container (Recommended)
+
+This project includes a dev container to isolate your development environment from your host machine, protecting against supply chain attacks by not exposing global credentials (`~/.ssh`, `~/.aws`, `~/.config`) to compromised packages.
+
+### Setup
+
+1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) in VS Code
+2. Open this project in VS Code
+3. Press `Ctrl+Shift+P` → **"Dev Containers: Reopen in Container"**
+4. The container will automatically install dependencies via `pnpm install`
+
+The dev server runs on port 3000, which is forwarded to your host automatically.
+
+This project also enforces `frozen-lockfile` and `ignore-scripts` via `.npmrc` to block malicious install hooks. If you need to work around these:
+
+**Adding a dependency:**
+
+```bash
+pnpm add <package> --no-frozen-lockfile
+```
+
+Then commit the updated `pnpm-lock.yaml`.
+
+**Approving a package's build script** (e.g., native bindings):
+
+```bash
+pnpm approve-builds
+pnpm rebuild
+```
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- Add `.devcontainer/devcontainer.json` for isolated development (Node 22, pnpm, port 3000 forwarded)
- Add `.npmrc` with `frozen-lockfile=true` and `ignore-scripts=true` to block malicious install hooks
- Update README with dev container setup instructions and workaround docs
- Add `.pnpm-store/` to `.gitignore` and `.prettierignore`

## Test plan
- [ ] Open project in VS Code and run "Dev Containers: Reopen in Container"
- [ ] Verify `pnpm install` runs with scripts disabled inside the container
- [ ] Verify `pnpm dev` starts the app on port 3000
- [ ] Verify `pnpm install` on host also respects `.npmrc` settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)