### PR TITLE
fix: add prettier as explicit devDependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ next-env.d.ts
 !.vscode/settings.json
 .code-workspace
 .claude/
+.pnpm-store/
 
 # debug
 npm-debug.log*

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,7 @@ node_modules
 
 # misc
 .claude
+.pnpm-store
 .github
 .vscode
 @types

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint": "^9.39.1",
     "eslint-config-next": "16.0.1",
     "eslint-config-prettier": "^10.1.8",
+    "prettier": "^2.8.8",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "husky": "^9.1.7",
     "jest": "^30.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,6 +334,9 @@ importers:
       jest-environment-jsdom:
         specifier: ^30.2.0
         version: 30.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      prettier:
+        specifier: ^2.8.8
+        version: 2.8.8
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@18.19.130)(typescript@5.9.2)


### PR DESCRIPTION
## Summary
- **Add `prettier` to devDependencies** — prettier was used in `format` / `format:check` scripts and the pre-commit hook but was never declared as a dependency. It worked as a ghost dependency via transitive hoisting, which breaks on pnpm 10+.
- **Ignore `.pnpm-store/`** in `.gitignore` and `.prettierignore`

> **Stack (1/3):** **#617** (this PR) → #616 → #615. Merge in order.

## Test plan
- [ ] `pnpm format:check` passes
- [ ] Pre-commit hook (`pnpm format:check && pnpm lint`) works

🤖 Generated with [Claude Code](https://claude.com/claude-code)