### PR TITLE
chore: update metrics server URL to active deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ NEXT_PUBLIC_GITHUB_LIP_NAMESPACE=adamsoffer
 NEXT_PUBLIC_SUBGRAPH_API_KEY=
 NEXT_PUBLIC_SUBGRAPH_ID=FE63YgkzcpVocxdCEyEYbvjYqEf2kb1A6daMYRxmejYC
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=
-NEXT_PUBLIC_METRICS_SERVER_URL=https://livepeer-leaderboard-serverless.vercel.app
+NEXT_PUBLIC_METRICS_SERVER_URL=https://leaderboard-serverless.vercel.app
 NEXT_PUBLIC_AI_METRICS_SERVER_URL=https://leaderboard-api.livepeer.cloud
 
 # Optional dev overrides (e.g. Graph Studio sandbox; leave empty in prod)


### PR DESCRIPTION
## Summary
- Point `NEXT_PUBLIC_METRICS_SERVER_URL` in `.env.example` at `https://leaderboard-serverless.vercel.app`
- The previous `livepeer-leaderboard-serverless.vercel.app` endpoint is no longer deployed