### PR TITLE
feat: add reward & fee cut history charts to orchestrator page

### DIFF
--- a/apollo/subgraph.ts
+++ b/apollo/subgraph.ts
@@ -10843,6 +10843,50 @@ export function useTranscoderActivatedEventsLazyQuery(baseOptions?: Apollo.LazyQ
 export type TranscoderActivatedEventsQueryHookResult = ReturnType<typeof useTranscoderActivatedEventsQuery>;
 export type TranscoderActivatedEventsLazyQueryHookResult = ReturnType<typeof useTranscoderActivatedEventsLazyQuery>;
 export type TranscoderActivatedEventsQueryResult = Apollo.QueryResult<TranscoderActivatedEventsQuery, TranscoderActivatedEventsQueryVariables>;
+
+export type TranscoderUpdateEventsQueryVariables = Exact<{
+  where?: InputMaybe<TranscoderUpdateEvent_Filter>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<TranscoderUpdateEvent_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+}>;
+
+export type TranscoderUpdateEventsQuery = { __typename: 'Query', transcoderUpdateEvents: Array<{ __typename: 'TranscoderUpdateEvent', id: string, rewardCut: string, feeShare: string, timestamp: number, round: { __typename: 'Round', id: string }, transaction: { __typename: 'Transaction', id: string } }> };
+
+export const TranscoderUpdateEventsDocument = gql`
+    query transcoderUpdateEvents($where: TranscoderUpdateEvent_filter, $first: Int, $orderBy: TranscoderUpdateEvent_orderBy, $orderDirection: OrderDirection) {
+  transcoderUpdateEvents(
+    where: $where
+    first: $first
+    orderBy: $orderBy
+    orderDirection: $orderDirection
+  ) {
+    id
+    rewardCut
+    feeShare
+    timestamp
+    round {
+      id
+    }
+    transaction {
+      id
+    }
+  }
+}
+    `;
+
+export function useTranscoderUpdateEventsQuery(baseOptions?: Apollo.QueryHookOptions<TranscoderUpdateEventsQuery, TranscoderUpdateEventsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<TranscoderUpdateEventsQuery, TranscoderUpdateEventsQueryVariables>(TranscoderUpdateEventsDocument, options);
+      }
+export function useTranscoderUpdateEventsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TranscoderUpdateEventsQuery, TranscoderUpdateEventsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<TranscoderUpdateEventsQuery, TranscoderUpdateEventsQueryVariables>(TranscoderUpdateEventsDocument, options);
+        }
+export type TranscoderUpdateEventsQueryHookResult = ReturnType<typeof useTranscoderUpdateEventsQuery>;
+export type TranscoderUpdateEventsLazyQueryHookResult = ReturnType<typeof useTranscoderUpdateEventsLazyQuery>;
+export type TranscoderUpdateEventsQueryResult = Apollo.QueryResult<TranscoderUpdateEventsQuery, TranscoderUpdateEventsQueryVariables>;
+
 export const TreasuryProposalDocument = gql`
     query treasuryProposal($id: ID!) {
   treasuryProposal(id: $id) {

--- a/components/ExplorerChart/index.tsx
+++ b/components/ExplorerChart/index.tsx
@@ -63,11 +63,13 @@ const ExplorerChart = ({
   basePercentChange,
   unit = "none",
   type,
+  lineCurve = "monotone",
+  yDomain,
   grouping = "day",
   onToggleGrouping,
 }: {
   title: string;
-  tooltip: string;
+  tooltip: React.ReactNode;
   base: number;
   basePercentChange: number;
   data: ChartDatum[];
@@ -80,6 +82,8 @@ const ExplorerChart = ({
     | "small-unitless"
     | "none";
   type: "bar" | "line";
+  lineCurve?: "monotone" | "stepAfter" | "linear";
+  yDomain?: [number | "auto" | "dataMin", number | "auto" | "dataMax"];
   grouping?: Group;
   onToggleGrouping?: (grouping: Group) => void;
 }) => {
@@ -223,7 +227,7 @@ const ExplorerChart = ({
       unit === "small-percent"
         ? 45
         : unit === "percent"
-        ? 35
+        ? 42
         : unit === "minutes"
         ? 35
         : unit === "eth"
@@ -245,23 +249,7 @@ const ExplorerChart = ({
         <ExplorerTooltip
           multiline
           side="bottom"
-          content={
-            tooltip ? (
-              <>
-                <div>{tooltip}</div>
-                <br />
-                <div>
-                  {`The estimation methodology was updated on 8/21/23. `}
-                  <a href="https://forum.livepeer.org/t/livepeer-explorer-minutes-estimation-methodology/2140">
-                    Read more about the changes
-                  </a>
-                  {"."}
-                </div>
-              </>
-            ) : (
-              <></>
-            )
-          }
+          content={tooltip ? <div>{tooltip}</div> : <></>}
         >
           <Flex
             css={{
@@ -479,13 +467,13 @@ const ExplorerChart = ({
                 width={widthYAxis}
                 orientation="right"
                 tick={CustomizedYAxisTick}
-                domain={["auto", "auto"]}
+                domain={yDomain ?? ["auto", "auto"]}
               />
               <ReTooltip content={CustomContentOfTooltip} />
 
               <Line
                 dataKey="y"
-                type="monotone"
+                type={lineCurve}
                 dot={{ r: 0, strokeWidth: 0 }}
                 activeDot={{ r: 3, strokeWidth: 0 }}
                 stroke="rgba(0, 235, 136, 0.8)"

--- a/components/OrchestratingView/index.tsx
+++ b/components/OrchestratingView/index.tsx
@@ -1,3 +1,4 @@
+import OrchestratorCutHistory from "@components/OrchestratorCutHistory";
 import Stat from "@components/Stat";
 import dayjs from "@lib/dayjs";
 import { Box, Flex, Link as A, Text } from "@livepeer/design-system";
@@ -250,21 +251,6 @@ const Index = ({ currentRound, transcoder, isActive }: Props) => {
         /> */}
         <Stat
           className="masonry-grid_item"
-          label="Fee Cut"
-          tooltip={
-            "The percent of the transcoding fees which are kept by the orchestrator, with the remainder distributed to its delegators by percent stake."
-          }
-          value={
-            transcoder?.feeShare
-              ? numbro(1 - +(transcoder?.feeShare || 0) / 1000000).format({
-                  output: "percent",
-                  mantissa: 0,
-                })
-              : "N/A"
-          }
-        />
-        <Stat
-          className="masonry-grid_item"
           label="Reward Cut"
           tooltip={
             "The percent of the inflationary reward fees which are kept by the orchestrator, with the remainder distributed to its delegators by percent stake."
@@ -277,6 +263,21 @@ const Index = ({ currentRound, transcoder, isActive }: Props) => {
                     output: "percent",
                     mantissa: 0,
                   })
+              : "N/A"
+          }
+        />
+        <Stat
+          className="masonry-grid_item"
+          label="Fee Cut"
+          tooltip={
+            "The percent of the transcoding fees which are kept by the orchestrator, with the remainder distributed to its delegators by percent stake."
+          }
+          value={
+            transcoder?.feeShare
+              ? numbro(1 - +(transcoder?.feeShare || 0) / 1000000).format({
+                  output: "percent",
+                  mantissa: 0,
+                })
               : "N/A"
           }
         />
@@ -329,112 +330,110 @@ const Index = ({ currentRound, transcoder, isActive }: Props) => {
             }
           />
         )}
-        <A
-          as={Link}
-          href={`/accounts/${transcoder?.id}/history`}
-          passHref
-          className="masonry-grid_item"
-          css={{
-            display: "block",
+      </Masonry>
+      <A
+        as={Link}
+        href={`/accounts/${transcoder?.id}/history`}
+        passHref
+        css={{
+          display: "block",
+          textDecoration: "none",
+          marginBottom: "$3",
+          "&:hover": {
             textDecoration: "none",
-            "&:hover": {
-              textDecoration: "none",
-              ".see-history": {
-                textDecoration: "underline",
-                color: "$primary11",
-                transition: "color .3s",
-              },
+            ".see-history": {
+              textDecoration: "underline",
+              color: "$primary11",
+              transition: "color .3s",
             },
-          }}
-        >
-          <Stat
-            label="Treasury Governance Participation"
-            variant="interactive"
-            tooltip={
-              <Box>
-                Number of proposals voted on relative to the number of proposals
-                the orchestrator was eligible for while active.
-              </Box>
-            }
-            value={
-              govStats ? (
-                <Flex css={{ alignItems: "baseline", gap: "$1" }}>
-                  <Box css={{ color: "$hiContrast" }}>{govStats.voted}</Box>
-                  <Box
-                    css={{
-                      fontSize: "$3",
-                      color: "$neutral11",
-                      fontWeight: 500,
-                    }}
-                  >
-                    / {govStats.eligible} Proposals
-                  </Box>
-                </Flex>
-              ) : (
-                "N/A"
-              )
-            }
-            meta={
-              <Box css={{ width: "100%", marginTop: "$2" }}>
-                {govStats && (
-                  <Box
-                    css={{
-                      width: "100%",
-                      height: 4,
-                      backgroundColor: "$neutral4",
-                      borderRadius: "$2",
-                      overflow: "hidden",
-                      marginBottom: "$2",
-                    }}
-                  >
-                    <Box
-                      css={{
-                        width: `${(govStats.voted / govStats.eligible) * 100}%`,
-                        height: "100%",
-                        backgroundColor: "$primary11",
-                      }}
-                    />
-                  </Box>
-                )}
-                <Flex
+          },
+        }}
+      >
+        <Stat
+          label="Treasury Governance Participation"
+          variant="interactive"
+          tooltip={
+            <Box>
+              Number of proposals voted on relative to the number of proposals
+              the orchestrator was eligible for while active.
+            </Box>
+          }
+          value={
+            govStats ? (
+              <Flex css={{ alignItems: "baseline", gap: "$1" }}>
+                <Box css={{ color: "$hiContrast" }}>{govStats.voted}</Box>
+                <Box
                   css={{
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    width: "100%",
+                    fontSize: "$3",
+                    color: "$neutral11",
+                    fontWeight: 500,
                   }}
                 >
-                  {govStats && (
-                    <Text
-                      size="2"
-                      css={{ color: "$neutral11", fontWeight: 600 }}
-                    >
-                      {numbro(govStats.voted / govStats.eligible).format({
-                        output: "percent",
-                        mantissa: 0,
-                      })}{" "}
-                      Participation
-                    </Text>
-                  )}
-                  <Text
-                    className="see-history"
-                    size="2"
+                  / {govStats.eligible} Proposals
+                </Box>
+              </Flex>
+            ) : (
+              "N/A"
+            )
+          }
+          meta={
+            <Box css={{ width: "100%", marginTop: "$2" }}>
+              {govStats && (
+                <Box
+                  css={{
+                    width: "100%",
+                    height: 4,
+                    backgroundColor: "$neutral4",
+                    borderRadius: "$2",
+                    overflow: "hidden",
+                    marginBottom: "$2",
+                  }}
+                >
+                  <Box
                     css={{
-                      color: "$primary11",
-                      fontWeight: 600,
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "$0.75",
+                      width: `${(govStats.voted / govStats.eligible) * 100}%`,
+                      height: "100%",
+                      backgroundColor: "$primary11",
                     }}
-                  >
-                    See history
-                    <Box as={ArrowTopRightIcon} width={15} height={15} />
+                  />
+                </Box>
+              )}
+              <Flex
+                css={{
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  width: "100%",
+                }}
+              >
+                {govStats && (
+                  <Text size="2" css={{ color: "$neutral11", fontWeight: 600 }}>
+                    {numbro(govStats.voted / govStats.eligible).format({
+                      output: "percent",
+                      mantissa: 0,
+                    })}{" "}
+                    Participation
                   </Text>
-                </Flex>
-              </Box>
-            }
-          />
-        </A>
-      </Masonry>
+                )}
+                <Text
+                  className="see-history"
+                  size="2"
+                  css={{
+                    color: "$primary11",
+                    fontWeight: 600,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "$0.75",
+                  }}
+                >
+                  See history
+                  <Box as={ArrowTopRightIcon} width={15} height={15} />
+                </Text>
+              </Flex>
+            </Box>
+          }
+        />
+      </A>
+      <OrchestratorCutHistory transcoder={transcoder} />
     </Box>
   );
 };

--- a/components/OrchestratorCutHistory/index.tsx
+++ b/components/OrchestratorCutHistory/index.tsx
@@ -1,0 +1,88 @@
+import ExplorerChart from "@components/ExplorerChart";
+import { Box, Flex } from "@livepeer/design-system";
+import type { AccountQueryResult } from "apollo";
+import { useOrchestratorCutHistory } from "hooks/useOrchestratorCutHistory";
+
+const Panel = ({ children }) => (
+  <Flex
+    css={{
+      minHeight: 240,
+      height: 240,
+      padding: "24px",
+      flexDirection: "column",
+      alignItems: "center",
+      justifyContent: "center",
+      border: "0.5px solid $colors$neutral4",
+      flex: 1,
+      width: "100%",
+    }}
+  >
+    {children}
+  </Flex>
+);
+
+interface Props {
+  transcoder?: NonNullable<AccountQueryResult["data"]>["transcoder"];
+}
+
+const OrchestratorCutHistory = ({ transcoder }: Props) => {
+  const { rewardCutData, feeCutData, baseRewardCut, baseFeeCut, loading } =
+    useOrchestratorCutHistory(transcoder);
+
+  // Hide when there's no orchestrator or no data to plot.
+  if (!transcoder?.id) return null;
+  if (!loading && rewardCutData.length === 0) return null;
+
+  return (
+    <Box css={{ marginBottom: "$3" }}>
+      <Flex
+        css={{
+          backgroundColor: "$panel",
+          borderRadius: "$4",
+          border: "1px solid $colors$neutral4",
+          overflow: "hidden",
+        }}
+      >
+        <Box
+          css={{
+            width: "100%",
+            display: "grid",
+            gridTemplateColumns: "1fr",
+            "@bp2": {
+              gridTemplateColumns: "1fr 1fr",
+            },
+          }}
+        >
+          <Panel>
+            <ExplorerChart
+              title="Reward Cut"
+              tooltip="The percent of inflationary rewards kept by the orchestrator over time."
+              data={rewardCutData}
+              base={baseRewardCut}
+              basePercentChange={0}
+              unit="percent"
+              type="line"
+              lineCurve="stepAfter"
+              yDomain={[0, 1]}
+            />
+          </Panel>
+          <Panel>
+            <ExplorerChart
+              title="Fee Cut"
+              tooltip="The percent of transcoding fees kept by the orchestrator over time."
+              data={feeCutData}
+              base={baseFeeCut}
+              basePercentChange={0}
+              unit="percent"
+              type="line"
+              lineCurve="stepAfter"
+              yDomain={[0, 1]}
+            />
+          </Panel>
+        </Box>
+      </Flex>
+    </Box>
+  );
+};
+
+export default OrchestratorCutHistory;

--- a/hooks/useOrchestratorCutHistory.tsx
+++ b/hooks/useOrchestratorCutHistory.tsx
@@ -1,0 +1,102 @@
+import type { ChartDatum } from "@components/ExplorerChart";
+import type { AccountQueryResult } from "apollo";
+import {
+  OrderDirection,
+  TranscoderUpdateEvent_OrderBy,
+  useTranscoderUpdateEventsQuery,
+} from "apollo";
+import { useMemo } from "react";
+
+export type CutDataPoint = {
+  timestamp: number;
+  rewardCut: number;
+  feeCut: number;
+};
+
+type Transcoder = NonNullable<AccountQueryResult["data"]>["transcoder"];
+
+export function useOrchestratorCutHistory(transcoder?: Transcoder) {
+  const { data, loading } = useTranscoderUpdateEventsQuery({
+    variables: {
+      where: {
+        delegate: transcoder?.id,
+      },
+      first: 1000,
+      orderBy: TranscoderUpdateEvent_OrderBy.Timestamp,
+      orderDirection: OrderDirection.Asc,
+    },
+    skip: !transcoder?.id,
+  });
+
+  const chartData = useMemo<CutDataPoint[]>(() => {
+    const events: CutDataPoint[] = (data?.transcoderUpdateEvents ?? []).map(
+      (event) => ({
+        timestamp: event.timestamp,
+        rewardCut: (Number(event.rewardCut) / 1000000) * 100,
+        feeCut: (1 - Number(event.feeShare) / 1000000) * 100,
+      })
+    );
+
+    // No update events — synthesize a starting anchor from current
+    // on-chain values at activation time so the chart shows a flat line.
+    if (
+      events.length === 0 &&
+      transcoder?.activationTimestamp &&
+      transcoder?.rewardCut != null &&
+      transcoder?.feeShare != null
+    ) {
+      events.push({
+        timestamp: Number(transcoder.activationTimestamp),
+        rewardCut: (Number(transcoder.rewardCut) / 1000000) * 100,
+        feeCut: (1 - Number(transcoder.feeShare) / 1000000) * 100,
+      });
+    }
+
+    if (events.length === 0) return [];
+
+    // "Now" anchor so the chart line extends to the present day.
+    const last = events[events.length - 1];
+    // eslint-disable-next-line react-hooks/purity
+    const now = Math.floor(Date.now() / 1000);
+    if (now - last.timestamp > 86400) {
+      events.push({
+        timestamp: now,
+        rewardCut: last.rewardCut,
+        feeCut: last.feeCut,
+      });
+    }
+
+    return events;
+  }, [
+    data,
+    transcoder?.activationTimestamp,
+    transcoder?.rewardCut,
+    transcoder?.feeShare,
+  ]);
+
+  // ExplorerChart's percent unit expects decimals (0.05 = 5%).
+  const rewardCutData = useMemo<ChartDatum[]>(
+    () => chartData.map((d) => ({ x: d.timestamp, y: d.rewardCut / 100 })),
+    [chartData]
+  );
+  const feeCutData = useMemo<ChartDatum[]>(
+    () => chartData.map((d) => ({ x: d.timestamp, y: d.feeCut / 100 })),
+    [chartData]
+  );
+
+  const baseRewardCut = chartData.length
+    ? chartData[chartData.length - 1].rewardCut / 100
+    : 0;
+  const baseFeeCut = chartData.length
+    ? chartData[chartData.length - 1].feeCut / 100
+    : 0;
+
+  return {
+    chartData,
+    rewardCutData,
+    feeCutData,
+    baseRewardCut,
+    baseFeeCut,
+    loading,
+  };
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -196,9 +196,20 @@ const Charts = ({ chartData }: { chartData: HomeChartData | null }) => {
       </Panel>
       <Panel>
         <ExplorerChart
-          tooltip={`The ${
-            usageGrouping === "day" ? "daily" : "weekly"
-          } usage of the network in minutes.`}
+          tooltip={
+            <>
+              {`The ${
+                usageGrouping === "day" ? "daily" : "weekly"
+              } usage of the network in minutes.`}
+              <br />
+              <br />
+              {"The estimation methodology was updated on 8/21/23. "}
+              <a href="https://forum.livepeer.org/t/livepeer-explorer-minutes-estimation-methodology/2140">
+                Read more about the changes
+              </a>
+              {"."}
+            </>
+          }
           data={
             usageGrouping === "week"
               ? usageData.slice(-26)

--- a/queries/transcoderUpdateEvents.graphql
+++ b/queries/transcoderUpdateEvents.graphql
@@ -1,0 +1,24 @@
+query transcoderUpdateEvents(
+  $where: TranscoderUpdateEvent_filter
+  $first: Int
+  $orderBy: TranscoderUpdateEvent_orderBy
+  $orderDirection: OrderDirection
+) {
+  transcoderUpdateEvents(
+    where: $where
+    first: $first
+    orderBy: $orderBy
+    orderDirection: $orderDirection
+  ) {
+    id
+    rewardCut
+    feeShare
+    timestamp
+    round {
+      id
+    }
+    transaction {
+      id
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds historical charts for an orchestrator's reward cut and fee cut to the orchestrator page. Delegators can now see how an orchestrator has changed their cuts over time before delegating.

- New `OrchestratorCutHistory` component renders two step-line charts (reward cut and fee cut) via `ExplorerChart`
- New `useOrchestratorCutHistory` hook fetches historical `TranscoderUpdateEvent`s from the subgraph and prepares chart-ready data, with two anchor points for edge cases:
  - a **"now" anchor** so the line extends to the present day when the last on-chain update is older than 24h
  - an **"activation" anchor** synthesized from the current on-chain cut values at `activationTimestamp` when the orchestrator has no `TranscoderUpdateEvent`s at all, so the chart renders a flat line from activation → now instead of an empty skeleton
- Chart is hidden entirely for accounts with nothing to plot (e.g. never-activated)
- `ExplorerChart` gains:
  - `lineCurve` prop (`monotone` / `stepAfter` / `linear`) for step-style lines
  - `yDomain` prop to pin Y-axis range — cut charts use `[0, 1]` to avoid Recharts auto-scaling to absurd ranges (e.g. 400%) on flat-line data
  - `tooltip` widened to `ReactNode` — the hardcoded "estimation methodology" note (leaked onto every chart as a default via #227) is removed and passed inline only from the _Estimated Usage_ chart, per the [forum post](https://forum.livepeer.org/t/livepeer-explorer-minutes-estimation-methodology/2140)
- Fee Cut / Reward Cut stat order swapped to match chart order; "See history" link moved outside Masonry for full-width layout

Note: this is the first of two PRs. A follow-up PR will add a bait-and-switch warning dialog on the delegation flow on top of the hook introduced here.

## Test plan

- [x] Visit `/accounts/<orchestrator-id>/orchestrating` for an orchestrator **with** `TranscoderUpdateEvent` history and confirm both charts render the step curve at the actual on-chain change points
- [x] Visit an orchestrator **without** any `TranscoderUpdateEvent`s (e.g. [`0x41239fb65360981316fcb4a8548320d305f9496d`](https://explorer.livepeer.org/accounts/0x41239fb65360981316fcb4a8548320d305f9496d/orchestrating)) and confirm a flat line renders from `activationTimestamp` to the current day with Y-axis 0–100%
- [x] Confirm the "now" anchor extends the line to the current day when the last update is older than 24h
- [x] Confirm the charts are **hidden entirely** (not stuck on skeleton) for accounts that are not active orchestrators
- [x] Confirm axis labels are not clipped on mobile (Y-axis '100%' label)
- [x] Confirm loading skeletons show while data is fetching
- [x] Confirm layout is unchanged elsewhere on the page
- [x] Confirm the estimation methodology note appears **only** on the _Estimated Usage_ chart on the homepage
- [x] Confirm the reward/fee cut tooltips do not show the estimation methodology note