### PR TITLE
feat: add Telegram bot alert dialog for orchestrators

### DIFF
--- a/components/Profile/index.tsx
+++ b/components/Profile/index.tsx
@@ -2,7 +2,17 @@ import { ExplorerTooltip } from "@components/ExplorerTooltip";
 import ShowMoreRichText from "@components/ShowMoreRichText";
 import { EnsIdentity } from "@lib/api/types/get-ens";
 import { formatAddress } from "@lib/utils";
-import { Box, Flex, Heading, Link as A, Text } from "@livepeer/design-system";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Flex,
+  Heading,
+  Link as A,
+  Text,
+} from "@livepeer/design-system";
 import {
   CheckIcon,
   CopyIcon,
@@ -12,7 +22,8 @@ import {
 } from "@modulz/radix-icons";
 import copy from "copy-to-clipboard";
 import { QRCodeCanvas } from "qrcode.react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { LuBell } from "react-icons/lu";
 
 import EditProfile from "../EditProfile";
 
@@ -20,12 +31,27 @@ interface Props {
   account: string;
   isActive: boolean;
   isMyAccount: boolean;
+  isOrchestrator?: boolean;
   css?: object;
   identity: EnsIdentity;
 }
 
-const Index = ({ account, isMyAccount = false, identity }: Props) => {
+const Index = ({
+  account,
+  isMyAccount = false,
+  isOrchestrator = false,
+  identity,
+}: Props) => {
   const [copied, setCopied] = useState(false);
+  const [alertsOpen, setAlertsOpen] = useState(false);
+  const [commandCopied, setCommandCopied] = useState(false);
+
+  const handleCopyCommand = useCallback(() => {
+    if (copy(`/subscribe ${account}`)) {
+      setCommandCopied(true);
+      setTimeout(() => setCommandCopied(false), 2000);
+    }
+  }, [account]);
 
   useEffect(() => {
     if (!copied) return;
@@ -202,6 +228,35 @@ const Index = ({ account, isMyAccount = false, identity }: Props) => {
                   )}
                 </Flex>
               </ExplorerTooltip>
+              {isOrchestrator && (
+                <ExplorerTooltip content="Get alerts">
+                  <Flex
+                    as="button"
+                    type="button"
+                    aria-label="Get orchestrator alerts"
+                    onClick={() => setAlertsOpen(true)}
+                    css={{
+                      marginLeft: "$2",
+                      cursor: "pointer",
+                      borderRadius: 1000,
+                      backgroundColor: "$neutral3",
+                      border: "1px solid $neutral6",
+                      padding: 0,
+                      width: 28,
+                      height: 28,
+                      flexShrink: 0,
+                      alignItems: "center",
+                      justifyContent: "center",
+                      color: "$muted",
+                      "&:hover": {
+                        color: "white",
+                      },
+                    }}
+                  >
+                    <LuBell size={14} />
+                  </Flex>
+                </ExplorerTooltip>
+              )}
             </Flex>
             {isMyAccount && (
               <Box
@@ -302,6 +357,111 @@ const Index = ({ account, isMyAccount = false, identity }: Props) => {
           </ShowMoreRichText>
         </Text>
       )}
+
+      <Dialog open={alertsOpen} onOpenChange={setAlertsOpen}>
+        <DialogContent
+          css={{
+            maxWidth: 400,
+            width: "calc(100vw - 32px)",
+            padding: "$4",
+            paddingRight: "$5",
+            "@bp2": {
+              padding: "$5",
+              paddingRight: "$6",
+            },
+          }}
+          onPointerEnterCapture={undefined}
+          onPointerLeaveCapture={undefined}
+          placeholder={undefined}
+        >
+          <DialogTitle asChild>
+            <Text
+              as="h2"
+              css={{
+                fontWeight: 600,
+                fontSize: "$4",
+                marginBottom: "$3",
+                lineHeight: 1.3,
+              }}
+            >
+              Get Orchestrator Alerts
+            </Text>
+          </DialogTitle>
+          <Text
+            css={{
+              marginBottom: "$3",
+              color: "$neutral11",
+              lineHeight: 1.5,
+            }}
+          >
+            Get notified about reward calls, missed rounds, and cut changes via
+            our Telegram bot. Native notifications are coming soon.
+          </Text>
+          <Text
+            css={{
+              fontSize: "$2",
+              color: "$neutral11",
+              marginBottom: "$2",
+            }}
+          >
+            Send this command to the bot:
+          </Text>
+          <Box
+            as="button"
+            type="button"
+            onClick={handleCopyCommand}
+            css={{
+              display: "flex",
+              alignItems: "flex-start",
+              justifyContent: "space-between",
+              gap: "$2",
+              width: "100%",
+              background: "$neutral3",
+              border: "1px solid $neutral5",
+              borderRadius: "$2",
+              padding: "$2 $3",
+              marginBottom: "$4",
+              fontFamily: "monospace",
+              fontSize: "$1",
+              color: "white",
+              wordBreak: "break-all",
+              lineHeight: 1.4,
+              cursor: "pointer",
+              textAlign: "left",
+              "&:hover": {
+                background: "$neutral5",
+              },
+            }}
+          >
+            <span>/subscribe {account}</span>
+            <Box
+              as={commandCopied ? CheckIcon : CopyIcon}
+              css={{
+                flexShrink: 0,
+                width: 14,
+                height: 14,
+                marginTop: 2,
+                color: commandCopied ? "$primary11" : "$neutral9",
+              }}
+            />
+          </Box>
+          <Button
+            as="a"
+            href="https://t.me/OrchestratorWatcherBot"
+            target="_blank"
+            rel="noopener noreferrer"
+            size="3"
+            variant="primary"
+            css={{
+              width: "100%",
+              justifyContent: "center",
+              textDecoration: "none",
+            }}
+          >
+            Open Telegram Bot
+          </Button>
+        </DialogContent>
+      </Dialog>
     </Box>
   );
 };

--- a/layouts/account.tsx
+++ b/layouts/account.tsx
@@ -206,6 +206,7 @@ const AccountLayout = ({
             isActive={isActive}
             account={query?.account?.toString() ?? ""}
             isMyAccount={isMyAccount}
+            isOrchestrator={isOrchestrator}
             identity={identity}
           />
           <Flex


### PR DESCRIPTION
> Re-opens #627, which was accidentally merged into a stacked base branch (`feat/delegation-cut-warning`) instead of `main`, so the changes never reached `main`.

Closes #628

## Summary

Adds a bell icon next to the orchestrator name on all orchestrator pages. Clicking opens a dialog linking to the [@OrchestratorWatcherBot](https://t.me/OrchestratorWatcherBot) Telegram bot as an interim alert solution until native notifications land (#319).

**Dialog contents:**
- What alerts are available (reward calls, missed rounds, cut changes)
- A `/subscribe <address>` command with click-to-copy (copy icon top-right, swaps to checkmark)
- "Open Telegram Bot" primary CTA button
- Note that native notifications are coming soon

**Bell icon visibility:** all orchestrator pages, no wallet connection required.

## Test plan

- [ ] Visit any orchestrator page — bell icon appears next to the copy-address button
- [ ] Click bell — dialog opens with title, description, copy command, and CTA
- [ ] Click the `/subscribe` code block — copies command, icon changes to checkmark
- [ ] Click "Open Telegram Bot" — opens Telegram in new tab
- [ ] Dialog closes via X button, click outside, or Escape
- [ ] Visit a non-orchestrator account — no bell icon
- [ ] Mobile: dialog is responsive, bell icon does not clip

🤖 Generated with [Claude Code](https://claude.com/claude-code)