### PR TITLE
feat: add delegation cut history reminder

### DIFF
--- a/components/DelegatingWidget/Delegate.tsx
+++ b/components/DelegatingWidget/Delegate.tsx
@@ -1,7 +1,8 @@
 import { bondingManager } from "@lib/api/abis/main/BondingManager";
 import { livepeerToken } from "@lib/api/abis/main/LivepeerToken";
 import { MAXIMUM_VALUE_UINT256 } from "@lib/utils";
-import { Box, Button } from "@livepeer/design-system";
+import { Box, Button, Flex, Text } from "@livepeer/design-system";
+import { InfoCircledIcon } from "@radix-ui/react-icons";
 import {
   useBondingManagerAddress,
   useLivepeerTokenAddress,
@@ -17,6 +18,7 @@ const Delegate = ({
   to,
   amount,
   isTransferStake,
+  isMyTranscoder,
   tokenBalance,
   transferAllowance,
   reset,
@@ -167,48 +169,80 @@ const Delegate = ({
     );
   }
 
+  const cutChangeNotice = isMyTranscoder ? null : (
+    <Flex
+      css={{
+        alignItems: "center",
+        gap: "$3",
+        padding: "$3",
+        marginBottom: "$3",
+        borderRadius: "$3",
+        background: "$neutral3",
+      }}
+    >
+      <Box
+        as={InfoCircledIcon}
+        css={{ color: "white", flexShrink: 0, width: 16, height: 16 }}
+      />
+      <Text css={{ fontSize: "$2", color: "white", lineHeight: 1.5 }}>
+        Please ensure you have checked the reward & fee cut history before
+        delegating.
+      </Text>
+    </Flex>
+  );
+
   if (showApproveFlow) {
     return (
-      <Box>
-        <Box
-          css={{ display: "grid", gap: "$3", gridTemplateColumns: "1fr 1fr" }}
-        >
-          <Button
-            size="4"
-            variant="primary"
-            disabled={sufficientTransferAllowance}
-            onClick={onApprove}
-            css={{ width: "100%" }}
+      <>
+        {cutChangeNotice}
+        <Box>
+          <Box
+            css={{
+              display: "grid",
+              gap: "$3",
+              gridTemplateColumns: "1fr 1fr",
+            }}
           >
-            Approve
-          </Button>
-          <Button
-            size="4"
-            disabled={!sufficientTransferAllowance}
-            variant="primary"
-            onClick={onDelegate}
-            css={{ width: "100%" }}
-          >
-            {+amount >= 0 && isTransferStake ? "Switch" : "Delegate"}
-          </Button>
+            <Button
+              size="4"
+              variant="primary"
+              disabled={sufficientTransferAllowance}
+              onClick={onApprove}
+              css={{ width: "100%" }}
+            >
+              Approve
+            </Button>
+            <Button
+              size="4"
+              disabled={!sufficientTransferAllowance}
+              variant="primary"
+              onClick={onDelegate}
+              css={{ width: "100%" }}
+            >
+              {+amount >= 0 && isTransferStake ? "Switch" : "Delegate"}
+            </Button>
+          </Box>
+          <ProgressSteps
+            steps={[sufficientTransferAllowance]}
+            css={{ mt: "$3" }}
+          />
         </Box>
-        <ProgressSteps
-          steps={[sufficientTransferAllowance]}
-          css={{ mt: "$3" }}
-        />
-      </Box>
+      </>
     );
   }
 
   return (
-    <Button
-      size="4"
-      onClick={onDelegate}
-      variant="primary"
-      css={{ width: "100%" }}
-    >
-      {+amount >= 0 && isTransferStake ? "Move Delegated Stake" : "Delegate"}
-    </Button>
+    <>
+      {cutChangeNotice}
+      <Button
+        size="4"
+        onClick={onDelegate}
+        variant="primary"
+        css={{ width: "100%" }}
+      >
+        {+amount >= 0 && isTransferStake ? "Move Delegated Stake" : "Delegate"}
+      </Button>
+    </>
   );
 };
 

--- a/components/DelegatingWidget/Footer.tsx
+++ b/components/DelegatingWidget/Footer.tsx
@@ -165,6 +165,7 @@ const Footer = ({
           to={transcoder?.id}
           amount={amount}
           isTransferStake={isTransferStake}
+          isMyTranscoder={isMyTranscoder}
           tokenBalance={tokenBalance}
           transferAllowance={transferAllowance}
           reset={reset}

--- a/components/ExplorerChart/index.tsx
+++ b/components/ExplorerChart/index.tsx
@@ -3,7 +3,7 @@ import dayjs from "@lib/dayjs";
 import { Box, Button, Flex, Skeleton, Text } from "@livepeer/design-system";
 import { QuestionMarkCircledIcon } from "@modulz/radix-icons";
 import numbro from "numbro";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import {
   Bar,
   BarChart as ReBarChart,
@@ -69,7 +69,7 @@ const ExplorerChart = ({
   onToggleGrouping,
 }: {
   title: string;
-  tooltip: React.ReactNode;
+  tooltip: ReactNode;
   base: number;
   basePercentChange: number;
   data: ChartDatum[];


### PR DESCRIPTION
> Re-opens #626, which was accidentally merged into the stacked base branch (`feat/reward-cut-history`) instead of `main`, so the changes never reached `main`.

Closes #629

## Summary

Adds a non-blocking info banner above the Delegate button reminding delegators to review reward & fee cut history before delegating.

- Static info banner with ℹ icon shown when delegating to a **new** orchestrator
- Hidden when adding more stake to the same orchestrator (already familiar)
- Universal gentle nudge — no detection logic, no thresholds, no false positives
- Simplifies `useOrchestratorCutHistory` by removing the complex warning system (severity tiers, scans, forgiveness logic) carried over from development

## Test plan

- [ ] Delegate to a **new** orchestrator — info banner appears above Delegate button
- [ ] Add more stake to **current** orchestrator — no banner
- [ ] Undelegate flow — no banner
- [ ] Banner does not block delegation
- [ ] Mobile: text wraps cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)