### PR TITLE
fix: center transaction error message in summary dialog

### DIFF
--- a/components/TxSummaryDialog/index.tsx
+++ b/components/TxSummaryDialog/index.tsx
@@ -83,7 +83,7 @@ const Index = () => {
         <Box css={{ textAlign: "center", marginTop: "$2", fontSize: "$2" }}>
           {latestTransaction?.error ? (
             <>
-              <Text css={{ marginBottom: "$3", maxWidth: 350 }}>
+              <Text css={{ display: "block", marginBottom: "$3" }}>
                 {latestTransaction?.error.length < 50
                   ? `${sentenceCase(latestTransaction?.error)}.`
                   : "Error with transaction, please check your inputs and try again."}


### PR DESCRIPTION
## Summary
- Remove the `maxWidth: 350` constraint on the error `Text` in `TxSummaryDialog` — it was narrower than the dialog (`maxWidth: 450` at bp1), causing the text block to sit left-aligned inside a center-aligned parent and wrap awkwardly.
- Add `display: block` so the `Text` fills the dialog width and inherits `textAlign: center` from its parent cleanly.

## Test plan
- [ ] Trigger a transaction error and verify the error message is horizontally centered in the dialog
- [ ] Confirm short (<50 char) error messages still render correctly
- [ ] Verify the dialog looks correct at both the 370px and 450px (`@bp1`) widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)