### PR TITLE
fix: time-scale x-axis on cut history charts

### DIFF
--- a/components/ExplorerChart/index.tsx
+++ b/components/ExplorerChart/index.tsx
@@ -35,19 +35,39 @@ const CustomContentOfTooltip = ({
 
 export type ChartDatum = { x: number; y: number };
 
-const CustomizedXAxisTick = ({ x, y, payload }) => {
+const CustomizedXAxisTick = ({
+  x,
+  y,
+  payload,
+  index,
+  visibleTicksCount,
+  xScale,
+}) => {
+  // Time mode is ms (D3 convention); category is unix seconds.
+  const date =
+    xScale === "time" ? dayjs(payload.value) : dayjs.unix(payload.value);
+  // Time scale fills edge-to-edge; anchor first/last labels inward to avoid clipping.
+  const textAnchor =
+    xScale === "time"
+      ? index === 0
+        ? "start"
+        : index === visibleTicksCount - 1
+        ? "end"
+        : "middle"
+      : "end";
+
   return (
     <g transform={`translate(${x},${y})`}>
       <text
         x={0}
         y={0}
         dy={14}
-        textAnchor="end"
+        textAnchor={textAnchor}
         fill="white"
         fontWeight={400}
         fontSize="13px"
       >
-        {dayjs.unix(payload.value).format("MMM YY")}
+        {date.format("MMM YY")}
       </text>
     </g>
   );
@@ -65,6 +85,7 @@ const ExplorerChart = ({
   type,
   lineCurve = "monotone",
   yDomain,
+  xScale = "category",
   grouping = "day",
   onToggleGrouping,
 }: {
@@ -84,23 +105,21 @@ const ExplorerChart = ({
   type: "bar" | "line";
   lineCurve?: "monotone" | "stepAfter" | "linear";
   yDomain?: [number | "auto" | "dataMin", number | "auto" | "dataMax"];
+  xScale?: "category" | "time";
   grouping?: Group;
   onToggleGrouping?: (grouping: Group) => void;
 }) => {
   const formatDateSubtitle = useCallback(
-    (date: number) =>
-      grouping === "day"
-        ? `${dayjs.unix(date).format("MMM D")}`
-        : `${dayjs
-            .unix(date)
-            .add(1, "day")
-            .startOf("week")
-            .format("MMM D")} - ${dayjs
-            .unix(date)
+    (date: number) => {
+      const d = xScale === "time" ? dayjs(date) : dayjs.unix(date);
+      return grouping === "day"
+        ? d.format("MMM D")
+        : `${d.add(1, "day").startOf("week").format("MMM D")} - ${d
             .add(1, "day")
             .endOf("week")
-            .format("MMM D")}`,
-    [grouping]
+            .format("MMM D")}`;
+    },
+    [grouping, xScale]
   );
   const formatSubtitle = useCallback(
     (value: number) => {
@@ -237,6 +256,32 @@ const ExplorerChart = ({
         : 30,
     [unit]
   );
+
+  const timeTicks = useMemo<number[] | undefined>(() => {
+    if (xScale !== "time" || !data || data.length < 2) return undefined;
+    const min = data[0].x;
+    const max = data[data.length - 1].x;
+    return [min, (min + max) / 2, max];
+  }, [xScale, data]);
+
+  const xAxis =
+    xScale === "time" ? (
+      <XAxis
+        dataKey="x"
+        type="number"
+        scale="time"
+        domain={["dataMin", "dataMax"]}
+        ticks={timeTicks}
+        interval={0}
+        tick={(props) => <CustomizedXAxisTick {...props} xScale="time" />}
+      />
+    ) : (
+      <XAxis
+        dataKey="x"
+        tick={CustomizedXAxisTick}
+        interval="preserveStartEnd"
+      />
+    );
 
   return (
     <Box css={{ position: "relative", width: "100%", height: "100%" }}>
@@ -410,11 +455,7 @@ const ExplorerChart = ({
                 })
               }
             >
-              <XAxis
-                dataKey="x"
-                tick={CustomizedXAxisTick}
-                interval="preserveStartEnd"
-              />
+              {xAxis}
               <YAxis
                 width={widthYAxis}
                 orientation="right"
@@ -458,11 +499,7 @@ const ExplorerChart = ({
                 })
               }
             >
-              <XAxis
-                dataKey="x"
-                tick={CustomizedXAxisTick}
-                interval="preserveStartEnd"
-              />
+              {xAxis}
               <YAxis
                 width={widthYAxis}
                 orientation="right"

--- a/components/OrchestratorCutHistory/index.tsx
+++ b/components/OrchestratorCutHistory/index.tsx
@@ -64,6 +64,7 @@ const OrchestratorCutHistory = ({ transcoder }: Props) => {
               type="line"
               lineCurve="stepAfter"
               yDomain={[0, 1]}
+              xScale="time"
             />
           </Panel>
           <Panel>
@@ -77,6 +78,7 @@ const OrchestratorCutHistory = ({ transcoder }: Props) => {
               type="line"
               lineCurve="stepAfter"
               yDomain={[0, 1]}
+              xScale="time"
             />
           </Panel>
         </Box>

--- a/hooks/useOrchestratorCutHistory.tsx
+++ b/hooks/useOrchestratorCutHistory.tsx
@@ -7,7 +7,7 @@ import {
 } from "apollo";
 import { useMemo } from "react";
 
-export type CutDataPoint = {
+type CutDataPoint = {
   timestamp: number;
   rewardCut: number;
   feeCut: number;
@@ -28,12 +28,12 @@ export function useOrchestratorCutHistory(transcoder?: Transcoder) {
     skip: !transcoder?.id,
   });
 
-  const chartData = useMemo<CutDataPoint[]>(() => {
+  const points = useMemo<CutDataPoint[]>(() => {
     const events: CutDataPoint[] = (data?.transcoderUpdateEvents ?? []).map(
       (event) => ({
-        timestamp: event.timestamp,
-        rewardCut: (Number(event.rewardCut) / 1000000) * 100,
-        feeCut: (1 - Number(event.feeShare) / 1000000) * 100,
+        timestamp: event.timestamp * 1000, // Convert to ms
+        rewardCut: Number(event.rewardCut) / 1000000,
+        feeCut: 1 - Number(event.feeShare) / 1000000,
       })
     );
 
@@ -46,9 +46,9 @@ export function useOrchestratorCutHistory(transcoder?: Transcoder) {
       transcoder?.feeShare != null
     ) {
       events.push({
-        timestamp: Number(transcoder.activationTimestamp),
-        rewardCut: (Number(transcoder.rewardCut) / 1000000) * 100,
-        feeCut: (1 - Number(transcoder.feeShare) / 1000000) * 100,
+        timestamp: Number(transcoder.activationTimestamp) * 1000,
+        rewardCut: Number(transcoder.rewardCut) / 1000000,
+        feeCut: 1 - Number(transcoder.feeShare) / 1000000,
       });
     }
 
@@ -57,8 +57,8 @@ export function useOrchestratorCutHistory(transcoder?: Transcoder) {
     // "Now" anchor so the chart line extends to the present day.
     const last = events[events.length - 1];
     // eslint-disable-next-line react-hooks/purity
-    const now = Math.floor(Date.now() / 1000);
-    if (now - last.timestamp > 86400) {
+    const now = Date.now();
+    if (now - last.timestamp > 86_400_000) {
       events.push({
         timestamp: now,
         rewardCut: last.rewardCut,
@@ -74,25 +74,20 @@ export function useOrchestratorCutHistory(transcoder?: Transcoder) {
     transcoder?.feeShare,
   ]);
 
-  // ExplorerChart's percent unit expects decimals (0.05 = 5%).
   const rewardCutData = useMemo<ChartDatum[]>(
-    () => chartData.map((d) => ({ x: d.timestamp, y: d.rewardCut / 100 })),
-    [chartData]
+    () => points.map((d) => ({ x: d.timestamp, y: d.rewardCut })),
+    [points]
   );
   const feeCutData = useMemo<ChartDatum[]>(
-    () => chartData.map((d) => ({ x: d.timestamp, y: d.feeCut / 100 })),
-    [chartData]
+    () => points.map((d) => ({ x: d.timestamp, y: d.feeCut })),
+    [points]
   );
 
-  const baseRewardCut = chartData.length
-    ? chartData[chartData.length - 1].rewardCut / 100
-    : 0;
-  const baseFeeCut = chartData.length
-    ? chartData[chartData.length - 1].feeCut / 100
-    : 0;
+  const last = points[points.length - 1];
+  const baseRewardCut = last?.rewardCut ?? 0;
+  const baseFeeCut = last?.feeCut ?? 0;
 
   return {
-    chartData,
     rewardCutData,
     feeCutData,
     baseRewardCut,


### PR DESCRIPTION
## Summary
- Reward Cut and Fee Cut charts placed each update event at an equally-spaced category slot, so a 1-day step looked as wide as a 2-month step — the timeline misrepresented when changes happened.
- Added an opt-in `xScale="time"` prop to `ExplorerChart` that switches the `XAxis` to `type="number"` with `scale="time"` and a `dataMin`/`dataMax` domain.
- Enabled it on both cut history charts so step widths now reflect actual durations. Other charts using `ExplorerChart` are unaffected (default remains `category`).
- Switched the custom x-axis tick to use Recharts' built-in `index` / `visibleTicksCount` so the first tick anchors `start`, the last anchors `end`, and the interior tick is centered — fixing the middle "Mar 24" label that previously inherited the right-anchor fallback and looked offset from its tick mark.

## Test plan
- [x] Open an orchestrator page and verify Reward Cut / Fee Cut steps are proportional to time gaps between updates.
- [x] Confirm middle x-axis tick label is centered under its tick mark; first/last labels stay edge-aligned.
- [x] Confirm homepage charts (volume, fees, usage, etc.) render unchanged.
- [x] Hover the cut charts — tooltip date/value still match the underlying event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
