### PR TITLE
fix: disambiguate chart x-axis year labels with apostrophe prefix

### DIFF
--- a/components/ExplorerChart/index.tsx
+++ b/components/ExplorerChart/index.tsx
@@ -67,7 +67,7 @@ const CustomizedXAxisTick = ({
         fontWeight={400}
         fontSize="13px"
       >
-        {date.format("MMM YY")}
+        {date.format("MMM [']YY")}
       </text>
     </g>
   );


### PR DESCRIPTION
## Summary
- Reviewer feedback on #638: \"Feb 22\" / \"Mar 24\" on chart x-axes read as month-day dates (e.g. February 22nd) rather than month-of-year (February 2022). The day-of-month numbers (22, 24, 26) are plausible enough that the format is genuinely ambiguous.
- Switched the x-axis tick format from \`MMM YY\` to \`MMM 'YY\` so labels render as \`Feb '22\` / \`Mar '24\` / \`Apr '26\`. The apostrophe prefix is universally read as \"year\" — eliminates the day-of-month misread completely.
- Width cost is ~1 character (~17% wider), not 2x like \`MMM YYYY\`, so the existing 3-tick layout fits unchanged at all viewport sizes.
- Convention used by CoinGecko, TradingView, Bloomberg, Yahoo Finance, and most financial dashboards.

## Test plan
- [x] Open homepage and verify chart x-axis labels read as \`Oct '25\` / \`Feb '26\` / \`Apr '26\` (Fees Paid, Estimated Usage) and \`Apr '25\` / \`Nov '25\` / \`Apr '26\` (Participation Rate, Inflation Rate, Delegators, Orchestrators).
- [x] Open an orchestrator page and verify Reward Cut / Fee Cut charts use the same format.
- [x] Confirm tick alignment unchanged (first/last edge-anchored, middle centered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)