### PR TITLE
fix: align homepage chart x-axis tick labels with their tick marks

### DIFF
--- a/components/ExplorerChart/index.tsx
+++ b/components/ExplorerChart/index.tsx
@@ -258,10 +258,10 @@ const ExplorerChart = ({
     return [min, (min + max) / 2, max];
   }, [xScale, data]);
 
-  // Explicit first/middle/last ticks for category mode, sidestepping Recharts'
-  // preserveStartEnd quirk that misaligns the last tick label vs the tick line.
+  // Sidesteps Recharts' preserveStartEnd line/text misalignment on endpoints.
+  // Need >=3 points so the middle tick doesn't duplicate first or last.
   const categoryTicks = useMemo<number[] | undefined>(() => {
-    if (xScale === "time" || !data || data.length < 2) return undefined;
+    if (xScale === "time" || !data || data.length < 3) return undefined;
     const mid = data[Math.floor(data.length / 2)].x;
     return [data[0].x, mid, data[data.length - 1].x];
   }, [xScale, data]);

--- a/components/ExplorerChart/index.tsx
+++ b/components/ExplorerChart/index.tsx
@@ -46,15 +46,9 @@ const CustomizedXAxisTick = ({
   // Time mode is ms (D3 convention); category is unix seconds.
   const date =
     xScale === "time" ? dayjs(payload.value) : dayjs.unix(payload.value);
-  // Time scale fills edge-to-edge; anchor first/last labels inward to avoid clipping.
+  // Anchor boundary labels inward so they stay inside the plot area.
   const textAnchor =
-    xScale === "time"
-      ? index === 0
-        ? "start"
-        : index === visibleTicksCount - 1
-        ? "end"
-        : "middle"
-      : "end";
+    index === visibleTicksCount - 1 ? "end" : index === 0 ? "start" : "middle";
 
   return (
     <g transform={`translate(${x},${y})`}>
@@ -264,6 +258,14 @@ const ExplorerChart = ({
     return [min, (min + max) / 2, max];
   }, [xScale, data]);
 
+  // Explicit first/middle/last ticks for category mode, sidestepping Recharts'
+  // preserveStartEnd quirk that misaligns the last tick label vs the tick line.
+  const categoryTicks = useMemo<number[] | undefined>(() => {
+    if (xScale === "time" || !data || data.length < 2) return undefined;
+    const mid = data[Math.floor(data.length / 2)].x;
+    return [data[0].x, mid, data[data.length - 1].x];
+  }, [xScale, data]);
+
   const xAxis =
     xScale === "time" ? (
       <XAxis
@@ -278,8 +280,9 @@ const ExplorerChart = ({
     ) : (
       <XAxis
         dataKey="x"
+        ticks={categoryTicks}
+        interval={0}
         tick={CustomizedXAxisTick}
-        interval="preserveStartEnd"
       />
     );
 


### PR DESCRIPTION
## Summary

- Pass explicit first/middle/last `ticks` to category-mode `<XAxis>` instead of relying on `interval="preserveStartEnd"`, which renders endpoint label text offset from its tick line on bar charts (Delegators / Orchestrators / Estimated Usage / Fees Paid).
- Switch the first-tick `textAnchor` to `start` (was `end`) so the leftmost label grows rightward into the plot area instead of clipping off the chart's left edge once the line and text share an x-position.
- Result: all six homepage charts now render first / middle / last labels with consistent line-text alignment.

## Why

`preserveStartEnd` is a known-leaky heuristic in Recharts — when an endpoint tick would otherwise clip, it nudges the *text* inward but leaves the *tick line* at the edge, breaking the implicit contract that "the label sits under its tick" ([recharts/recharts#1684](https://github.com/recharts/recharts/issues/1684), [#2543](https://github.com/recharts/recharts/issues/2543)). Passing an explicit `ticks={[first, mid, last]}` array with `interval={0}` bypasses that path entirely and is the community-recommended workaround.

## Test plan

- [x] Verified all 6 homepage charts render first/middle/last labels with no clipping (Playwright SVG measurement: every first tick now reports `clipped: false`).
- [x] Confirmed last-tick `text-anchor="end"` text right-edge matches its tick `lineX` across all charts.
- [x] Confirmed middle tick remains centered under its tick line.
- [x] Time-scale charts (cut history pages) unaffected — `timeTicks` path unchanged.
- [x] Reviewer: visually confirm 6-card homepage grid on Overview page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)