### PR TITLE
refactor: order ExplorerChart props by required → optional → defaulted

### DIFF
--- a/components/ExplorerChart/index.tsx
+++ b/components/ExplorerChart/index.tsx
@@ -75,19 +75,22 @@ const ExplorerChart = ({
   data,
   base,
   basePercentChange,
-  unit = "none",
   type,
-  lineCurve = "monotone",
   yDomain,
+  onToggleGrouping,
+  unit = "none",
+  lineCurve = "monotone",
   xScale = "category",
   grouping = "day",
-  onToggleGrouping,
 }: {
   title: string;
   tooltip: ReactNode;
+  data: ChartDatum[];
   base: number;
   basePercentChange: number;
-  data: ChartDatum[];
+  type: "bar" | "line";
+  yDomain?: [number | "auto" | "dataMin", number | "auto" | "dataMax"];
+  onToggleGrouping?: (grouping: Group) => void;
   unit:
     | "usd"
     | "eth"
@@ -96,12 +99,9 @@ const ExplorerChart = ({
     | "small-percent"
     | "small-unitless"
     | "none";
-  type: "bar" | "line";
   lineCurve?: "monotone" | "stepAfter" | "linear";
-  yDomain?: [number | "auto" | "dataMin", number | "auto" | "dataMax"];
   xScale?: "category" | "time";
   grouping?: Group;
-  onToggleGrouping?: (grouping: Group) => void;
 }) => {
   const formatDateSubtitle = useCallback(
     (date: number) => {

--- a/components/ExplorerChart/index.tsx
+++ b/components/ExplorerChart/index.tsx
@@ -75,10 +75,10 @@ const ExplorerChart = ({
   data,
   base,
   basePercentChange,
+  unit,
   type,
   yDomain,
   onToggleGrouping,
-  unit = "none",
   lineCurve = "monotone",
   xScale = "category",
   grouping = "day",
@@ -88,9 +88,6 @@ const ExplorerChart = ({
   data: ChartDatum[];
   base: number;
   basePercentChange: number;
-  type: "bar" | "line";
-  yDomain?: [number | "auto" | "dataMin", number | "auto" | "dataMax"];
-  onToggleGrouping?: (grouping: Group) => void;
   unit:
     | "usd"
     | "eth"
@@ -99,6 +96,9 @@ const ExplorerChart = ({
     | "small-percent"
     | "small-unitless"
     | "none";
+  type: "bar" | "line";
+  yDomain?: [number | "auto" | "dataMin", number | "auto" | "dataMax"];
+  onToggleGrouping?: (grouping: Group) => void;
   lineCurve?: "monotone" | "stepAfter" | "linear";
   xScale?: "category" | "time";
   grouping?: Group;


### PR DESCRIPTION
## Summary

Reorders the destructured props and matching type definition in `ExplorerChart` to follow the standard JS/TS convention: required props first, then optional (`?`), then those with default values.

Also aligns the destructure order with the type order — previously `data` sat in different positions in each.

## Why

Mixing defaulted and required props in the destructure (e.g. `unit = "none", type, lineCurve = "monotone", yDomain, ...`) makes it harder to read the API contract at a glance. Standard convention puts defaults at the end, mirroring how positional function arguments must be ordered.

## Test plan

- [x] `pnpm typecheck` passes.
- [x] `pnpm lint` passes via pre-commit hook.
- [x] No behavior change — all 8 callers (`pages/index.tsx`, `components/OrchestratorCutHistory/index.tsx`) pass props by name via JSX, so destructure order is positionally irrelevant.
- [ ] Reviewer: visually confirm homepage charts and orchestrator cut history charts still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)