### PR TITLE
fix: validate identity.url scheme before rendering as external link

### DIFF
--- a/components/Profile/index.tsx
+++ b/components/Profile/index.tsx
@@ -1,7 +1,7 @@
 import { ExplorerTooltip } from "@components/ExplorerTooltip";
 import ShowMoreRichText from "@components/ShowMoreRichText";
 import { EnsIdentity } from "@lib/api/types/get-ens";
-import { formatAddress } from "@lib/utils";
+import { formatAddress, sanitizeExternalUrl } from "@lib/utils";
 import {
   Box,
   Button,
@@ -66,6 +66,11 @@ const Index = ({
       setCopied(true);
     }
   };
+
+  // ENS-supplied URL — must be validated before rendering as an external link
+  // so a malicious orchestrator can't smuggle in `javascript:` / `data:` /
+  // schemeless hrefs via their ENS `url` text record.
+  const safeIdentityUrl = sanitizeExternalUrl(identity?.url);
 
   return (
     <Box css={{ marginBottom: "$3" }}>
@@ -272,14 +277,14 @@ const Index = ({
             )}
           </Flex>
           <Flex align="center" css={{ flexWrap: "wrap" }}>
-            {identity?.url && (
+            {safeIdentityUrl && (
               <A
                 variant="contrast"
                 css={{ fontSize: "$2", minWidth: 0, maxWidth: "100%" }}
-                href={identity.url}
+                href={safeIdentityUrl}
                 target="__blank"
                 rel="noopener noreferrer"
-                title={identity.url}
+                title={safeIdentityUrl}
               >
                 <Flex
                   align="center"
@@ -301,7 +306,7 @@ const Index = ({
                       whiteSpace: "nowrap",
                     }}
                   >
-                    {identity.url.replace(/(^\w+:|^)\/\//, "")}
+                    {safeIdentityUrl.replace(/(^\w+:|^)\/\//, "")}
                   </Box>
                 </Flex>
               </A>

--- a/lib/utils.tsx
+++ b/lib/utils.tsx
@@ -283,6 +283,37 @@ export const isImageUrl = (url: string): boolean => {
 };
 
 /**
+ * Sanitize a user-supplied URL for use as an external `<a href>`.
+ *
+ * Auto-prefixes `https://` when the input has no scheme (so values like
+ * `evil.com/path` aren't treated as relative links), then validates that the
+ * resulting URL parses and uses an `http:` or `https:` protocol. Anything
+ * else (e.g. `javascript:`, `data:`, malformed input) is rejected.
+ *
+ * @param url - The user-supplied URL.
+ * @returns The sanitized absolute URL, or `null` if it is unsafe / invalid.
+ */
+export const sanitizeExternalUrl = (
+  url: string | null | undefined
+): string | null => {
+  if (!url) return null;
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  const withScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+  try {
+    const parsed = new URL(withScheme);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+};
+
+/**
  * Shorten an Ethereum address for display.
  * @param address - The address to shorten.
  * @returns The shortened address.


### PR DESCRIPTION
Closes #643

## Summary

Sanitizes the ENS-supplied `identity.url` value before rendering it as an external link in the orchestrator profile header. Adds `sanitizeExternalUrl` to `lib/utils.tsx` and uses it for both `href` and the displayed text.

## Why

`identity.url` is set by the orchestrator via their ENS `url` text record — fully user-controlled. Without validation, values like `javascript:alert(...)`, `data:text/html,...`, or schemeless `evil.com/path` (which resolves as a *relative* link to explorer.livepeer.org) are rendered verbatim into the DOM. React 16+ warns on `javascript:` hrefs but does not reliably block them.

## What changed

- Add `sanitizeExternalUrl(url)` helper to `lib/utils.tsx`. It auto-prefixes `https://` for schemeless input, parses via `new URL(...)`, returns the canonical form on success, or `null` for anything that fails to parse or uses a non-http(s) protocol.
- In `components/Profile/index.tsx`, compute `safeIdentityUrl` once at the top of the component and use it for the link's `href`, `title`, and the visible text. Suppress the entire link block when sanitization fails.
- Twitter / GitHub blocks are untouched — those interpolate handles into hardcoded `https://twitter.com/` / `https://github.com/` URLs and are not the same risk.

## Test plan

- [x] `pnpm typecheck` passes (via pre-commit hook).
- [x] `pnpm lint` and `prettier --check` pass.
- [ ] Reviewer: visit a profile with a valid `http(s)` URL — link still works as before.
- [ ] Reviewer: confirm a profile with a `javascript:` URL doesn't render the link block at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
