### PR TITLE
chore: replace __blank typo with spec-correct _blank

### DIFF
--- a/components/Profile/index.tsx
+++ b/components/Profile/index.tsx
@@ -277,7 +277,7 @@ const Index = ({
                 variant="contrast"
                 css={{ fontSize: "$2" }}
                 href={identity.url}
-                target="__blank"
+                target="_blank"
                 rel="noopener noreferrer"
               >
                 <Flex
@@ -295,7 +295,7 @@ const Index = ({
                 variant="contrast"
                 css={{ fontSize: "$2" }}
                 href={`https://twitter.com/${identity.twitter}`}
-                target="__blank"
+                target="_blank"
                 rel="noopener noreferrer"
               >
                 <Flex
@@ -321,7 +321,7 @@ const Index = ({
                 variant="contrast"
                 css={{ fontSize: "$2" }}
                 href={`https://github.com/${identity.github}`}
-                target="__blank"
+                target="_blank"
                 rel="noopener noreferrer"
               >
                 <Flex


### PR DESCRIPTION
Closes #646

## Summary

Replace `target="__blank"` with the spec-correct `target="_blank"` on the three external links in the orchestrator profile (website, Twitter, GitHub).

## Why

The HTML spec defines `_blank` as the keyword for "open in new tab"; `__blank` (two underscores) is just a custom browsing-context name. Modern browsers reset `window.name` on cross-origin navigation as a tracking mitigation, so the visible impact today is near-zero — but worth fixing for spec compliance and reader expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
