### PR TITLE
fix: abbreviate y-axis chart ticks below 10K to prevent label clipping

### DIFF
--- a/components/ExplorerChart/index.tsx
+++ b/components/ExplorerChart/index.tsx
@@ -197,11 +197,13 @@ const ExplorerChart = ({
           fontSize="13px"
         >
           {(() => {
+            // Tight tick width: always abbreviate so 4-digit values don't clip.
             switch (unit) {
               case "usd":
                 return formatUSD(payload.value, {
                   precision: 0,
                   abbreviate: true,
+                  abbreviateThreshold: 0,
                 });
               case "eth":
                 return formatNumber(payload.value, { precision: 1 }) + " Ξ";
@@ -213,11 +215,13 @@ const ExplorerChart = ({
                 return formatNumber(payload.value, {
                   precision: 1,
                   abbreviate: true,
+                  abbreviateThreshold: 0,
                 });
               default:
                 return formatNumber(payload.value, {
                   precision: 0,
                   abbreviate: true,
+                  abbreviateThreshold: 0,
                 });
             }
           })()}
@@ -233,12 +237,12 @@ const ExplorerChart = ({
         : unit === "percent"
         ? 42
         : unit === "minutes"
-        ? 35
-        : unit === "eth"
-        ? 35
-        : unit === "usd"
         ? 36
-        : 30,
+        : unit === "eth"
+        ? 36
+        : unit === "usd"
+        ? 38
+        : 32,
     [unit]
   );
 

--- a/utils/numberFormatters.test.ts
+++ b/utils/numberFormatters.test.ts
@@ -339,6 +339,28 @@ describe("formatNumber", () => {
       expect(formatNumber(9999, { abbreviate: true })).toBe("9,999");
       expect(formatNumber(10000, { abbreviate: true })).toBe("10K");
     });
+
+    it("respects a custom abbreviateThreshold", () => {
+      expect(
+        formatNumber(3000, { abbreviate: true, abbreviateThreshold: 1000 })
+      ).toBe("3K");
+      expect(
+        formatNumber(999, { abbreviate: true, abbreviateThreshold: 1000 })
+      ).toBe("999");
+      expect(
+        formatNumber(-2500, { abbreviate: true, abbreviateThreshold: 1000 })
+      ).toBe("-2.5K");
+    });
+
+    it("abbreviates sub-1K values when threshold is 0", () => {
+      expect(
+        formatNumber(500, { abbreviate: true, abbreviateThreshold: 0 })
+      ).toBe("0.5K");
+    });
+
+    it("threshold has no effect when abbreviate is false", () => {
+      expect(formatNumber(3000, { abbreviateThreshold: 1000 })).toBe("3,000");
+    });
   });
 
   describe("null/undefined handling", () => {
@@ -373,6 +395,9 @@ describe("formatUSD", () => {
   it("respects options", () => {
     expect(formatUSD(15000, { abbreviate: true })).toBe("$15K");
     expect(formatUSD(1234.56, { precision: 0 })).toBe("$1,235");
+    expect(
+      formatUSD(3000, { abbreviate: true, abbreviateThreshold: 1000 })
+    ).toBe("$3K");
   });
 
   it("handles zero/null", () => {

--- a/utils/numberFormatters.test.ts
+++ b/utils/numberFormatters.test.ts
@@ -81,6 +81,11 @@ describe("formatLPT", () => {
     it("can disable abbreviation", () => {
       expect(formatLPT(15000, { abbreviate: false })).toBe("15,000 LPT");
     });
+
+    it("respects a custom abbreviateThreshold", () => {
+      expect(formatLPT(3000, { abbreviateThreshold: 1000 })).toBe("3K LPT");
+      expect(formatLPT(999, { abbreviateThreshold: 1000 })).toBe("999 LPT");
+    });
   });
 
   describe("null/undefined handling", () => {
@@ -178,6 +183,15 @@ describe("formatETH", () => {
       expect(formatETH(15000, { abbreviate: true, forceSign: true })).toBe(
         "+15K ETH"
       );
+    });
+
+    it("respects a custom abbreviateThreshold", () => {
+      expect(
+        formatETH(3000, { abbreviate: true, abbreviateThreshold: 1000 })
+      ).toBe("3K ETH");
+      expect(
+        formatETH(999, { abbreviate: true, abbreviateThreshold: 1000 })
+      ).toBe("999 ETH");
     });
   });
 

--- a/utils/numberFormatters.ts
+++ b/utils/numberFormatters.ts
@@ -49,6 +49,7 @@ export function formatLPT(
   const {
     showSymbol = true,
     abbreviate = true,
+    abbreviateThreshold = 10000,
     precision = 2,
     thousandSeparated = true,
     trimZeros = true,
@@ -87,8 +88,8 @@ export function formatLPT(
 
   let formatted: string;
 
-  // Use abbreviations for large numbers (>= 10,000)
-  if (abbreviate && Math.abs(num) >= 10000) {
+  // Use abbreviations for large numbers (>= abbreviateThreshold, default 10,000)
+  if (abbreviate && Math.abs(num) >= abbreviateThreshold) {
     formatted = numbro(num)
       .format({
         average: true,
@@ -139,6 +140,7 @@ export function formatETH(
     trimZeros = true,
     forceSign = false,
     abbreviate = false,
+    abbreviateThreshold = 10000,
   } = options;
 
   // Handle null/undefined
@@ -171,8 +173,8 @@ export function formatETH(
     return showSymbol ? `> -${thresholdStr} ETH` : `> -${thresholdStr}`;
   }
 
-  // Use abbreviations for large numbers (>= 10,000)
-  if (abbreviate && Math.abs(num) >= 10000) {
+  // Use abbreviations for large numbers (>= abbreviateThreshold, default 10,000)
+  if (abbreviate && Math.abs(num) >= abbreviateThreshold) {
     const abbreviated = numbro(num)
       .format({
         average: true,

--- a/utils/numberFormatters.ts
+++ b/utils/numberFormatters.ts
@@ -8,6 +8,8 @@ export interface FormatOptions {
   showSymbol?: boolean;
   /** Whether to use K/M/B/T abbreviations for large numbers */
   abbreviate?: boolean;
+  /** Minimum absolute value at which `abbreviate` kicks in. Defaults to 10000. */
+  abbreviateThreshold?: number;
   /** Number of decimal places to show */
   precision?: number;
   /** Whether to show thousand separators (commas) */
@@ -344,6 +346,7 @@ export function formatRound(
  * formatNumber(1234.56)                           // "1,234.56"
  * formatNumber(1234.56, { precision: 0 })         // "1,235"
  * formatNumber(15000, { abbreviate: true })       // "15K"
+ * formatNumber(500, { abbreviate: true, abbreviateThreshold: 0 })  // "0.5K"
  */
 export function formatNumber(
   value: number | string | null | undefined,
@@ -352,6 +355,7 @@ export function formatNumber(
   const {
     precision = 2,
     abbreviate = false,
+    abbreviateThreshold = 10000,
     thousandSeparated = true,
     trimZeros = true,
     forceSign = false,
@@ -375,7 +379,7 @@ export function formatNumber(
   }
 
   // Use abbreviations for large numbers if requested
-  if (abbreviate && Math.abs(num) >= 10000) {
+  if (abbreviate && Math.abs(num) >= abbreviateThreshold) {
     return numbro(num)
       .format({
         average: true,


### PR DESCRIPTION
## Summary
- Y-axis tick labels were clipping (e.g. "3,000" → "3,00") because the unified formatter's `abbreviate: true` only kicks in at ≥10K, while the y-axis width budget (30px) was sized for the prior always-abbreviated output.
- Adds an `abbreviateThreshold` option to `FormatOptions` (default `10000`) so the y-axis tick can opt into earlier abbreviation by passing `abbreviateThreshold: 0`. Other ~30 call sites are unaffected.
- Nudges y-axis widths by 1-2px so 4-char abbreviated labels like `"2.7K"` / `"$2.7K"` don't clip.

## Test plan
- [x] Visual: Delegators chart on homepage renders `"3K" / "2.7K" / "2.4K"` ticks without clipping.
- [x] Visual: spot-check usd / orchestrator-count charts render abbreviated ticks correctly.
- [x] Unit: `pnpm test -- numberFormatters` passes (67/67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)