### PR TITLE
chore(deps): bump @livepeer/design-system to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@graphql-tools/schema": "8.5.0",
     "@graphql-tools/stitch": "8.7.0",
     "@graphql-tools/wrap": "8.5.0",
-    "@livepeer/design-system": "1.1.2",
+    "@livepeer/design-system": "1.2.0",
     "@mdx-js/loader": "^2.1.2",
     "@mdx-js/react": "^2.1.2",
     "@modulz/radix-icons": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: 8.5.0
         version: 8.5.0(graphql@16.13.1)
       '@livepeer/design-system':
-        specifier: 1.1.2
-        version: 1.1.2(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(next@16.1.7(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: 1.2.0
+        version: 1.2.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(next@16.1.7(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@mdx-js/loader':
         specifier: ^2.1.2
         version: 2.3.0(webpack@5.105.4)
@@ -1983,11 +1983,12 @@ packages:
       react:
         optional: true
 
-  '@livepeer/design-system@1.1.2':
-    resolution: {integrity: sha512-LoxcFyAAuIuHBDrkEJk9mHX1nY0kmES09K8MOJa4D7RuZOaVztRsx1aDGj/hUaKh19BLnyTfSGHY4TJ7pvO1yQ==}
+  '@livepeer/design-system@1.2.0':
+    resolution: {integrity: sha512-I+SFzxVA/ss/dDqv18mS9RDk2dkGKPR+qMfXYn3r5rWRPPmVwOnVPvHkJSS9rMtN17zMzJzWjkm1PO2HfrF7fw==}
+    engines: {node: '>=20'}
     peerDependencies:
-      react: 17.0.1
-      react-dom: 17.0.1
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   '@mdx-js/loader@2.3.0':
     resolution: {integrity: sha512-IqsscXh7Q3Rzb+f5DXYk0HU71PK+WuFsEhf+mSV3fOhpLcEpgsHvTQ2h0T6TlZ5gHOaBeFjkXwB52by7ypMyNg==}
@@ -2370,9 +2371,6 @@ packages:
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
-
-  '@radix-ui/primitive@0.0.1':
-    resolution: {integrity: sha512-Z8R0kdAZui8eYTuGY5oQUA0SU4jYq43m4bZW6Dw0B35fUp+U3r+pCrkj0EADJAPv1UaKNskSv/lrfRdC7719Rg==}
 
   '@radix-ui/primitive@1.0.1':
     resolution: {integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==}
@@ -2987,11 +2985,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-polymorphic@0.0.6':
-    resolution: {integrity: sha512-M6VVxOLII8bdnKIYK9qDH8kO8/sYJXunA0VcNKlGJvD95GuolwypXGi3gLIHCqlAozHMFJ5hzy/Vsy/rCU8Glw==}
-    peerDependencies:
-      react: ^16.8 || ^17.0
-
   '@radix-ui/react-popover@1.0.6':
     resolution: {integrity: sha512-cZ4defGpkZ0qTRtlIBzJLSzL6ht7ofhhW4i1+pkemjV1IKXm0wgCRnee154qlV6r9Ttunmh2TNZhMfV2bavUyA==}
     peerDependencies:
@@ -3095,11 +3088,6 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
-
-  '@radix-ui/react-primitive@0.0.5':
-    resolution: {integrity: sha512-zZacpav02cmljSaBfuc/jTqJdsZmVSQsp9Eh03v6ksS/6sGmLga46cwztDzb2by/x2izodke5NdHrVOUNAMbeA==}
-    peerDependencies:
-      react: ^16.8 || ^17.0
 
   '@radix-ui/react-primitive@1.0.3':
     resolution: {integrity: sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==}
@@ -3388,11 +3376,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-toggle-button@0.0.6':
-    resolution: {integrity: sha512-YAU905fz2wSIb6E7KNs0maSV0Ej+lq8l1YtRboA7gLku22d/BAiTSZjOpif+C6759xpRQz3OesFjPIW8JEsLnw==}
-    peerDependencies:
-      react: ^16.8 || ^17.0
-
   '@radix-ui/react-toggle-group@1.1.11':
     resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
     peerDependencies:
@@ -3471,11 +3454,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-use-callback-ref@0.0.1':
-    resolution: {integrity: sha512-WNqLyGlHuxfghIPuKH1/1q/NNc+W2ve2S823syefD78btShmR6LJqpUXinn9X7uK7ih/pB3UySMmbTv9CWrb9A==}
-    peerDependencies:
-      react: ^16.8 || ^17.0
-
   '@radix-ui/react-use-callback-ref@1.0.1':
     resolution: {integrity: sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==}
     peerDependencies:
@@ -3493,11 +3471,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@radix-ui/react-use-controllable-state@0.0.1':
-    resolution: {integrity: sha512-xWirTCesup7uyt7jDRkQDQbjKzlNq7B4y+FhHFjRF5ZThSVICdR30O4IXhfAs3gH0Of/6yLR+RnGPOwEui1bqQ==}
-    peerDependencies:
-      react: ^16.8 || ^17.0
 
   '@radix-ui/react-use-controllable-state@1.0.1':
     resolution: {integrity: sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==}
@@ -5683,6 +5656,9 @@ packages:
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -10029,6 +10005,9 @@ packages:
     resolution: {integrity: sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==}
     engines: {node: '>=8.0.0'}
 
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
@@ -13521,7 +13500,7 @@ snapshots:
       - encoding
       - immer
 
-  '@livepeer/design-system@1.1.2(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(next@16.1.7(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@livepeer/design-system@1.2.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(next@16.1.7(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@radix-ui/colors': 0.1.8
       '@radix-ui/react-accessible-icon': 1.1.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -13550,16 +13529,18 @@ snapshots:
       '@radix-ui/react-switch': 1.0.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@radix-ui/react-tabs': 1.0.4(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@radix-ui/react-toggle': 1.0.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@radix-ui/react-toggle-button': 0.0.6(react@19.2.1)
       '@radix-ui/react-tooltip': 1.0.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@19.2.2)(react@19.2.1)
       '@stitches/react': 1.2.8(react@19.2.1)
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
       lodash.merge: 4.6.2
       lodash.omit: 4.5.0
       next-themes: 0.2.1(next@16.1.7(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
       react-transition-group: 4.4.5(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      tailwind-merge: 3.5.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@types/react'
@@ -14037,8 +14018,6 @@ snapshots:
       '@babel/runtime': 7.28.6
 
   '@radix-ui/number@1.1.1': {}
-
-  '@radix-ui/primitive@0.0.1': {}
 
   '@radix-ui/primitive@1.0.1':
     dependencies:
@@ -14709,10 +14688,6 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
 
-  '@radix-ui/react-polymorphic@0.0.6(react@19.2.1)':
-    dependencies:
-      react: 19.2.1
-
   '@radix-ui/react-popover@1.0.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -14837,11 +14812,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
-
-  '@radix-ui/react-primitive@0.0.5(react@19.2.1)':
-    dependencies:
-      '@radix-ui/react-polymorphic': 0.0.6(react@19.2.1)
-      react: 19.2.1
 
   '@radix-ui/react-primitive@1.0.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
@@ -15174,14 +15144,6 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
 
-  '@radix-ui/react-toggle-button@0.0.6(react@19.2.1)':
-    dependencies:
-      '@radix-ui/primitive': 0.0.1
-      '@radix-ui/react-polymorphic': 0.0.6(react@19.2.1)
-      '@radix-ui/react-primitive': 0.0.5(react@19.2.1)
-      '@radix-ui/react-use-controllable-state': 0.0.1(react@19.2.1)
-      react: 19.2.1
-
   '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -15276,10 +15238,6 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
 
-  '@radix-ui/react-use-callback-ref@0.0.1(react@19.2.1)':
-    dependencies:
-      react: 19.2.1
-
   '@radix-ui/react-use-callback-ref@1.0.1(@types/react@19.2.2)(react@19.2.1)':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -15292,11 +15250,6 @@ snapshots:
       react: 19.2.1
     optionalDependencies:
       '@types/react': 19.2.2
-
-  '@radix-ui/react-use-controllable-state@0.0.1(react@19.2.1)':
-    dependencies:
-      '@radix-ui/react-use-callback-ref': 0.0.1(react@19.2.1)
-      react: 19.2.1
 
   '@radix-ui/react-use-controllable-state@1.0.1(@types/react@19.2.2)(react@19.2.1)':
     dependencies:
@@ -18526,6 +18479,10 @@ snapshots:
       to-buffer: 1.2.2
 
   cjs-module-lexer@2.2.0: {}
+
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
 
   clean-stack@2.2.0: {}
 
@@ -24123,6 +24080,8 @@ snapshots:
       deep-extend: 0.6.0
       typical: 5.2.0
       wordwrapjs: 4.0.1
+
+  tailwind-merge@3.5.0: {}
 
   tapable@2.3.0: {}
 


### PR DESCRIPTION
## Summary

Bumps `@livepeer/design-system` from `1.1.2` → `1.2.0`. v1.2.0 is the infrastructure modernization release: pnpm + tsup build pipeline, React 18 peer dep alignment, and the Tailwind v4 + CVA bridge that v2.0.0 component migrations will build on.

**Zero behavior change for Explorer** — additive infra work only, no API changes, no styling diffs. Verified locally via `pnpm dev` (pages compile, requests succeed) and `pnpm typecheck` (clean).

## Why now

v1.1.2 (PR #622) restored the long-shipped Button styling as committed source of truth. v1.2.0 picks up the toolchain modernization that landed on `main` immediately after, unblocking future component migrations to Tailwind + CVA without churning the registry version repeatedly.

## Test plan

- [x] `pnpm install` resolves cleanly (lockfile updated)
- [x] `pnpm typecheck` passes (zero errors)
- [x] `pnpm dev` boots and serves pages without runtime errors
- [x] Visual smoke test: Profile, Treasury vote table, Migrate flows

Refs livepeer/design-system#156
Refs livepeer/design-system#164

🤖 Generated with [Claude Code](https://claude.com/claude-code)