### PR TITLE
fix: render account page for wallets with no Arbitrum activity

### DIFF
--- a/pages/accounts/[account]/broadcasting.tsx
+++ b/pages/accounts/[account]/broadcasting.tsx
@@ -13,6 +13,7 @@ import {
   getApollo,
   OrchestratorsSortedQueryResult,
 } from "apollo";
+import { isAddress } from "viem";
 
 type PageProps = {
   hadError: boolean;
@@ -59,9 +60,15 @@ export const getStaticProps = async (context: {
   params: { account: string };
 }) => {
   try {
-    const client = getApollo();
     const accountId = context.params?.account?.toString().toLowerCase();
 
+    // 404 only on malformed addresses; a valid address with no on-chain activity still
+    // renders the empty-state account page.
+    if (!accountId || !isAddress(accountId)) {
+      return { notFound: true };
+    }
+
+    const client = getApollo();
     const { account, fallback } = await getAccount(client, accountId);
 
     // If we couldn't fetch account data, treat it as a temporary error
@@ -75,16 +82,6 @@ export const getStaticProps = async (context: {
     // If we couldn't fetch orchestrators data, treat it as a temporary error
     if (!sortedOrchestrators.data) {
       throw new Error("Failed to fetch orchestrators data");
-    }
-
-    // Only return 404 if the account truly doesn't exist
-    // (no delegator AND no transcoder AND no gateway)
-    if (
-      !account.data?.delegator &&
-      !account.data?.transcoder &&
-      !account.data?.gateway
-    ) {
-      return { notFound: true };
     }
 
     const isSelfRedeeming = await getGatewaySelfRedeem(client, accountId);

--- a/pages/accounts/[account]/delegating.tsx
+++ b/pages/accounts/[account]/delegating.tsx
@@ -8,6 +8,7 @@ import {
   getApollo,
   OrchestratorsSortedQueryResult,
 } from "apollo";
+import { isAddress } from "viem";
 
 type PageProps = {
   hadError: boolean;
@@ -47,11 +48,16 @@ export const getStaticProps = async (context: {
   params: { account: string };
 }) => {
   try {
+    const accountId = context.params?.account?.toString().toLowerCase();
+
+    // 404 only on malformed addresses; a valid address with no on-chain activity still
+    // renders the empty-state account page.
+    if (!accountId || !isAddress(accountId)) {
+      return { notFound: true };
+    }
+
     const client = getApollo();
-    const { account, fallback } = await getAccount(
-      client,
-      context.params?.account?.toString().toLowerCase()
-    );
+    const { account, fallback } = await getAccount(client, accountId);
 
     // If we couldn't fetch account data, treat it as a temporary error
     if (!account.data) {
@@ -64,16 +70,6 @@ export const getStaticProps = async (context: {
     // If we couldn't fetch orchestrators data, treat it as a temporary error
     if (!sortedOrchestrators.data) {
       throw new Error("Failed to fetch orchestrators data");
-    }
-
-    // Only return 404 if the account truly doesn't exist
-    // (no delegator AND no transcoder AND no gateway)
-    if (
-      !account.data?.delegator &&
-      !account.data?.transcoder &&
-      !account.data?.gateway
-    ) {
-      return { notFound: true };
     }
 
     const props: PageProps = {

--- a/pages/accounts/[account]/history.tsx
+++ b/pages/accounts/[account]/history.tsx
@@ -8,6 +8,7 @@ import {
   getApollo,
   OrchestratorsSortedQueryResult,
 } from "apollo";
+import { isAddress } from "viem";
 
 type PageProps = {
   hadError: boolean;
@@ -47,11 +48,16 @@ export const getStaticProps = async (context: {
   params: { account: string };
 }) => {
   try {
+    const accountId = context.params?.account?.toString().toLowerCase();
+
+    // 404 only on malformed addresses; a valid address with no on-chain activity still
+    // renders the empty-state account page.
+    if (!accountId || !isAddress(accountId)) {
+      return { notFound: true };
+    }
+
     const client = getApollo();
-    const { account, fallback } = await getAccount(
-      client,
-      context.params?.account?.toString().toLowerCase()
-    );
+    const { account, fallback } = await getAccount(client, accountId);
 
     // If we couldn't fetch account data, treat it as a temporary error
     if (!account.data) {
@@ -64,16 +70,6 @@ export const getStaticProps = async (context: {
     // If we couldn't fetch orchestrators data, treat it as a temporary error
     if (!sortedOrchestrators.data) {
       throw new Error("Failed to fetch orchestrators data");
-    }
-
-    // Only return 404 if the account truly doesn't exist
-    // (no delegator AND no transcoder AND no gateway)
-    if (
-      !account.data?.delegator &&
-      !account.data?.transcoder &&
-      !account.data?.gateway
-    ) {
-      return { notFound: true };
     }
 
     const props: PageProps = {

--- a/pages/accounts/[account]/orchestrating.tsx
+++ b/pages/accounts/[account]/orchestrating.tsx
@@ -8,6 +8,7 @@ import {
   getApollo,
   OrchestratorsSortedQueryResult,
 } from "apollo";
+import { isAddress } from "viem";
 
 type PageProps = {
   hadError: boolean;
@@ -51,11 +52,16 @@ export const getStaticProps = async (context: {
   params: { account: string };
 }) => {
   try {
+    const accountId = context.params?.account?.toString().toLowerCase();
+
+    // 404 only on malformed addresses; a valid address with no on-chain activity still
+    // renders the empty-state account page.
+    if (!accountId || !isAddress(accountId)) {
+      return { notFound: true };
+    }
+
     const client = getApollo();
-    const { account, fallback } = await getAccount(
-      client,
-      context.params?.account?.toString().toLowerCase()
-    );
+    const { account, fallback } = await getAccount(client, accountId);
 
     // If we couldn't fetch account data, treat it as a temporary error
     if (!account.data) {
@@ -68,16 +74,6 @@ export const getStaticProps = async (context: {
     // If we couldn't fetch orchestrators data, treat it as a temporary error
     if (!sortedOrchestrators.data) {
       throw new Error("Failed to fetch orchestrators data");
-    }
-
-    // Only return 404 if the account truly doesn't exist
-    // (no delegator AND no transcoder AND no gateway)
-    if (
-      !account.data?.delegator &&
-      !account.data?.transcoder &&
-      !account.data?.gateway
-    ) {
-      return { notFound: true };
     }
 
     const props: PageProps = {


### PR DESCRIPTION
## Summary
- Stop 404'ing account pages for valid addresses with no on-chain activity
- Replace `!delegator && !transcoder && !gateway` check with `isAddress(...)` validation
- Empty-state UI (`DelegatingView`'s "Delegate LPT" CTA) was already in place — only the SSG guard was blocking it

## Problem
Multiple users reported that a freshly connected wallet with no Arbitrum stake yet shows an error page when navigating to `/accounts/<their-address>` or clicking "My Account" in the nav.

Root cause: `getStaticProps` in all four account sub-pages 404'd whenever the subgraph returned no `delegator`/`transcoder`/`broadcaster` entity for the address. The Livepeer subgraph only creates those entities after the address interacts with the protocol contracts, so a valid EOA with no stake has none of them.

This was introduced in #485, which split transient-vs-permanent failures (a real improvement) but used "no subgraph entity" as the heuristic for "account doesn't exist" — wrong for a chain where every EOA is a valid account from block zero.

## Fix
- 404 only when the URL param isn't a syntactically valid address (`viem`'s `isAddress`)
- Drop the entity-presence check; let the layout render with empty data
- `DelegatingView` already handles missing `bondedAmount` by showing a "Delegate LPT with an Orchestrator…" CTA for the user's own account, so no UI changes needed
- #485's transient-failure handling is preserved (Apollo errors still throw → 60s revalidate, no 404 cached)

## Test plan
- [x] Visit `/accounts/<wallet-with-no-stake>/delegating` — renders profile + "Delegate LPT" CTA instead of 404
- [x] Connect a fresh wallet → "My Account" in nav → empty-state page loads
- [x] Visit `/accounts/notanaddress/delegating` → still 404s
- [x] Existing orchestrator/delegator pages unchanged
- [x] Broadcasting page loads for a gateway address

🤖 Generated with [Claude Code](https://claude.com/claude-code)