### PR TITLE
fix: ensure wallet modal slider mode on mobile

### DIFF
--- a/components/Web3Providers/index.tsx
+++ b/components/Web3Providers/index.tsx
@@ -8,7 +8,9 @@ import {
   baseAccount,
   braveWallet,
   metaMaskWallet,
+  rabbyWallet,
   rainbowWallet,
+  trustWallet,
   walletConnectWallet,
 } from "@rainbow-me/rainbowkit/wallets";
 import rainbowTheme from "constants/rainbowTheme";
@@ -40,6 +42,8 @@ const Index = ({
             metaMaskWallet,
             braveWallet,
             rainbowWallet,
+            trustWallet,
+            rabbyWallet,
             baseAccount,
             walletConnectWallet,
           ],


### PR DESCRIPTION
## Summary
- Add `trustWallet` to fix mobile modal layout (was static 4-tile, now horizontal slider)
- Add `rabbyWallet` for desktop DeFi power users (drops silently on mobile)
- Reorder wallets by mobile-capability and install share

## Problem
Non-Brave mobile users saw a static 4-tile layout instead of RainbowKit's intended horizontal slider with peek hint. Root cause: RainbowKit's `MobileOptions` filters with `wallet.ready` (stricter than desktop's `wallet.ready || extensionDownloadUrl`), silently dropping injected-only connectors that lack mobile deep-links.

Previous list yielded only 4 mobile-visible wallets:
- MetaMask (deep-link)
- Rainbow (deep-link)
- Base Account (`installed: true`)
- WalletConnect

Below RainbowKit's 5-wallet threshold for slider mode (verified in `MobileOptions.tsx` — the gap formula `calc((100% - 40px - 240px + 47px) / 4)` is designed for 4 fully visible + ~13px peek of the 5th).

## Fix
Added two wallets:
- **`trustWallet`** — mobile-first, has `mobile.getUri` deep-link → bumps mobile-visible to 5
- **`rabbyWallet`** — desktop DeFi power users → adds desktop option, drops silently on mobile

Final order:

```
metaMaskWallet,    // dominant Ethereum wallet
braveWallet,       // Brave-only
rainbowWallet,     // popular general-purpose
trustWallet,       // mobile-first global audience
rabbyWallet,       // DeFi power users (desktop-visible)
baseAccount,       // Coinbase ecosystem
walletConnectWallet, // fallback
```

Effective counts:
- **Desktop:** 7 in Brave, 6 elsewhere
- **Mobile:** 5 (Rabby drops, Brave drops outside Brave) → slider mode triggered

## Test plan
- [x] Mobile (non-Brave): Connect Wallet → 5 wallets in horizontal scroll with peek hint visible
- [x] Brave mobile: same, with Brave tile additionally shown
- [x] Desktop: 6 wallets in vertical list, all icons render
- [x] Existing wallets still connect correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)