### PR TITLE
fix: truncate long ENS names in EthAddressBadge

### DIFF
--- a/components/EthAddressBadge/index.tsx
+++ b/components/EthAddressBadge/index.tsx
@@ -8,11 +8,24 @@ interface EthAddressBadgeProps {
 
 const EthAddressBadge = ({ value }: EthAddressBadgeProps) => {
   const ensName = useEnsData(value);
+  const displayName = ensName?.name || ensName?.idShort || "";
 
   return (
-    <Link passHref href={`/accounts/${value}/delegating`}>
-      <Badge css={{ cursor: "pointer" }} variant="primary" size="1">
-        {ensName?.name ? ensName?.name : ensName?.idShort ?? ""}
+    <Link passHref href={`/accounts/${value}/delegating`} title={displayName}>
+      <Badge
+        css={{
+          cursor: "pointer",
+          display: "inline-block",
+          maxWidth: 240,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          verticalAlign: "bottom",
+        }}
+        variant="primary"
+        size="1"
+      >
+        {displayName}
       </Badge>
     </Link>
   );


### PR DESCRIPTION
## Summary
- CSS ellipsis truncation on `EthAddressBadge` so over-long names don't push column widths
- Full string available via `title` tooltip on hover
- Same recipe as #642 (consumer-side responsive truncation)

Closes #609

## Why this component
`EthAddressBadge` is the voter cell in `DesktopVoteTable` and is reused across the transactions list — one fix benefits every surface that displays an ENS-or-address badge.

## Why CSS over JS char-count
Responsive: short names render fully, only over-long names hit the ellipsis. Matches the codebase convention from #642. No magic character constants to maintain.

## Test plan
- [x] Treasury proposal votes tab with a long-ENS voter renders truncated, no horizontal scroll
- [x] Hover shows the full ENS name via tooltip
- [x] Short names (e.g. `vitalik.eth`) display unchanged
- [x] Addresses with no ENS still show as `0x1234...abcd` (unchanged)
- [x] Transactions list still renders correctly with badges in inline prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)