### PR TITLE
fix: handle overdue round in current round tracker

### DIFF
--- a/components/RoundStatus/index.tsx
+++ b/components/RoundStatus/index.tsx
@@ -37,32 +37,38 @@ const Index = ({
 
   const currentRoundInfo = useCurrentRoundData();
 
+  const blocksSinceCurrentRoundStart = useMemo(
+    () =>
+      currentRoundInfo?.initialized
+        ? currentRoundInfo.currentL1Block - currentRoundInfo.startBlock
+        : 0,
+    [currentRoundInfo]
+  );
+  const isOverdue = useMemo(
+    () =>
+      Boolean(
+        protocol && blocksSinceCurrentRoundStart >= +protocol.roundLength
+      ),
+    [protocol, blocksSinceCurrentRoundStart]
+  );
   const blocksRemaining = useMemo(
     () =>
-      currentRoundInfo?.initialized && protocol
-        ? +protocol.roundLength -
-          (+Number(currentRoundInfo.currentL1Block) -
-            +Number(currentRoundInfo.startBlock))
+      protocol
+        ? Math.max(+protocol.roundLength - blocksSinceCurrentRoundStart, 0)
         : 0,
-    [protocol, currentRoundInfo]
+    [protocol, blocksSinceCurrentRoundStart]
   );
   const timeRemaining = useMemo(
     () => AVERAGE_L1_BLOCK_TIME * blocksRemaining,
     [blocksRemaining]
   );
-  const blocksSinceCurrentRoundStart = useMemo(
-    () =>
-      currentRoundInfo?.initialized
-        ? +Number(currentRoundInfo.currentL1Block) -
-          +Number(currentRoundInfo.startBlock)
-        : 0,
-    [currentRoundInfo]
-  );
-
   const percentage = useMemo(
     () =>
       protocol
-        ? (blocksSinceCurrentRoundStart / +protocol.roundLength) * 100
+        ? Math.min(
+            (blocksSinceCurrentRoundStart / +protocol.roundLength) * 100,
+            100
+          )
         : 0,
     [blocksSinceCurrentRoundStart, protocol]
   );
@@ -227,37 +233,51 @@ const Index = ({
                 </Box>
               </Box>
             </Box>
-            <Box css={{ lineHeight: 1.5 }}>
-              <Text css={{ fontSize: "$2" }}>
-                There are{" "}
-                <Box
-                  as="span"
-                  css={{
-                    fontWeight: "bold",
-                  }}
-                >
-                  {blocksRemaining} blocks
-                </Box>{" "}
-                and approximately{" "}
-                <Box
-                  as="span"
-                  css={{
-                    fontWeight: "bold",
-                  }}
-                >
-                  {dayjs().add(timeRemaining, "seconds").fromNow(true)}
-                </Box>{" "}
-                remaining until the current round ends and round{" "}
-                <Box
-                  as="span"
-                  css={{
-                    fontWeight: "bold",
-                  }}
-                >
-                  #{+Number(currentRoundInfo.id) + 1}
-                </Box>{" "}
-                begins.
-              </Text>
+            <Box css={{ lineHeight: 1.5, minHeight: 78 }}>
+              {isOverdue ? (
+                <Text css={{ fontSize: "$2" }}>
+                  Round{" "}
+                  <Box as="span" css={{ fontWeight: "bold" }}>
+                    #{currentRoundInfo.id}
+                  </Box>{" "}
+                  has ended. Awaiting an orchestrator to start round{" "}
+                  <Box as="span" css={{ fontWeight: "bold" }}>
+                    #{currentRoundInfo.id + 1}
+                  </Box>
+                  .
+                </Text>
+              ) : (
+                <Text css={{ fontSize: "$2" }}>
+                  There are{" "}
+                  <Box
+                    as="span"
+                    css={{
+                      fontWeight: "bold",
+                    }}
+                  >
+                    {blocksRemaining} blocks
+                  </Box>{" "}
+                  and approximately{" "}
+                  <Box
+                    as="span"
+                    css={{
+                      fontWeight: "bold",
+                    }}
+                  >
+                    {dayjs().add(timeRemaining, "seconds").fromNow(true)}
+                  </Box>{" "}
+                  remaining until the current round ends and round{" "}
+                  <Box
+                    as="span"
+                    css={{
+                      fontWeight: "bold",
+                    }}
+                  >
+                    #{currentRoundInfo.id + 1}
+                  </Box>{" "}
+                  begins.
+                </Text>
+              )}
             </Box>
             <ExplorerTooltip
               multiline

--- a/components/RoundStatus/index.tsx
+++ b/components/RoundStatus/index.tsx
@@ -62,6 +62,24 @@ const Index = ({
     () => AVERAGE_L1_BLOCK_TIME * blocksRemaining,
     [blocksRemaining]
   );
+  const blocksOverdue = useMemo(
+    () =>
+      protocol
+        ? Math.max(blocksSinceCurrentRoundStart - +protocol.roundLength, 0)
+        : 0,
+    [protocol, blocksSinceCurrentRoundStart]
+  );
+  const timeOverdue = useMemo(
+    () => AVERAGE_L1_BLOCK_TIME * blocksOverdue,
+    [blocksOverdue]
+  );
+  const blocksSinceCurrentRoundStartDisplay = useMemo(
+    () =>
+      protocol
+        ? Math.min(blocksSinceCurrentRoundStart, +protocol.roundLength)
+        : blocksSinceCurrentRoundStart,
+    [protocol, blocksSinceCurrentRoundStart]
+  );
   const percentage = useMemo(
     () =>
       protocol
@@ -225,7 +243,7 @@ const Index = ({
               >
                 <Box css={{ textAlign: "center" }}>
                   <Box css={{ fontWeight: "bold", fontSize: "$5" }}>
-                    {blocksSinceCurrentRoundStart}
+                    {blocksSinceCurrentRoundStartDisplay}
                   </Box>
                   <Box css={{ fontSize: "$1" }}>
                     of {protocol.roundLength} blocks
@@ -240,7 +258,11 @@ const Index = ({
                   <Box as="span" css={{ fontWeight: "bold" }}>
                     #{currentRoundInfo.id}
                   </Box>{" "}
-                  has ended. Awaiting an orchestrator to start round{" "}
+                  ended approximately{" "}
+                  <Box as="span" css={{ fontWeight: "bold" }}>
+                    {dayjs().subtract(timeOverdue, "seconds").fromNow(true)} ago
+                  </Box>
+                  . Awaiting an orchestrator to start round{" "}
                   <Box as="span" css={{ fontWeight: "bold" }}>
                     #{currentRoundInfo.id + 1}
                   </Box>


### PR DESCRIPTION
## Summary
- Detect overdue rounds (nominal end passed, `initializeRound()` not yet called) and swap copy to "Round #N has ended. Awaiting an orchestrator..." instead of showing nonsense like "-74 blocks remaining"
- Clamp `blocksRemaining` to >= 0 and progress ring to <= 100% as a defense-in-depth measure
- Code cleanup: reuse the existing `blocksSinceCurrentRoundStart` memo, drop redundant `+Number()` coercions (fields are already typed `number` after the API serialization layer)

Closes #525

## Test plan
- [x] Active round: copy reads "There are X blocks ... remaining", ring fills proportionally
- [x] Overdue round: copy reads "Round #N has ended. Awaiting an orchestrator...", ring stays at 100%
- [x] `blocksRemaining` never displays a negative number

🤖 Generated with [Claude Code](https://claude.com/claude-code)