### PR TITLE
chore: replace @modulz/radix-icons with @radix-ui/react-icons

### DIFF
--- a/components/Claim/index.tsx
+++ b/components/Claim/index.tsx
@@ -2,7 +2,7 @@ import { LAYOUT_MAX_WIDTH } from "@layouts/constants";
 import { l2Migrator } from "@lib/api/abis/bridge/L2Migrator";
 import { getL2MigratorAddress } from "@lib/api/contracts";
 import { Box, Button, Container, Flex, Text } from "@livepeer/design-system";
-import { ArrowTopRightIcon } from "@modulz/radix-icons";
+import { ArrowTopRightIcon } from "@radix-ui/react-icons";
 import { formatAddress } from "@utils/web3";
 import { constants, ethers } from "ethers";
 import { useAccountAddress, useL1DelegatorData } from "hooks";

--- a/components/DelegatingView/index.tsx
+++ b/components/DelegatingView/index.tsx
@@ -2,7 +2,7 @@ import { ExplorerTooltip } from "@components/ExplorerTooltip";
 import Stat from "@components/Stat";
 import { bondingManager } from "@lib/api/abis/main/BondingManager";
 import { Box, Button, Flex, Link as A, Text } from "@livepeer/design-system";
-import { QuestionMarkCircledIcon } from "@modulz/radix-icons";
+import { QuestionMarkCircledIcon } from "@radix-ui/react-icons";
 import { formatETH, formatLPT, formatPercent } from "@utils/numberFormatters";
 import { checkAddressEquality, formatAddress } from "@utils/web3";
 import { AccountQueryResult, OrchestratorsSortedQueryResult } from "apollo";

--- a/components/DelegatingWidget/ProjectionBox.tsx
+++ b/components/DelegatingWidget/ProjectionBox.tsx
@@ -1,6 +1,6 @@
 import { ExplorerTooltip } from "@components/ExplorerTooltip";
 import { Box, Card, Flex, Text } from "@livepeer/design-system";
-import { QuestionMarkCircledIcon } from "@modulz/radix-icons";
+import { QuestionMarkCircledIcon } from "@radix-ui/react-icons";
 import { formatETH, formatLPT, formatPercent } from "@utils/numberFormatters";
 import { useExplorerStore } from "hooks";
 

--- a/components/EditProfile/index.tsx
+++ b/components/EditProfile/index.tsx
@@ -11,7 +11,7 @@ import {
   Link as A,
   Text,
 } from "@livepeer/design-system";
-import { ArrowTopRightIcon } from "@modulz/radix-icons";
+import { ArrowTopRightIcon } from "@radix-ui/react-icons";
 
 const Index = () => {
   return (

--- a/components/ExplorerChart/index.tsx
+++ b/components/ExplorerChart/index.tsx
@@ -1,7 +1,7 @@
 import { ExplorerTooltip } from "@components/ExplorerTooltip";
 import dayjs from "@lib/dayjs";
 import { Box, Button, Flex, Skeleton, Text } from "@livepeer/design-system";
-import { QuestionMarkCircledIcon } from "@modulz/radix-icons";
+import { QuestionMarkCircledIcon } from "@radix-ui/react-icons";
 import {
   formatETH,
   formatNumber,

--- a/components/OrchestratingView/index.tsx
+++ b/components/OrchestratingView/index.tsx
@@ -2,7 +2,11 @@ import OrchestratorCutHistory from "@components/OrchestratorCutHistory";
 import Stat from "@components/Stat";
 import dayjs from "@lib/dayjs";
 import { Box, Flex, Link as A, Text } from "@livepeer/design-system";
-import { ArrowTopRightIcon, CheckIcon, Cross1Icon } from "@modulz/radix-icons";
+import {
+  ArrowTopRightIcon,
+  CheckIcon,
+  Cross1Icon,
+} from "@radix-ui/react-icons";
 import {
   formatETH,
   formatNumber,

--- a/components/OrchestratorList/index.tsx
+++ b/components/OrchestratorList/index.tsx
@@ -29,7 +29,7 @@ import {
   Text,
   TextField,
 } from "@livepeer/design-system";
-import { ArrowTopRightIcon } from "@modulz/radix-icons";
+import { ArrowTopRightIcon } from "@radix-ui/react-icons";
 import {
   ChevronDownIcon,
   DotsHorizontalIcon,

--- a/components/PerformanceList/index.tsx
+++ b/components/PerformanceList/index.tsx
@@ -6,7 +6,7 @@ import { AllPerformanceMetrics } from "@lib/api/types/get-performance";
 import { Region } from "@lib/api/types/get-regions";
 import { textTruncate } from "@lib/utils";
 import { Badge, Box, Flex, Link as A, Skeleton } from "@livepeer/design-system";
-import { QuestionMarkCircledIcon } from "@modulz/radix-icons";
+import { QuestionMarkCircledIcon } from "@radix-ui/react-icons";
 import { formatNumber, formatPercent } from "@utils/numberFormatters";
 import { formatAddress } from "@utils/web3";
 import { OrchestratorsQueryResult } from "apollo";

--- a/components/PerformanceListSelector/index.tsx
+++ b/components/PerformanceListSelector/index.tsx
@@ -1,6 +1,6 @@
 import { Pipeline } from "@lib/api/types/get-available-pipelines";
 import { Box, Skeleton } from "@livepeer/design-system";
-import { ChevronDownIcon } from "@modulz/radix-icons";
+import { ChevronDownIcon } from "@radix-ui/react-icons";
 import { useAvailableInferencePipelinesData } from "hooks";
 
 interface PerformanceSelectorProps {

--- a/components/PopoverLink/index.tsx
+++ b/components/PopoverLink/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Link as A } from "@livepeer/design-system";
-import { ChevronRightIcon } from "@modulz/radix-icons";
+import { ChevronRightIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 
 const PopoverLink = ({ href, children, newWindow = false }) => {

--- a/components/Profile/index.tsx
+++ b/components/Profile/index.tsx
@@ -18,7 +18,7 @@ import {
   GitHubLogoIcon,
   GlobeIcon,
   TwitterLogoIcon,
-} from "@modulz/radix-icons";
+} from "@radix-ui/react-icons";
 import { formatAddress } from "@utils/web3";
 import copy from "copy-to-clipboard";
 import { QRCodeCanvas } from "qrcode.react";

--- a/components/RoundStatus/index.tsx
+++ b/components/RoundStatus/index.tsx
@@ -7,7 +7,7 @@ import {
   CheckIcon,
   Cross1Icon,
   QuestionMarkCircledIcon,
-} from "@modulz/radix-icons";
+} from "@radix-ui/react-icons";
 import {
   formatETH,
   formatLPT,

--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -10,7 +10,7 @@ import {
   Text,
   TextField,
 } from "@livepeer/design-system";
-import { ArrowRightIcon, MagnifyingGlassIcon } from "@modulz/radix-icons";
+import { ArrowRightIcon, MagnifyingGlassIcon } from "@radix-ui/react-icons";
 import { formatAddress } from "@utils/web3";
 import Fuse from "fuse.js";
 import { useAllEnsData } from "hooks";

--- a/components/ShowMoreRichText/index.tsx
+++ b/components/ShowMoreRichText/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex } from "@livepeer/design-system";
-import { ChevronDownIcon, ChevronUpIcon } from "@modulz/radix-icons";
+import { ChevronDownIcon, ChevronUpIcon } from "@radix-ui/react-icons";
 import {
   ReactNode,
   useEffect,

--- a/components/Stat/index.tsx
+++ b/components/Stat/index.tsx
@@ -7,7 +7,7 @@ import {
   Skeleton,
   Text,
 } from "@livepeer/design-system";
-import { QuestionMarkCircledIcon } from "@modulz/radix-icons";
+import { QuestionMarkCircledIcon } from "@radix-ui/react-icons";
 import { ReactNode } from "react";
 
 type Props = {

--- a/components/TransactionBadge/index.tsx
+++ b/components/TransactionBadge/index.tsx
@@ -1,5 +1,5 @@
 import { Badge, Box, Link as A } from "@livepeer/design-system";
-import { ArrowTopRightIcon } from "@modulz/radix-icons";
+import { ArrowTopRightIcon } from "@radix-ui/react-icons";
 import { formatTransactionHash } from "@utils/web3";
 
 interface TransactionBadgeProps {

--- a/components/TxConfirmedDialog/index.tsx
+++ b/components/TxConfirmedDialog/index.tsx
@@ -13,7 +13,7 @@ import {
   Heading,
   Link as A,
 } from "@livepeer/design-system";
-import { CheckIcon } from "@modulz/radix-icons";
+import { CheckIcon } from "@radix-ui/react-icons";
 import { formatAddress, fromWei } from "@utils/web3";
 import { TransactionStatus, useExplorerStore } from "hooks";
 import { useBondingManagerAddress } from "hooks/useContracts";

--- a/components/TxStartedDialog/index.tsx
+++ b/components/TxStartedDialog/index.tsx
@@ -11,7 +11,7 @@ import {
   Heading,
   Link as A,
 } from "@livepeer/design-system";
-import { ExternalLinkIcon } from "@modulz/radix-icons";
+import { ExternalLinkIcon } from "@radix-ui/react-icons";
 import { formatAddress, fromWei } from "@utils/web3";
 import { TransactionStatus, useAccountAddress, useExplorerStore } from "hooks";
 import { CHAIN_INFO, DEFAULT_CHAIN_ID } from "lib/chains";

--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -31,7 +31,7 @@ import {
   ArrowTopRightIcon,
   ChevronDownIcon,
   EyeOpenIcon,
-} from "@modulz/radix-icons";
+} from "@radix-ui/react-icons";
 import { EMPTY_ADDRESS, formatAddress } from "@utils/web3";
 import {
   useAccountQuery,

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@livepeer/design-system": "1.2.0",
     "@mdx-js/loader": "^2.1.2",
     "@mdx-js/react": "^2.1.2",
-    "@modulz/radix-icons": "^4.0.0",
     "@mui/material": "^7.3.5",
     "@next/mdx": "16.0.1",
     "@radix-ui/react-icons": "^1.3.2",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,7 +21,7 @@ import {
   Heading,
   Link as A,
 } from "@livepeer/design-system";
-import { ArrowRightIcon } from "@modulz/radix-icons";
+import { ArrowRightIcon } from "@radix-ui/react-icons";
 import { PERCENTAGE_PRECISION_BILLION } from "@utils/web3";
 import { useChartData } from "hooks";
 import Link from "next/link";

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -8,7 +8,7 @@ import { Pipeline } from "@lib/api/types/get-available-pipelines";
 import { EnsIdentity } from "@lib/api/types/get-ens";
 import { Region } from "@lib/api/types/get-regions";
 import { Box, Container, Flex, Heading } from "@livepeer/design-system";
-import { ChevronDownIcon } from "@modulz/radix-icons";
+import { ChevronDownIcon } from "@radix-ui/react-icons";
 import { useAllScoreData, useRegionsData } from "hooks/useSwr";
 import Head from "next/head";
 import { useMemo, useState } from "react";

--- a/pages/migrate/broadcaster.tsx
+++ b/pages/migrate/broadcaster.tsx
@@ -25,9 +25,8 @@ import {
   Text,
   TextField,
 } from "@livepeer/design-system";
-import { ArrowTopRightIcon } from "@modulz/radix-icons";
 import { Step, StepContent, StepLabel, Stepper } from "@mui/material";
-import { ArrowRightIcon } from "@radix-ui/react-icons";
+import { ArrowRightIcon, ArrowTopRightIcon } from "@radix-ui/react-icons";
 import { formatAddress, formatTransactionHash } from "@utils/web3";
 import { ethers } from "ethers";
 import { useAccountAddress, useActiveChain } from "hooks";

--- a/pages/migrate/delegator/index.tsx
+++ b/pages/migrate/delegator/index.tsx
@@ -24,9 +24,8 @@ import {
   Text,
   TextField,
 } from "@livepeer/design-system";
-import { ArrowTopRightIcon } from "@modulz/radix-icons";
 import { Step, StepContent, StepLabel, Stepper } from "@mui/material";
-import { ArrowRightIcon } from "@radix-ui/react-icons";
+import { ArrowRightIcon, ArrowTopRightIcon } from "@radix-ui/react-icons";
 import { formatAddress, formatTransactionHash } from "@utils/web3";
 import { ethers } from "ethers";
 import { useAccountAddress, useActiveChain, useL1DelegatorData } from "hooks";

--- a/pages/migrate/orchestrator.tsx
+++ b/pages/migrate/orchestrator.tsx
@@ -19,9 +19,8 @@ import {
   Text,
   TextField,
 } from "@livepeer/design-system";
-import { ArrowTopRightIcon } from "@modulz/radix-icons";
 import { Step, StepContent, StepLabel, Stepper } from "@mui/material";
-import { ArrowRightIcon } from "@radix-ui/react-icons";
+import { ArrowRightIcon, ArrowTopRightIcon } from "@radix-ui/react-icons";
 import { formatAddress, formatTransactionHash } from "@utils/web3";
 import { ethers } from "ethers";
 import { useAccountAddress, useActiveChain, useL1DelegatorData } from "hooks";

--- a/pages/orchestrators.tsx
+++ b/pages/orchestrators.tsx
@@ -12,7 +12,7 @@ import {
   Heading,
   Link as A,
 } from "@livepeer/design-system";
-import { ArrowRightIcon } from "@modulz/radix-icons";
+import { ArrowRightIcon } from "@radix-ui/react-icons";
 import Head from "next/head";
 import Link from "next/link";
 import { useEffect, useState } from "react";

--- a/pages/voting/create-poll.tsx
+++ b/pages/voting/create-poll.tsx
@@ -12,7 +12,7 @@ import {
   RadioCard,
   RadioCardGroup,
 } from "@livepeer/design-system";
-import { ArrowTopRightIcon } from "@modulz/radix-icons";
+import { ArrowTopRightIcon } from "@radix-ui/react-icons";
 import { fromWei } from "@utils/web3";
 import { useAccountQuery } from "apollo";
 import { createApolloFetch } from "apollo-fetch";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,6 @@ importers:
       '@mdx-js/react':
         specifier: ^2.1.2
         version: 2.3.0(react@19.2.1)
-      '@modulz/radix-icons':
-        specifier: ^4.0.0
-        version: 4.0.0(react@19.2.1)
       '@mui/material':
         specifier: ^7.3.5
         version: 7.3.9(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.1))(@types/react@19.2.2)(react@19.2.1))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -2079,11 +2076,6 @@ packages:
   '@metamask/utils@9.3.0':
     resolution: {integrity: sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g==}
     engines: {node: '>=16.0.0'}
-
-  '@modulz/radix-icons@4.0.0':
-    resolution: {integrity: sha512-d79T4cYvMGMocVC/q1WiMO578FPFfUoxmXIkduc8cUQAPDr7thuEV5HrCHhqqqkoVaYD0QPct180ilcNUyGPrg==}
-    peerDependencies:
-      react: ^16.x || ^17.x
 
   '@mui/core-downloads-tracker@7.3.9':
     resolution: {integrity: sha512-MOkOCTfbMJwLshlBCKJ59V2F/uaLYfmKnN76kksj6jlGUVdI25A9Hzs08m+zjBRdLv+sK7Rqdsefe8X7h/6PCw==}
@@ -13758,10 +13750,6 @@ snapshots:
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
-
-  '@modulz/radix-icons@4.0.0(react@19.2.1)':
-    dependencies:
-      react: 19.2.1
 
   '@mui/core-downloads-tracker@7.3.9': {}
 


### PR DESCRIPTION
## Summary
- Replace 26 `@modulz/radix-icons` imports with `@radix-ui/react-icons`, which is already a project dependency.
- Drop `@modulz/radix-icons` from `package.json`.
- Merge a few duplicate icon imports introduced by the rename.

## Why
Modulz rebranded to Radix in 2022; `@modulz/radix-icons` was renamed to `@radix-ui/react-icons`. The packages are API-compatible — `IconProps` is byte-identical, every used icon exists in both, and the new package wraps icons in `React.forwardRef`, which is preferable under React 19.

The repo currently mixes both packages; this consolidates onto the maintained one.

Closes #658

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm format:check` passes
- [x] Spot-check icons render on home, orchestrators, leaderboard, voting, treasury, and migrate pages