### PR TITLE
chore: add toggleable retroactive grant notice to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -108,5 +108,26 @@ body:
     id: additional-context
     attributes:
       label: Additional context
-      description: Add any other context about the problem here.
-      placeholder: Any other information that might help us debug.
+      description: Add any other context about the problem here. If this issue is retroactively compensated, remove the `<!--` and `-->` markers from the block below so the notice appears in the published issue.
+      value: |
+        <!--
+        ## Retroactive Grant Notice
+
+        > [!IMPORTANT]
+        > Compensation cap: **[FILL IN AMOUNT]**
+
+        Before picking this up, read the [Retroactive Grants post](https://forum.livepeer.org/t/about-the-retroactive-grant-applications-category/3250/2?u=mehrdad) in full. Key points:
+
+        - **Not pay-for-delivery.** Compensation is based on demonstrated adoption and community impact — not on shipping. Real, named community contributors must use your work and publicly attest to it. Building in isolation, then asking for a grant, does not qualify.
+        - **Talk to the community first.** A public discussion (Discord or Forum) about the problem must precede the work, and evidence of it must be part of your application. No prior discussion, no tempcheck, no public signal = won't pass review.
+
+        **Required steps before investing more time:**
+        1. Read the [original Retroactive Grants post](https://forum.livepeer.org/t/about-the-retroactive-grant-applications-category/3250/2?u=mehrdad) in full.
+        2. Start a public discussion (Discord or Forum). Get input. Confirm direction.
+        3. Secure at least one community proof point — a Discord thread with positive signal, a Review Team acknowledgement, or evidence of active adoption.
+        4. Identify, by name, who has this problem.
+        5. Build, ship, and confirm it's actually being used.
+        6. Apply with at least one named community contributor willing to publicly attest to your work's impact on the forum post.
+
+        Skipping steps 2, 3, 4, or 6 will halt the application. Reach out to **jj.a.ss.o.nn_everestnode** on Discord before you start building.
+        -->

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -39,8 +39,29 @@ body:
     id: additional-context
     attributes:
       label: Additional context
-      description: Add any other context or screenshots about the feature request here.
-      placeholder: Any other relevant info, mockups, or examples.
+      description: Add any other context or screenshots about the feature request here. If this issue is retroactively compensated, remove the `<!--` and `-->` markers from the block below so the notice appears in the published issue.
+      value: |
+        <!--
+        ## Retroactive Grant Notice
+
+        > [!IMPORTANT]
+        > Compensation cap: **[FILL IN AMOUNT]**
+
+        Before picking this up, read the [Retroactive Grants post](https://forum.livepeer.org/t/about-the-retroactive-grant-applications-category/3250/2?u=mehrdad) in full. Key points:
+
+        - **Not pay-for-delivery.** Compensation is based on demonstrated adoption and community impact — not on shipping. Real, named community contributors must use your work and publicly attest to it. Building in isolation, then asking for a grant, does not qualify.
+        - **Talk to the community first.** A public discussion (Discord or Forum) about the problem must precede the work, and evidence of it must be part of your application. No prior discussion, no tempcheck, no public signal = won't pass review.
+
+        **Required steps before investing more time:**
+        1. Read the [original Retroactive Grants post](https://forum.livepeer.org/t/about-the-retroactive-grant-applications-category/3250/2?u=mehrdad) in full.
+        2. Start a public discussion (Discord or Forum). Get input. Confirm direction.
+        3. Secure at least one community proof point — a Discord thread with positive signal, a Review Team acknowledgement, or evidence of active adoption.
+        4. Identify, by name, who has this problem.
+        5. Build, ship, and confirm it's actually being used.
+        6. Apply with at least one named community contributor willing to publicly attest to your work's impact on the forum post.
+
+        Skipping steps 2, 3, 4, or 6 will halt the application. Reach out to **jj.a.ss.o.nn_everestnode** on Discord before you start building.
+        -->
 
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

Adds a hidden-by-default retroactive grant notice to both the **Bug Report** and **Feature Request** issue templates. The notice is embedded in the existing _Additional context_ field as an HTML-commented block, so:

- **By default** — nothing extra appears in the published issue (the comment is invisible after markdown rendering, and the `Additional context` heading is the normal expected one).
- **For a retroactive grant issue** — the team member creating the issue removes the `<!--` and `-->` markers and fills in the compensation cap before submitting. The full notice then renders for anyone picking up the work.

## Why

Some issues we open are eligible for retroactive compensation. Contributors who pick those up need to understand up front that this isn't pay-for-delivery: payment depends on demonstrated community adoption and proof points, with specific required steps (public discussion, named beneficiaries, attestation) that must be completed before applying. Linking to the [Retroactive Grants forum post](https://forum.livepeer.org/t/about-the-retroactive-grant-applications-category/3250/2) and surfacing the cap in the issue itself avoids surprises later.

## How it works

- The notice lives inside the `value:` of the `Additional context` textarea on both templates, wrapped in `<!-- ... -->`.
- A `> [!IMPORTANT]` callout at the top of the notice holds the compensation cap with a `**[FILL IN AMOUNT]**` placeholder — clearly visible so it can't be forgotten when activating the notice.
- The `description:` of the field explains the uncomment-to-activate flow to whoever is filling out the form.
- No new fields, no separate template, no stray headings in normal (non-retro) issues.

## Test plan

- [x] Tested both states (markers in / markers out) on a fork — see https://github.com/mehrdadmms/explorer/issues/new/choose.
- [ ] Open a Bug Report on this repo with markers left in place → verify no extra heading or visible content appears.
- [ ] Open a Feature Request with markers removed and a cap filled in → verify the notice renders correctly with the IMPORTANT callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub issue templates for bug reports and feature requests with guidance on retroactive grant notices, including instructions for displaying notices in published issues, compensation cap information, and required submission steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/livepeer/explorer/pull/669?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->