### PR TITLE
fix: keep retroactive grant notice inside the alert block

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -115,19 +115,19 @@ body:
 
         > [!IMPORTANT]
         > Compensation cap: **[FILL IN AMOUNT]**
-
-        Before picking this up, read the [Retroactive Grants post](https://forum.livepeer.org/t/about-the-retroactive-grant-applications-category/3250/2?u=mehrdad) in full. Key points:
-
-        - **Not pay-for-delivery.** Compensation is based on demonstrated adoption and community impact — not on shipping. Real, named community contributors must use your work and publicly attest to it. Building in isolation, then asking for a grant, does not qualify.
-        - **Talk to the community first.** A public discussion (Discord or Forum) about the problem must precede the work, and evidence of it must be part of your application. No prior discussion, no tempcheck, no public signal = won't pass review.
-
-        **Required steps before investing more time:**
-        1. Read the [original Retroactive Grants post](https://forum.livepeer.org/t/about-the-retroactive-grant-applications-category/3250/2?u=mehrdad) in full.
-        2. Start a public discussion (Discord or Forum). Get input. Confirm direction.
-        3. Secure at least one community proof point — a Discord thread with positive signal, a Review Team acknowledgement, or evidence of active adoption.
-        4. Identify, by name, who has this problem.
-        5. Build, ship, and confirm it's actually being used.
-        6. Apply with at least one named community contributor willing to publicly attest to your work's impact on the forum post.
-
-        Skipping steps 2, 3, 4, or 6 will halt the application. Reach out to **jj.a.ss.o.nn_everestnode** on Discord before you start building.
+        >
+        > Before picking this up, read the [Retroactive Grants post](https://forum.livepeer.org/t/about-the-retroactive-grant-applications-category/3250/2?u=mehrdad) in full. Key points:
+        >
+        > - **Not pay-for-delivery.** Compensation is based on demonstrated adoption and community impact — not on shipping. Real, named community contributors must use your work and publicly attest to it. Building in isolation, then asking for a grant, does not qualify.
+        > - **Talk to the community first.** A public discussion (Discord or Forum) about the problem must precede the work, and evidence of it must be part of your application. No prior discussion, no tempcheck, no public signal = won't pass review.
+        >
+        > **Required steps before investing more time:**
+        > 1. Read the [original Retroactive Grants post](https://forum.livepeer.org/t/about-the-retroactive-grant-applications-category/3250/2?u=mehrdad) in full.
+        > 2. Start a public discussion (Discord or Forum). Get input. Confirm direction.
+        > 3. Secure at least one community proof point — a Discord thread with positive signal, a Review Team acknowledgement, or evidence of active adoption.
+        > 4. Identify, by name, who has this problem.
+        > 5. Build, ship, and confirm it's actually being used.
+        > 6. Apply with at least one named community contributor willing to publicly attest to your work's impact on the forum post.
+        >
+        > Skipping steps 2, 3, 4, or 6 will halt the application. Reach out to **jj.a.ss.o.nn_everestnode** on Discord before you start building.
         -->

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -46,21 +46,21 @@ body:
 
         > [!IMPORTANT]
         > Compensation cap: **[FILL IN AMOUNT]**
-
-        Before picking this up, read the [Retroactive Grants post](https://forum.livepeer.org/t/about-the-retroactive-grant-applications-category/3250/2?u=mehrdad) in full. Key points:
-
-        - **Not pay-for-delivery.** Compensation is based on demonstrated adoption and community impact — not on shipping. Real, named community contributors must use your work and publicly attest to it. Building in isolation, then asking for a grant, does not qualify.
-        - **Talk to the community first.** A public discussion (Discord or Forum) about the problem must precede the work, and evidence of it must be part of your application. No prior discussion, no tempcheck, no public signal = won't pass review.
-
-        **Required steps before investing more time:**
-        1. Read the [original Retroactive Grants post](https://forum.livepeer.org/t/about-the-retroactive-grant-applications-category/3250/2?u=mehrdad) in full.
-        2. Start a public discussion (Discord or Forum). Get input. Confirm direction.
-        3. Secure at least one community proof point — a Discord thread with positive signal, a Review Team acknowledgement, or evidence of active adoption.
-        4. Identify, by name, who has this problem.
-        5. Build, ship, and confirm it's actually being used.
-        6. Apply with at least one named community contributor willing to publicly attest to your work's impact on the forum post.
-
-        Skipping steps 2, 3, 4, or 6 will halt the application. Reach out to **jj.a.ss.o.nn_everestnode** on Discord before you start building.
+        >
+        > Before picking this up, read the [Retroactive Grants post](https://forum.livepeer.org/t/about-the-retroactive-grant-applications-category/3250/2?u=mehrdad) in full. Key points:
+        >
+        > - **Not pay-for-delivery.** Compensation is based on demonstrated adoption and community impact — not on shipping. Real, named community contributors must use your work and publicly attest to it. Building in isolation, then asking for a grant, does not qualify.
+        > - **Talk to the community first.** A public discussion (Discord or Forum) about the problem must precede the work, and evidence of it must be part of your application. No prior discussion, no tempcheck, no public signal = won't pass review.
+        >
+        > **Required steps before investing more time:**
+        > 1. Read the [original Retroactive Grants post](https://forum.livepeer.org/t/about-the-retroactive-grant-applications-category/3250/2?u=mehrdad) in full.
+        > 2. Start a public discussion (Discord or Forum). Get input. Confirm direction.
+        > 3. Secure at least one community proof point — a Discord thread with positive signal, a Review Team acknowledgement, or evidence of active adoption.
+        > 4. Identify, by name, who has this problem.
+        > 5. Build, ship, and confirm it's actually being used.
+        > 6. Apply with at least one named community contributor willing to publicly attest to your work's impact on the forum post.
+        >
+        > Skipping steps 2, 3, 4, or 6 will halt the application. Reach out to **jj.a.ss.o.nn_everestnode** on Discord before you start building.
         -->
 
   - type: markdown


### PR DESCRIPTION
## Summary
- The `> [!IMPORTANT]` callout in `bug-report.yml` and `feature-request.yml` only wrapped the first two lines; blank lines closed the blockquote and the rest of the notice rendered as plain text.
- Prefix every line of the notice (including blank separators) with `>` so the entire retroactive-grant block stays inside the alert.

## Test plan
- [x] Open a draft issue with each template, uncomment the notice, and confirm the full block renders as a single GitHub `IMPORTANT` callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub issue templates with improved markdown formatting in contribution notices to enhance readability and presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/livepeer/explorer/pull/673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->