### PR TITLE
fix: show delegate ENS name and avatar in delegation widget on My Account view

### DIFF
--- a/layouts/account.tsx
+++ b/layouts/account.tsx
@@ -97,6 +97,8 @@ const AccountLayout = ({
     pollInterval,
   });
 
+  const delegateIdentity = useEnsData(dataMyAccount?.delegator?.delegate?.id);
+
   // Fetch fresh account data client-side, using static props as fallback
   const { data: dataViewedAccount } = useAccountQuery({
     variables: {
@@ -350,7 +352,9 @@ const AccountLayout = ({
                 }
                 protocol={viewedAccount?.protocol}
                 treasury={treasury}
-                delegateProfile={identity}
+                delegateProfile={
+                  isDelegatingAndIsMyAccountView ? delegateIdentity : identity
+                }
               />
             </Flex>
           ) : (
@@ -366,7 +370,9 @@ const AccountLayout = ({
                 }
                 protocol={viewedAccount?.protocol}
                 treasury={treasury}
-                delegateProfile={identity}
+                delegateProfile={
+                  isDelegatingAndIsMyAccountView ? delegateIdentity : identity
+                }
               />
             </BottomDrawer>
           ))}


### PR DESCRIPTION
On the My Account view the delegation widget showed the raw address instead of the delegate orchestrator's ENS name and avatar. Resolve the delegate's ENS from `delegator.delegate.id` and pass it on that view, mirroring the existing `transcoder` source selection. Orchestrator pages are unchanged.