### PR TITLE
fix: resolve ENS reverse records via viem Universal Resolver

### DIFF
--- a/lib/api/ens.ts
+++ b/lib/api/ens.ts
@@ -1,6 +1,8 @@
-import { l1Provider } from "@lib/chains";
+import { l1PublicClient } from "@lib/chains";
 import { formatAddress } from "@utils/web3";
 import sanitizeHtml from "sanitize-html";
+import { isAddress } from "viem";
+import { normalize } from "viem/ens";
 
 import { EnsIdentity } from "./types/get-ens";
 
@@ -55,16 +57,19 @@ const sanitizeOptions: sanitizeHtml.IOptions = {
 export const getEnsForAddress = async (address: string | null | undefined) => {
   const idShort = address?.replace(address?.slice(6, 38), "…");
 
-  const name = address ? await l1Provider.lookupAddress(address) : null;
+  const name =
+    address && isAddress(address)
+      ? await l1PublicClient.getEnsName({ address })
+      : null;
 
   if (name) {
-    const resolver = await l1Provider.getResolver(name);
+    const normalizedName = normalize(name);
     const [description, url, twitter, github, avatar] = await Promise.all([
-      resolver?.getText("description"),
-      resolver?.getText("url"),
-      resolver?.getText("com.twitter"),
-      resolver?.getText("com.github"),
-      resolver?.getAvatar(),
+      l1PublicClient.getEnsText({ name: normalizedName, key: "description" }),
+      l1PublicClient.getEnsText({ name: normalizedName, key: "url" }),
+      l1PublicClient.getEnsText({ name: normalizedName, key: "com.twitter" }),
+      l1PublicClient.getEnsText({ name: normalizedName, key: "com.github" }),
+      l1PublicClient.getEnsText({ name: normalizedName, key: "avatar" }),
     ]);
 
     const ens: EnsIdentity = {
@@ -75,7 +80,7 @@ export const getEnsForAddress = async (address: string | null | undefined) => {
       url,
       twitter,
       github,
-      avatar: avatar?.url ? `/api/ens-data/image/${name}` : null,
+      avatar: avatar ? `/api/ens-data/image/${name}` : null,
     };
 
     return ens;
@@ -105,7 +110,10 @@ export const nl2br = (str, is_xhtml = true) => {
 export const getEnsForVotes = async (address: string | null | undefined) => {
   const idShort = formatAddress(address);
 
-  const name = address ? await l1Provider.lookupAddress(address) : null;
+  const name =
+    address && isAddress(address)
+      ? await l1PublicClient.getEnsName({ address })
+      : null;
 
   return {
     id: address ?? "",


### PR DESCRIPTION
## Problem
Orchestrators who set their ENS primary name via the current ENS flow (ENSIP-19 / L2 primary names) show only their address on the profile — no ENS name or avatar.

## Cause
Reverse resolution used ethers v5 `lookupAddress`, which only reads the legacy `addr.reverse` registry node. Names set through the modern flow live elsewhere, so resolution returned `null`.

## Fix
Switch `getEnsForAddress` / `getEnsForVotes` to viem's `getEnsName` / `getEnsText` on the existing `l1PublicClient`, whose Universal Resolver resolves both legacy and modern reverse records. Avatar presence now uses the `avatar` text record (the image proxy already resolves the image).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ENS address validation and data resolution for more reliable address lookups
  * Enhanced ENS text record retrieval (including descriptions, URLs, and social profiles)
  * Refined avatar field handling for better data accuracy

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/livepeer/explorer/pull/679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->