### PR TITLE
fix: use normalized, URL-encoded ENS name for avatar proxy URL

### DIFF
--- a/lib/api/ens.ts
+++ b/lib/api/ens.ts
@@ -80,7 +80,9 @@ export const getEnsForAddress = async (address: string | null | undefined) => {
       url,
       twitter,
       github,
-      avatar: avatar ? `/api/ens-data/image/${name}` : null,
+      avatar: avatar
+        ? `/api/ens-data/image/${encodeURIComponent(normalizedName)}`
+        : null,
     };
 
     return ens;


### PR DESCRIPTION
Follow-up to #679.

## Change
Build the avatar proxy URL from the **normalized** name and `encodeURIComponent` the path segment:

```ts
avatar: avatar
  ? `/api/ens-data/image/${encodeURIComponent(normalizedName)}`
  : null,
```

## Why
- **Encoding:** a normalized ENS name can still contain Unicode (emoji domains); raw Unicode in a URL path segment is invalid. ASCII names like `transcode.eth` are unaffected (no-op).
- **Normalized name:** the image route (`pages/api/ens-data/image/[name].tsx`) checks its blacklist on the raw param *before* normalizing, so feeding it the canonical form keeps that filter consistent. The route re-normalizes, so this is idempotent.

Addresses a Copilot review comment on #679.