### PR TITLE
fix: prevent duplicate inflation rate y-axis tick labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ usage.backup.json
 .gitignore
 bquxjob_1944883c_19a4f7cd5f0.json
 usage.json
+.playwright-mcp/

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,7 @@ node_modules
 
 # misc
 .claude
+.playwright-mcp
 .pnpm-store
 .github
 .vscode

--- a/components/ExplorerChart/index.tsx
+++ b/components/ExplorerChart/index.tsx
@@ -210,7 +210,7 @@ const ExplorerChart = ({
               case "percent":
                 return formatPercent(payload.value, { precision: 0 });
               case "small-percent":
-                return formatPercent(payload.value, { precision: 2 });
+                return formatPercent(payload.value, { precision: 3 });
               case "small-unitless":
                 return formatNumber(payload.value, {
                   precision: 1,
@@ -233,7 +233,7 @@ const ExplorerChart = ({
   const widthYAxis = useMemo(
     () =>
       unit === "small-percent"
-        ? 45
+        ? 52
         : unit === "percent"
         ? 42
         : unit === "minutes"


### PR DESCRIPTION
## Problem

On the home page Inflation Rate chart, the y-axis showed the same label twice (e.g. `0.06%` appearing on two adjacent ticks).

The inflation rate sits in a very narrow band (~0.055%–0.066%), and the `small-percent` y-axis ticks were formatted with only 2 decimals. Recharts generated ticks like `0.0575%` and `0.0625%`, both of which rounded to `0.06%`.

## Fix

- Bump `small-percent` y-axis tick precision from 2 → 3 decimals so adjacent ticks no longer collapse to the same label (now `0.056%` / `0.064%` / `0.072%`).
- Widen the `small-percent` y-axis from 45 → 52px so the extra digit doesn't clip the trailing `%`.

`small-percent` is used only by the inflation chart, and the headline/hover value (precision 5) is unchanged.

## Verification

Verified in the browser — y-axis ticks are now distinct and the `%` is no longer clipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Explorer Chart Y-axis tick formatting with increased decimal precision and label width for small percentage values.

* **Chores**
  * Updated configuration files to exclude Playwright build artifacts from version control and code formatting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->