### PR TITLE
fix: source fees paid chart from subgraph

### DIFF
--- a/lib/api/types/get-protocol-day-data.ts
+++ b/lib/api/types/get-protocol-day-data.ts
@@ -6,11 +6,20 @@ export interface ProtocolDay {
   participationRate: number;
   delegatorsCount: number;
   activeTranscoderCount: number;
+  volumeUsd: number;
+}
+
+export interface ProtocolWeek {
+  // Unix seconds of the first day in the week bucket.
+  date: number;
+  weeklyVolumeUsd: number;
 }
 
 export interface ProtocolDayData {
   // Continuous, gap-free daily series, ascending by date.
   dayData: ProtocolDay[];
+  // Days bucketed into weeks for the fees "W" view.
+  weeklyData: ProtocolWeek[];
 
   // Latest-day values with their day-over-day percent change.
   inflation: number;
@@ -21,4 +30,10 @@ export interface ProtocolDayData {
   delegatorsCountChange: number;
   activeTranscoderCount: number;
   activeTranscoderCountChange: number;
+
+  // Fees: latest day and latest complete week, with their percent change.
+  oneDayVolumeUSD: number;
+  volumeChangeUSD: number;
+  oneWeekVolumeUSD: number;
+  weeklyVolumeChangeUSD: number;
 }

--- a/pages/api/protocol-day-data.tsx
+++ b/pages/api/protocol-day-data.tsx
@@ -2,8 +2,10 @@ import { getCacheControlHeader } from "@lib/api";
 import type {
   ProtocolDay,
   ProtocolDayData,
+  ProtocolWeek,
 } from "@lib/api/types/get-protocol-day-data";
 import { CHAIN_INFO, DEFAULT_CHAIN_ID } from "@lib/chains";
+import dayjs from "@lib/dayjs";
 import { fetchWithRetry } from "@lib/fetchWithRetry";
 import { getPercentChange } from "@lib/utils";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -24,6 +26,7 @@ const DAYS_QUERY = `
       participationRate
       delegatorsCount
       activeTranscoderCount
+      volumeUSD
     }
   }
 `;
@@ -74,6 +77,7 @@ const protocolDayDataHandler = async (
           participationRate: Number(day.participationRate),
           delegatorsCount: Number(day.delegatorsCount),
           activeTranscoderCount: Number(day.activeTranscoderCount),
+          volumeUsd: Number(day.volumeUSD),
         });
       }
 
@@ -89,14 +93,33 @@ const protocolDayDataHandler = async (
 
     if (dayData.length === 0) return res.status(502).json(null);
 
+    // Bucket days into weeks for the fees "W" view. A new week-of-year number
+    // starts a new bucket (mirrors the off-chain /usage aggregation).
+    const weeklyData: ProtocolWeek[] = [];
+    let currentWeek = -1;
+    for (const day of dayData) {
+      const week = dayjs.utc(dayjs.unix(day.dateS)).week();
+      if (week !== currentWeek) {
+        currentWeek = week;
+        weeklyData.push({ date: day.dateS, weeklyVolumeUsd: 0 });
+      }
+      weeklyData[weeklyData.length - 1].weeklyVolumeUsd += day.volumeUsd;
+    }
+
     const current = dayData[dayData.length - 1];
     const previous = dayData[dayData.length - 2];
 
     const change = (key: keyof ProtocolDay) =>
       getPercentChange(current?.[key] ?? 0, previous?.[key] ?? 0);
 
+    // The last week bucket is in-progress, so headline fees use the last
+    // complete week (second-to-last) and compare it to the week before that.
+    const lastCompleteWeek = weeklyData[weeklyData.length - 2];
+    const priorWeek = weeklyData[weeklyData.length - 3];
+
     const data: ProtocolDayData = {
       dayData,
+      weeklyData,
       inflation: current?.inflation ?? 0,
       inflationChange: change("inflation"),
       participationRate: current?.participationRate ?? 0,
@@ -105,6 +128,13 @@ const protocolDayDataHandler = async (
       delegatorsCountChange: change("delegatorsCount"),
       activeTranscoderCount: current?.activeTranscoderCount ?? 0,
       activeTranscoderCountChange: change("activeTranscoderCount"),
+      oneDayVolumeUSD: current?.volumeUsd ?? 0,
+      volumeChangeUSD: change("volumeUsd"),
+      oneWeekVolumeUSD: lastCompleteWeek?.weeklyVolumeUsd ?? 0,
+      weeklyVolumeChangeUSD: getPercentChange(
+        lastCompleteWeek?.weeklyVolumeUsd ?? 0,
+        priorWeek?.weeklyVolumeUsd ?? 0
+      ),
     };
 
     res.setHeader("Cache-Control", getCacheControlHeader("day"));

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -68,15 +68,15 @@ const Charts = ({ chartData }: { chartData: HomeChartData | null }) => {
   const feesPaidData = useMemo(
     () =>
       (feesPaidGrouping === "day"
-        ? chartData?.dayData?.map((day) => ({
+        ? protocolDayData?.dayData?.map((day) => ({
             x: Number(day.dateS),
             y: Number(day.volumeUsd),
           }))
-        : chartData?.weeklyData?.map((week) => ({
+        : protocolDayData?.weeklyData?.map((week) => ({
             x: Number(week.date),
             y: Number(week.weeklyVolumeUsd),
           }))) ?? [],
-    [feesPaidGrouping, chartData]
+    [feesPaidGrouping, protocolDayData]
   );
 
   const [usageGrouping, setUsageGrouping] = useState<Group>("week");
@@ -156,13 +156,13 @@ const Charts = ({ chartData }: { chartData: HomeChartData | null }) => {
           }
           base={Number(
             (feesPaidGrouping === "day"
-              ? chartData?.oneDayVolumeUSD
-              : chartData?.oneWeekVolumeUSD) ?? 0
+              ? protocolDayData?.oneDayVolumeUSD
+              : protocolDayData?.oneWeekVolumeUSD) ?? 0
           )}
           basePercentChange={Number(
             (feesPaidGrouping === "day"
-              ? chartData?.volumeChangeUSD
-              : chartData?.weeklyVolumeChangeUSD) ?? 0
+              ? protocolDayData?.volumeChangeUSD
+              : protocolDayData?.weeklyVolumeChangeUSD) ?? 0
           )}
           title={`Fees Paid ${feesPaidGrouping === "day" ? "(1d)" : "(7d)"}`}
           unit="usd"


### PR DESCRIPTION
## Problem

The **Fees Paid** chart still read from the off-chain `livepeer.com/data/usage` API, which drops multi-week windows. The latest gap removed **all of April 2026** (Mar 18 → May 12, 56 days). On the category x-axis this silently splices Mar 17 directly to May 13, which stretches both views back too far (the "D" view started Oct '25 instead of Dec '25) and distorts the bars.

This follows #701, which moved the four protocol *line* charts to the subgraph; Fees was deferred because it's a bar chart needing weekly aggregation.

## Fix

Extend the shared `/api/protocol-day-data` route (subgraph, chain-indexed, gap-free) with what the Fees chart needs:

- Add daily **`volumeUSD`** to the query and `ProtocolDay`.
- Build a **weekly rollup** (`weeklyData`) in code — there's no `Week` entity in the subgraph — using the same week-of-year bucketing as `/usage`.
- Add fee headline values: `oneDayVolumeUSD`, `volumeChangeUSD`, `oneWeekVolumeUSD`, `weeklyVolumeChangeUSD` (the weekly ones use the last *complete* week, like `/usage`).
- Point the Fees chart's data + base/change at `protocolDayData`.

**Estimated Usage** stays on `/usage` — `feeDerivedMinutes` is an off-chain-only estimate.

## Verification

Compared subgraph vs off-chain across all history:

- **Daily volume matches** on every common day (1,518/1,520 exact; the 2 diffs are a ~0.2% USD rounding and the Mar 17 gap-boundary day where the subgraph is *more* correct).
- **Weekly default headline matches exactly:** `oneWeekVolumeUSD` = 5760.611 both, `weeklyVolumeChangeUSD` = −3.636% both.
- The subgraph fills the gap: **April 2026 = 0 days off-chain vs 30 days on subgraph.**
- `tsc --noEmit` clean.

## Reviewer note — in-progress current day

The subgraph is one day fresher than the off-chain API, so the Fees series now includes **today (in-progress)**. The weekly default view is unaffected (uses the last complete week), but the **daily "D" view** ends on a *partial* today: a short last bar and a misleading headline (e.g. `$561 −40%` vs a complete `$941`). 

I left it fresh for consistency with the other subgraph-sourced charts. If preferred, I can **exclude the in-progress current day** from the fees daily headline/last bar to match the old "last complete day" behavior. Flagging for your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced protocol volume tracking with daily and weekly USD metrics
  * Implemented weekly volume aggregation and time-based bucketing
  * Updated Fees Paid chart with volume-based metrics and percent-change indicators
  * Added multi-period volume comparison support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->