### PR TITLE
fix: stop close button overlapping the LPT embed modal

### DIFF
--- a/components/EmbedModal/index.tsx
+++ b/components/EmbedModal/index.tsx
@@ -1,11 +1,28 @@
-import { Dialog, DialogContent, DialogTrigger } from "@livepeer/design-system";
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+} from "@livepeer/design-system";
 
 const EmbedModal = ({ trigger, children }) => {
   return (
     <Dialog>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
-      <DialogContent css={{ width: "100%", maxWidth: 500, height: "80vh" }}>
-        {children}
+      <DialogContent
+        css={{
+          width: "100%",
+          maxWidth: 500,
+          height: "80vh",
+          display: "flex",
+          flexDirection: "column",
+          // The built-in close button is a ghost IconButton with no pointer cursor.
+          "& button": { cursor: "pointer" },
+        }}
+      >
+        {/* marginTop matches the Search dialog so the close button clears the
+            embedded content (and its scrollbar) instead of overlapping it. */}
+        <Box css={{ flex: 1, minHeight: 0, marginTop: "$4" }}>{children}</Box>
       </DialogContent>
     </Dialog>
   );

--- a/components/EmbedModal/index.tsx
+++ b/components/EmbedModal/index.tsx
@@ -20,8 +20,6 @@ const EmbedModal = ({ trigger, children }) => {
           "& button": { cursor: "pointer" },
         }}
       >
-        {/* marginTop matches the Search dialog so the close button clears the
-            embedded content (and its scrollbar) instead of overlapping it. */}
         <Box css={{ flex: 1, minHeight: 0, marginTop: "$4" }}>{children}</Box>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary

The close button in the Get LPT / Bridge LPT embed modal overlapped the embedded iframe (and its scrollbar) and had no pointer cursor.

- Lay the dialog out as a flex column with the iframe filling the body (`flex: 1; minHeight: 0`), which removes the inner scrollbar that was colliding with the close button.
- Add `marginTop: "$4"` to the content wrapper — the same spacing the Search dialog uses — so the built-in close button clears the embed.
- Give the close button a pointer cursor (`"& button": { cursor: "pointer" }`), matching the Search dialog.

## Testing

- [x] Mobile drawer → Get LPT / Bridge LPT: close button sits clear of the embed, no scrollbar overlap, pointer cursor on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced layout and cursor behavior for the embed modal dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->