### PR TITLE
fix: pre-select LPT as bridge destination token

### DIFF
--- a/constants/links.ts
+++ b/constants/links.ts
@@ -6,4 +6,4 @@ const ETHEREUM_LPT_ADDRESS = "0x58b6a8a3302369daec383334672404ee733ab239";
 export const GET_LPT_URL = `https://swap.defillama.com/?chain=arbitrum&from=0x0000000000000000000000000000000000000000&to=${ARBITRUM_LPT_ADDRESS}`;
 
 // Bridge LPT from Ethereum to Arbitrum One via the Arbitrum bridge portal.
-export const BRIDGE_LPT_URL = `https://portal.arbitrum.io/bridge?destinationChain=arbitrum-one&sourceChain=ethereum&token=${ETHEREUM_LPT_ADDRESS}`;
+export const BRIDGE_LPT_URL = `https://portal.arbitrum.io/bridge?destinationChain=arbitrum-one&sourceChain=ethereum&token=${ETHEREUM_LPT_ADDRESS}&destinationToken=${ETHEREUM_LPT_ADDRESS}`;


### PR DESCRIPTION
The "Bridge LPT" menu option (#705) opened the Arbitrum portal with LPT on the source side but ETH on the destination side, because the portal falls back to ETH when `destinationToken` is absent.

Add `destinationToken` to `BRIDGE_LPT_URL` so LPT is pre-selected on both the Ethereum and Arbitrum One sides.

Note: the portal expects the **L1 (Ethereum) LPT address** for `destinationToken` and resolves the L2 counterpart internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bridge URL configuration to include additional token routing parameters for improved cross-chain token transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->