### PR TITLE
fix: wrong network indicator invisible on migrate

### DIFF
--- a/components/ConnectButton/index.tsx
+++ b/components/ConnectButton/index.tsx
@@ -1,9 +1,51 @@
-import { ConnectButton as ConnectButtonRainbowKit } from "@rainbow-me/rainbowkit";
+import {
+  ConnectButton as ConnectButtonRainbowKit,
+  useChainModal,
+} from "@rainbow-me/rainbowkit";
 import { ConnectButtonProps } from "@rainbow-me/rainbowkit/dist/components/ConnectButton/ConnectButton";
+import { DEFAULT_CHAIN_ID, L1_CHAIN_ID } from "lib/chains";
+import { useRouter } from "next/router";
 import { useWindowSize } from "react-use";
+import { useAccount } from "wagmi";
 
 const ConnectButton = (props: ConnectButtonProps) => {
   const { width } = useWindowSize();
+  const { pathname } = useRouter();
+  const { chain, status } = useAccount();
+  const { openChainModal } = useChainModal();
+  const expectedChainId = pathname.startsWith("/migrate")
+    ? L1_CHAIN_ID
+    : DEFAULT_CHAIN_ID;
+  const isWrongRouteChain =
+    status === "connected" && chain?.id && chain.id !== expectedChainId;
+
+  if (isWrongRouteChain) {
+    return (
+      <button
+        type="button"
+        onClick={openChainModal}
+        style={{
+          alignItems: "center",
+          backgroundColor: "#5D181D",
+          border: 0,
+          borderRadius: 8,
+          color: "#FF6B70",
+          cursor: openChainModal ? "pointer" : "default",
+          display: "inline-flex",
+          fontFamily: "Inter, -apple-system, system-ui, sans-serif",
+          fontSize: 13,
+          fontWeight: 600,
+          height: 36,
+          lineHeight: 1,
+          padding: "0 12px",
+          whiteSpace: "nowrap",
+        }}
+      >
+        Wrong Network
+      </button>
+    );
+  }
+
   return (
     <ConnectButtonRainbowKit
       chainStatus="none"

--- a/components/ConnectButton/index.tsx
+++ b/components/ConnectButton/index.tsx
@@ -2,22 +2,24 @@ import {
   ConnectButton as ConnectButtonRainbowKit,
   useChainModal,
 } from "@rainbow-me/rainbowkit";
-import { ConnectButtonProps } from "@rainbow-me/rainbowkit/dist/components/ConnectButton/ConnectButton";
 import { DEFAULT_CHAIN_ID, L1_CHAIN_ID } from "lib/chains";
 import { useRouter } from "next/router";
+import type { ComponentProps } from "react";
 import { useWindowSize } from "react-use";
 import { useAccount } from "wagmi";
+
+type ConnectButtonProps = ComponentProps<typeof ConnectButtonRainbowKit>;
 
 const ConnectButton = (props: ConnectButtonProps) => {
   const { width } = useWindowSize();
   const { pathname } = useRouter();
-  const { chain, status } = useAccount();
+  const { chainId, status } = useAccount();
   const { openChainModal } = useChainModal();
   const expectedChainId = pathname.startsWith("/migrate")
     ? L1_CHAIN_ID
     : DEFAULT_CHAIN_ID;
   const isWrongRouteChain =
-    status === "connected" && chain?.id && chain.id !== expectedChainId;
+    status === "connected" && chainId && chainId !== expectedChainId;
 
   if (isWrongRouteChain) {
     return (

--- a/components/ConnectButton/index.tsx
+++ b/components/ConnectButton/index.tsx
@@ -2,24 +2,16 @@ import {
   ConnectButton as ConnectButtonRainbowKit,
   useChainModal,
 } from "@rainbow-me/rainbowkit";
-import { DEFAULT_CHAIN_ID, L1_CHAIN_ID } from "lib/chains";
-import { useRouter } from "next/router";
+import { useIsWrongRouteChain } from "hooks";
 import type { ComponentProps } from "react";
 import { useWindowSize } from "react-use";
-import { useAccount } from "wagmi";
 
 type ConnectButtonProps = ComponentProps<typeof ConnectButtonRainbowKit>;
 
 const ConnectButton = (props: ConnectButtonProps) => {
   const { width } = useWindowSize();
-  const { pathname } = useRouter();
-  const { chainId, status } = useAccount();
+  const isWrongRouteChain = useIsWrongRouteChain();
   const { openChainModal } = useChainModal();
-  const expectedChainId = pathname.startsWith("/migrate")
-    ? L1_CHAIN_ID
-    : DEFAULT_CHAIN_ID;
-  const isWrongRouteChain =
-    status === "connected" && chainId && chainId !== expectedChainId;
 
   if (isWrongRouteChain) {
     return (

--- a/components/DelegatingWidget/Footer.tsx
+++ b/components/DelegatingWidget/Footer.tsx
@@ -11,8 +11,10 @@ import {
   StakingAction,
   useAccountAddress,
   useAccountBalanceData,
+  useExpectedChainId,
   usePendingFeesAndStakeData,
 } from "hooks";
+import { CHAIN_INFO } from "lib/chains";
 import { useMemo } from "react";
 import { parseEther } from "viem";
 
@@ -27,6 +29,7 @@ type FooterData = {
 
   action: StakingAction;
   amount: string;
+  isWrongRouteChain: boolean;
 
   currentRound:
     | NonNullable<
@@ -58,11 +61,14 @@ const Footer = ({
     transcoder,
     action,
     amount,
+    isWrongRouteChain,
     currentRound,
   },
   css = {},
 }: Props) => {
   const accountAddress = useAccountAddress();
+  const expectedChainId = useExpectedChainId();
+  const expectedChainLabel = CHAIN_INFO[expectedChainId].label;
 
   const delegatorPendingStakeAndFees = usePendingFeesAndStakeData(
     delegator?.id
@@ -152,6 +158,25 @@ const Footer = ({
         </Button>
         <Footnote>
           Connect your wallet to{" "}
+          {action === "delegate" ? "delegate" : "undelegate"}.
+        </Footnote>
+      </>
+    );
+  }
+
+  if (isWrongRouteChain) {
+    return (
+      <>
+        <Button
+          size="4"
+          disabled={true}
+          variant="primary"
+          css={{ width: "100%" }}
+        >
+          {action === "delegate" ? "Delegate" : "Undelegate"}
+        </Button>
+        <Footnote>
+          Switch to {expectedChainLabel} to{" "}
           {action === "delegate" ? "delegate" : "undelegate"}.
         </Footnote>
       </>

--- a/components/DelegatingWidget/Footer.tsx
+++ b/components/DelegatingWidget/Footer.tsx
@@ -145,25 +145,6 @@ const Footer = ({
     }
   }, [isOwnOrchestrator, stakeWei, amount]);
 
-  if (!accountAddress) {
-    return (
-      <>
-        <Button
-          size="4"
-          disabled={true}
-          variant="primary"
-          css={{ width: "100%" }}
-        >
-          {action === "delegate" ? "Delegate" : "Undelegate"}
-        </Button>
-        <Footnote>
-          Connect your wallet to{" "}
-          {action === "delegate" ? "delegate" : "undelegate"}.
-        </Footnote>
-      </>
-    );
-  }
-
   if (isWrongRouteChain) {
     return (
       <>
@@ -177,6 +158,25 @@ const Footer = ({
         </Button>
         <Footnote>
           Switch to {expectedChainLabel} to{" "}
+          {action === "delegate" ? "delegate" : "undelegate"}.
+        </Footnote>
+      </>
+    );
+  }
+
+  if (!accountAddress) {
+    return (
+      <>
+        <Button
+          size="4"
+          disabled={true}
+          variant="primary"
+          css={{ width: "100%" }}
+        >
+          {action === "delegate" ? "Delegate" : "Undelegate"}
+        </Button>
+        <Footnote>
+          Connect your wallet to{" "}
           {action === "delegate" ? "delegate" : "undelegate"}.
         </Footnote>
       </>

--- a/components/DelegatingWidget/index.tsx
+++ b/components/DelegatingWidget/index.tsx
@@ -6,6 +6,7 @@ import { AccountQueryResult, OrchestratorsSortedQueryResult } from "apollo";
 import {
   useEnsData,
   useExplorerStore,
+  useIsWrongRouteChain,
   usePendingFeesAndStakeData,
 } from "hooks";
 import { useMemo, useState } from "react";
@@ -48,6 +49,7 @@ const Index = ({
   const [amount, setAmount] = useState("");
   const { selectedStakingAction, setSelectedStakingAction } =
     useExplorerStore();
+  const isWrongRouteChain = useIsWrongRouteChain();
 
   const pendingFeesAndStake = usePendingFeesAndStakeData(delegator?.id);
 
@@ -96,15 +98,19 @@ const Index = ({
         <Tabs
           index={selectedStakingAction === "delegate" ? 0 : 1}
           onChange={(index: number) => {
+            if (isWrongRouteChain) return;
             setSelectedStakingAction(index ? "undelegate" : "delegate");
           }}
         >
           <TabList>
-            <Tab isSelected={selectedStakingAction === "delegate"}>
+            <Tab
+              disabled={isWrongRouteChain}
+              isSelected={selectedStakingAction === "delegate"}
+            >
               Delegate
             </Tab>
             <Tab
-              disabled={isTransferStake}
+              disabled={isTransferStake || isWrongRouteChain}
               isSelected={selectedStakingAction === "undelegate"}
             >
               Undelegate
@@ -202,6 +208,7 @@ const Index = ({
             transcoder,
             action: selectedStakingAction,
             amount,
+            isWrongRouteChain,
           }}
         />
       </Box>

--- a/components/Web3Providers/index.tsx
+++ b/components/Web3Providers/index.tsx
@@ -20,17 +20,19 @@ import { WagmiProvider } from "wagmi";
 
 const Index = ({
   children,
-  isMigrateRoute,
   locale,
 }: {
   children: React.ReactNode;
-  isMigrateRoute: boolean;
   locale?: string;
 }) => {
-  const { config, layoutKey } = useMemo(() => {
-    const chains = [isMigrateRoute ? L1_CHAIN : DEFAULT_CHAIN] as _chains;
+  const config = useMemo(() => {
+    const chains = (
+      DEFAULT_CHAIN.id === L1_CHAIN.id
+        ? [DEFAULT_CHAIN]
+        : [DEFAULT_CHAIN, L1_CHAIN]
+    ) as _chains;
 
-    const config = getDefaultConfig({
+    return getDefaultConfig({
       appName: "Livepeer Explorer",
       projectId: WALLET_CONNECT_PROJECT_ID ?? "",
       chains,
@@ -50,15 +52,10 @@ const Index = ({
         },
       ],
     });
-
-    return {
-      config,
-      layoutKey: chains.map((e) => e.id).join(","),
-    };
-  }, [isMigrateRoute]);
+  }, []);
 
   return (
-    <WagmiProvider config={config} key={layoutKey}>
+    <WagmiProvider config={config}>
       <RainbowKitProvider
         appInfo={{
           appName: "Livepeer Explorer",

--- a/hooks/wallet.tsx
+++ b/hooks/wallet.tsx
@@ -1,5 +1,10 @@
-import { ALL_SUPPORTED_CHAIN_IDS } from "@lib/chains";
+import {
+  ALL_SUPPORTED_CHAIN_IDS,
+  DEFAULT_CHAIN_ID,
+  L1_CHAIN_ID,
+} from "@lib/chains";
 import { Signer } from "ethers";
+import { useRouter } from "next/router";
 import { useMemo, useState } from "react";
 import { useAccount, useDisconnect } from "wagmi";
 
@@ -50,6 +55,20 @@ export const useAccountSigner = () => {
 export const useActiveChain = () => {
   const { chain } = useAccount();
   return chain;
+};
+
+export const useExpectedChainId = () => {
+  const { pathname } = useRouter();
+  return pathname.startsWith("/migrate") ? L1_CHAIN_ID : DEFAULT_CHAIN_ID;
+};
+
+export const useIsWrongRouteChain = () => {
+  const expectedChainId = useExpectedChainId();
+  const { chainId, status } = useAccount();
+
+  return Boolean(
+    status === "connected" && chainId && chainId !== expectedChainId
+  );
 };
 
 export function useDisconnectWallet() {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,12 +4,10 @@ import "../styles/globals.css";
 import { ApolloProvider } from "@apollo/client";
 import { fetcher } from "@lib/fetcher";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { DEFAULT_CHAIN, L1_CHAIN } from "lib/chains";
 import dynamic from "next/dynamic";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { Tooltip } from "radix-ui";
-import { useMemo } from "react";
 import { CookiesProvider } from "react-cookie";
 import { SWRConfig } from "swr";
 
@@ -24,11 +22,7 @@ const Web3Providers = dynamic(() => import("../components/Web3Providers"), {
 
 function App({ Component, pageProps, fallback = null }) {
   const client = useApollo();
-  const { route, locale } = useRouter();
-
-  const isMigrateRoute = useMemo(() => route.includes("/migrate"), [route]);
-  const chains = [isMigrateRoute ? L1_CHAIN : DEFAULT_CHAIN];
-  const layoutKey = chains.map((e) => e.id).join(",");
+  const { locale } = useRouter();
 
   const getLayout = Component.getLayout || ((page) => <Layout>{page}</Layout>);
 
@@ -43,13 +37,10 @@ function App({ Component, pageProps, fallback = null }) {
         <title>Livepeer Explorer</title>
       </Head>
 
-      <ApolloProvider
-        key={layoutKey} // triggers a re-render of the entire app, to make sure that the chains are not memo-ized incorrectly
-        client={client}
-      >
+      <ApolloProvider client={client}>
         <Tooltip.Provider>
           <QueryClientProvider client={queryClient}>
-            <Web3Providers isMigrateRoute={isMigrateRoute} locale={locale}>
+            <Web3Providers locale={locale}>
               <SWRConfig
                 value={{
                   dedupingInterval: 5000,


### PR DESCRIPTION
## Description

Fixes wallet state getting lost when navigating between `/` and `/migrate`.

The app now keeps one stable wagmi/RainbowKit provider with both supported chains instead of remounting providers per route, avoiding wagmi’s reconnect race. It also adds a route-aware “Wrong Network” pill so users still get the correct chain warning for migrate vs. explorer pages.

## Type of Change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [x] style: Code style/formatting changes (no logic changes)
- [ ] refactor: Code refactoring (no behavior change)
- [ ] perf: Performance improvement
- [ ] test: Adding or updating tests
- [ ] build: Build system or dependency changes
- [ ] ci: CI/CD changes
- [ ] chore: Other changes

## Related Issue(s)

Closes: #666 

## Changes Made

- Adds a custom "wrong network" pill
- Includes both Ethereum and Arbitrum as supported chains (before, it set this depending on page and remounted depending on the change)
- Adds some custom logic for determining wrong network now that both chains mentioned above are listed as supported

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests passing

### How to test (optional unless test is not trivial)

- Connect wallet
- On homepage, switch to Arbitrum in your wallet
- Go to Migrate page
- See that "wrong network" is displayed in the top-right

## Impact / Risk

Risk level: Medium

Impacted areas: UI

User impact: users correctly see that they are on the wrong network on the migrate page

Rollback plan: Vercel rollback, then manual git revert

## Screenshots / Recordings

<img width="1174" height="530" alt="Screenshot 2026-06-25 at 7 48 17 PM" src="https://github.com/user-attachments/assets/0d958a7a-f54a-4df3-80b1-b2c6c079d759" />

## Additional Notes

NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Wrong Network” experience for wallet connections and staking actions when the connected network doesn’t match the current route, including a one-click option to switch networks.
  * Automatically determines the expected chain based on the current route to drive the correct network context.

* **Bug Fixes**
  * Reduced unnecessary page remounts and re-renders during navigation.
  * Simplified wallet/provider setup for more consistent behavior across routes.
  * Disabled or prevented delegate/undelegate interactions in the wrong-network context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->