### PR TITLE
fix: change create a poll LIP fetch to cached runtime API call

### DIFF
--- a/lib/api/poll-lips.ts
+++ b/lib/api/poll-lips.ts
@@ -1,7 +1,7 @@
-import { createApolloFetch } from "apollo-fetch";
 import fm from "front-matter";
 import { CHAIN_INFO, DEFAULT_CHAIN_ID } from "lib/chains";
-import { catIpfsJson, IpfsPoll } from "utils/ipfs";
+import { fetchWithRetry } from "lib/fetchWithRetry";
+import { IpfsPoll } from "utils/ipfs";
 
 import { PollLip, PollLips } from "./types/get-poll-lips";
 
@@ -25,7 +25,7 @@ type GitHubLipResponse = {
     content: {
       entries: {
         content: {
-          text: string;
+          text?: string;
         };
       }[];
     };
@@ -34,6 +34,70 @@ type GitHubLipResponse = {
 
 const getLipNamespace = () =>
   process.env.NEXT_PUBLIC_GITHUB_LIP_NAMESPACE || "livepeer";
+
+const UPSTREAM_TIMEOUT_MS = 8_000;
+const IPFS_CONCURRENCY = 5;
+
+type GraphQLResponse<T> = {
+  data?: T;
+  errors?: unknown[];
+};
+
+async function fetchGraphQL<T>(
+  uri: string,
+  query: string,
+  headers?: HeadersInit
+): Promise<GraphQLResponse<T>> {
+  const response = await fetchWithRetry(
+    uri,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...headers,
+      },
+      body: JSON.stringify({ query }),
+    },
+    { timeoutMs: UPSTREAM_TIMEOUT_MS }
+  );
+
+  return response.json() as Promise<GraphQLResponse<T>>;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = [];
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(items[index]);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, worker)
+  );
+
+  return results;
+}
+
+async function fetchIpfsPoll(ipfsHash: string | undefined | null) {
+  if (!ipfsHash) return null;
+
+  const response = await fetchWithRetry(
+    `https://ipfs.livepeer.com/ipfs/${ipfsHash}`,
+    { method: "GET" },
+    { timeoutMs: UPSTREAM_TIMEOUT_MS }
+  );
+
+  return response.json() as Promise<IpfsPoll>;
+}
 
 export async function getPollLips(): Promise<PollLips> {
   const lipsQuery = `
@@ -64,39 +128,27 @@ export async function getPollLips(): Promise<PollLips> {
     }
     `;
 
-  const githubFetch = createApolloFetch({
-    uri: "https://api.github.com/graphql",
-  });
-
-  githubFetch.use(({ options }, next) => {
-    if (!options.headers) {
-      options.headers = {};
+  const result = await fetchGraphQL<GitHubLipResponse>(
+    "https://api.github.com/graphql",
+    lipsQuery,
+    {
+      authorization: `Bearer ${process.env.GITHUB_ACCESS_TOKEN}`,
     }
-    options.headers[
-      "authorization"
-    ] = `Bearer ${process.env.GITHUB_ACCESS_TOKEN}`;
-
-    next();
-  });
-
-  const result = await githubFetch({ query: lipsQuery });
+  );
   if (result.errors?.length) {
     throw new Error(
       `GitHub GraphQL returned errors: ${JSON.stringify(result.errors)}`
     );
   }
 
-  const githubData = result.data as GitHubLipResponse | undefined;
+  const githubData = result.data;
   if (!githubData?.repository?.content?.entries) {
     throw new Error(`No LIP data returned for ${getLipNamespace()}/LIPS`);
   }
 
-  const subgraphFetch = createApolloFetch({
-    uri: CHAIN_INFO[DEFAULT_CHAIN_ID].subgraph,
-  });
-  const { data: pollsData, errors: pollsErrors } = await subgraphFetch({
-    query: `{ polls { proposal } }`,
-  });
+  const { data: pollsData, errors: pollsErrors } = await fetchGraphQL<{
+    polls: { proposal?: string | null }[];
+  }>(CHAIN_INFO[DEFAULT_CHAIN_ID].subgraph, `{ polls { proposal } }`);
   if (pollsErrors?.length) {
     throw new Error(
       `Polls subgraph returned errors: ${JSON.stringify(pollsErrors)}`
@@ -105,20 +157,30 @@ export async function getPollLips(): Promise<PollLips> {
 
   const createdPolls: string[] = [];
   if (pollsData) {
-    await Promise.all(
-      pollsData.polls.map(async (poll) => {
-        const obj = await catIpfsJson<IpfsPoll>(poll?.proposal);
+    await mapWithConcurrency(
+      pollsData.polls,
+      IPFS_CONCURRENCY,
+      async (poll) => {
+        const obj = await fetchIpfsPoll(poll?.proposal).catch((err) => {
+          console.warn(
+            `[poll-lips] Failed to read poll IPFS object ${poll?.proposal}`,
+            err
+          );
+          return null;
+        });
 
         if (obj?.text && obj?.gitCommitHash) {
           const transformedProposal = fm(obj.text) as TransformedProposal;
           createdPolls.push(String(transformedProposal.attributes.lip));
         }
-      })
+      }
     );
   }
 
   const lips: PollLip[] = [];
   for (const lip of githubData.repository.content.entries) {
+    if (typeof lip.content.text !== "string") continue;
+
     const transformedLip = fm(lip.content.text) as unknown as PollLip;
     transformedLip.attributes.created = String(
       transformedLip.attributes.created
@@ -137,8 +199,10 @@ export async function getPollLips(): Promise<PollLips> {
     projectOwner: githubData.repository.owner.login,
     projectName: githubData.repository.name,
     gitCommitHash: githubData.repository.defaultBranchRef.target.oid,
-    lips: lips.sort((a, b) =>
-      a?.attributes?.lip < b?.attributes?.lip ? 1 : -1
-    ),
+    lips: lips.sort((a, b) => {
+      const aLip = Number(a?.attributes?.lip ?? 0);
+      const bLip = Number(b?.attributes?.lip ?? 0);
+      return bLip - aLip;
+    }),
   };
 }

--- a/lib/api/poll-lips.ts
+++ b/lib/api/poll-lips.ts
@@ -1,0 +1,144 @@
+import { createApolloFetch } from "apollo-fetch";
+import fm from "front-matter";
+import { CHAIN_INFO, DEFAULT_CHAIN_ID } from "lib/chains";
+import { catIpfsJson, IpfsPoll } from "utils/ipfs";
+
+import { PollLip, PollLips } from "./types/get-poll-lips";
+
+type TransformedProposal = {
+  attributes: {
+    lip: string;
+  };
+};
+
+type GitHubLipResponse = {
+  repository?: {
+    owner: {
+      login: string;
+    };
+    name: string;
+    defaultBranchRef: {
+      target: {
+        oid: string;
+      };
+    };
+    content: {
+      entries: {
+        content: {
+          text: string;
+        };
+      }[];
+    };
+  };
+};
+
+const getLipNamespace = () =>
+  process.env.NEXT_PUBLIC_GITHUB_LIP_NAMESPACE || "livepeer";
+
+export async function getPollLips(): Promise<PollLips> {
+  const lipsQuery = `
+    {
+      repository(owner: "${getLipNamespace()}", name: "LIPS") {
+        owner {
+          login
+        }
+        name
+        defaultBranchRef {
+          target {
+            oid
+          }
+        }
+        content: object(expression: "master:LIPs/") {
+          ... on Tree {
+            entries {
+              content: object {
+                commitResourcePath
+                ... on Blob {
+                  text
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    `;
+
+  const githubFetch = createApolloFetch({
+    uri: "https://api.github.com/graphql",
+  });
+
+  githubFetch.use(({ options }, next) => {
+    if (!options.headers) {
+      options.headers = {};
+    }
+    options.headers[
+      "authorization"
+    ] = `Bearer ${process.env.GITHUB_ACCESS_TOKEN}`;
+
+    next();
+  });
+
+  const result = await githubFetch({ query: lipsQuery });
+  if (result.errors?.length) {
+    throw new Error(
+      `GitHub GraphQL returned errors: ${JSON.stringify(result.errors)}`
+    );
+  }
+
+  const githubData = result.data as GitHubLipResponse | undefined;
+  if (!githubData?.repository?.content?.entries) {
+    throw new Error(`No LIP data returned for ${getLipNamespace()}/LIPS`);
+  }
+
+  const subgraphFetch = createApolloFetch({
+    uri: CHAIN_INFO[DEFAULT_CHAIN_ID].subgraph,
+  });
+  const { data: pollsData, errors: pollsErrors } = await subgraphFetch({
+    query: `{ polls { proposal } }`,
+  });
+  if (pollsErrors?.length) {
+    throw new Error(
+      `Polls subgraph returned errors: ${JSON.stringify(pollsErrors)}`
+    );
+  }
+
+  const createdPolls: string[] = [];
+  if (pollsData) {
+    await Promise.all(
+      pollsData.polls.map(async (poll) => {
+        const obj = await catIpfsJson<IpfsPoll>(poll?.proposal);
+
+        if (obj?.text && obj?.gitCommitHash) {
+          const transformedProposal = fm(obj.text) as TransformedProposal;
+          createdPolls.push(String(transformedProposal.attributes.lip));
+        }
+      })
+    );
+  }
+
+  const lips: PollLip[] = [];
+  for (const lip of githubData.repository.content.entries) {
+    const transformedLip = fm(lip.content.text) as unknown as PollLip;
+    transformedLip.attributes.created = String(
+      transformedLip.attributes.created
+    );
+
+    if (
+      transformedLip.attributes.status === "Proposed" &&
+      !transformedLip.attributes["part-of"] &&
+      !createdPolls.includes(String(transformedLip.attributes.lip))
+    ) {
+      lips.push({ ...transformedLip, text: lip.content.text });
+    }
+  }
+
+  return {
+    projectOwner: githubData.repository.owner.login,
+    projectName: githubData.repository.name,
+    gitCommitHash: githubData.repository.defaultBranchRef.target.oid,
+    lips: lips.sort((a, b) =>
+      a?.attributes?.lip < b?.attributes?.lip ? 1 : -1
+    ),
+  };
+}

--- a/lib/api/poll-lips.ts
+++ b/lib/api/poll-lips.ts
@@ -43,6 +43,7 @@ type GraphQLResponse<T> = {
   errors?: unknown[];
 };
 
+/** Posts a GraphQL query with the shared upstream timeout. */
 async function fetchGraphQL<T>(
   uri: string,
   query: string,
@@ -64,6 +65,7 @@ async function fetchGraphQL<T>(
   return response.json() as Promise<GraphQLResponse<T>>;
 }
 
+/** Runs async work over a list while capping concurrent upstream requests. */
 async function mapWithConcurrency<T, R>(
   items: T[],
   concurrency: number,
@@ -87,6 +89,7 @@ async function mapWithConcurrency<T, R>(
   return results;
 }
 
+/** Reads a poll proposal JSON object from Livepeer's IPFS gateway. */
 async function fetchIpfsPoll(ipfsHash: string | undefined | null) {
   if (!ipfsHash) return null;
 
@@ -99,6 +102,7 @@ async function fetchIpfsPoll(ipfsHash: string | undefined | null) {
   return response.json() as Promise<IpfsPoll>;
 }
 
+/** Fetches proposed LIPs and excludes any that already have an on-chain poll. */
 export async function getPollLips(): Promise<PollLips> {
   const lipsQuery = `
     {
@@ -170,8 +174,15 @@ export async function getPollLips(): Promise<PollLips> {
         });
 
         if (obj?.text && obj?.gitCommitHash) {
-          const transformedProposal = fm(obj.text) as TransformedProposal;
-          createdPolls.push(String(transformedProposal.attributes.lip));
+          try {
+            const transformedProposal = fm(obj.text) as TransformedProposal;
+            createdPolls.push(String(transformedProposal.attributes.lip));
+          } catch (err) {
+            console.warn(
+              `[poll-lips] Failed to parse poll IPFS object ${poll?.proposal}`,
+              err
+            );
+          }
         }
       }
     );

--- a/lib/api/types/get-poll-lips.ts
+++ b/lib/api/types/get-poll-lips.ts
@@ -10,8 +10,8 @@ export type PollLip = {
 };
 
 export type PollLips = {
-  projectOwner: string | null;
-  projectName: string | null;
-  gitCommitHash: string | null;
+  projectOwner: string;
+  projectName: string;
+  gitCommitHash: string;
   lips: PollLip[];
 };

--- a/lib/api/types/get-poll-lips.ts
+++ b/lib/api/types/get-poll-lips.ts
@@ -1,0 +1,17 @@
+export type PollLip = {
+  attributes: {
+    lip: string;
+    title: string;
+    status: string;
+    created: string;
+    "part-of"?: string;
+  };
+  text: string;
+};
+
+export type PollLips = {
+  projectOwner: string | null;
+  projectName: string | null;
+  gitCommitHash: string | null;
+  lips: PollLip[];
+};

--- a/pages/api/polls/lips.ts
+++ b/pages/api/polls/lips.ts
@@ -16,7 +16,7 @@ const handler = async (
 
   try {
     const lips = await getPollLips();
-    res.setHeader("Cache-Control", getCacheControlHeader("revalidate"));
+    res.setHeader("Cache-Control", getCacheControlHeader("minute"));
     return res.status(200).json(lips);
   } catch (err) {
     res.setHeader("Cache-Control", "no-store");

--- a/pages/api/polls/lips.ts
+++ b/pages/api/polls/lips.ts
@@ -1,0 +1,31 @@
+import { getCacheControlHeader } from "@lib/api";
+import { externalApiError, methodNotAllowed } from "@lib/api/errors";
+import { getPollLips } from "@lib/api/poll-lips";
+import { PollLips } from "@lib/api/types/get-poll-lips";
+import { NextApiRequest, NextApiResponse } from "next";
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse<PollLips | null>
+) => {
+  const method = req.method;
+
+  if (method !== "GET") {
+    return methodNotAllowed(res, method ?? "unknown", ["GET"]);
+  }
+
+  try {
+    res.setHeader("Cache-Control", getCacheControlHeader("revalidate"));
+
+    const lips = await getPollLips();
+    return res.status(200).json(lips);
+  } catch (err) {
+    return externalApiError(
+      res,
+      "poll LIPs",
+      err instanceof Error ? err.message : undefined
+    );
+  }
+};
+
+export default handler;

--- a/pages/api/polls/lips.ts
+++ b/pages/api/polls/lips.ts
@@ -15,11 +15,11 @@ const handler = async (
   }
 
   try {
-    res.setHeader("Cache-Control", getCacheControlHeader("revalidate"));
-
     const lips = await getPollLips();
+    res.setHeader("Cache-Control", getCacheControlHeader("revalidate"));
     return res.status(200).json(lips);
   } catch (err) {
+    res.setHeader("Cache-Control", "no-store");
     return externalApiError(
       res,
       "poll LIPs",

--- a/pages/voting/create-poll.tsx
+++ b/pages/voting/create-poll.tsx
@@ -1,7 +1,7 @@
-import ErrorComponent from "@components/Error";
 import Spinner from "@components/Spinner";
 import { pollCreator } from "@lib/api/abis/main/PollCreator";
 import { getPollCreatorAddress } from "@lib/api/contracts";
+import { PollLips } from "@lib/api/types/get-poll-lips";
 import {
   Box,
   Button,
@@ -15,32 +15,26 @@ import {
 import { ArrowTopRightIcon } from "@radix-ui/react-icons";
 import { fromWei } from "@utils/web3";
 import { useAccountQuery } from "apollo";
-import { createApolloFetch } from "apollo-fetch";
 import { hexlify, toUtf8Bytes } from "ethers/lib/utils";
-import fm from "front-matter";
 import { useAccountAddress, usePendingFeesAndStakeData } from "hooks";
 import { useHandleTransaction } from "hooks/useHandleTransaction";
 import { LAYOUT_MAX_WIDTH } from "layouts/constants";
 import { getLayout } from "layouts/main";
-import { CHAIN_INFO, DEFAULT_CHAIN_ID } from "lib/chains";
 import Head from "next/head";
 import { useEffect, useState } from "react";
-import { addIpfs, catIpfsJson, IpfsPoll } from "utils/ipfs";
+import useSWR from "swr";
+import { addIpfs } from "utils/ipfs";
 import { Address } from "viem";
 import { useSimulateContract, useWriteContract } from "wagmi";
 
 const pollCreatorAddress = getPollCreatorAddress();
 
-const CreatePoll = ({
-  hadError,
-  projectOwner,
-  projectName,
-  gitCommitHash,
-  lips,
-}) => {
+const CreatePoll = () => {
   const accountAddress = useAccountAddress();
   const [sufficientStake, setSufficientStake] = useState(false);
   const [isCreatePollLoading, setIsCreatePollLoading] = useState(false);
+  const { data: pollLips, error: lipsError } = useSWR<PollLips>("/polls/lips");
+  const lips = pollLips?.lips ?? [];
 
   const [hash, setHash] = useState<Address | null>(null);
 
@@ -73,6 +67,10 @@ const CreatePoll = ({
     gitCommitHash: string;
     text: string;
   } | null>(null);
+
+  useEffect(() => {
+    setSelectedProposal(null);
+  }, [pollLips?.gitCommitHash]);
 
   const { data: config } = useSimulateContract({
     query: { enabled: Boolean(pollCreatorAddress && hash) },
@@ -107,10 +105,6 @@ const CreatePoll = ({
       writeContract(config.request);
     }
   }, [config, hash, writeContract, status]);
-
-  if (hadError) {
-    return <ErrorComponent statusCode={500} />;
-  }
 
   return (
     <>
@@ -150,12 +144,23 @@ const CreatePoll = ({
             }
           }}
         >
-          {lips && lips.length > 0 ? (
+          {!pollLips && !lipsError ? (
+            <Flex css={{ alignItems: "center" }}>
+              <Box css={{ marginRight: "$3" }}>Loading LIPs</Box>
+              <Spinner />
+            </Flex>
+          ) : lipsError ? (
+            <Box css={{ color: "$red11" }}>
+              Unable to load LIPs. Please try again shortly.
+            </Box>
+          ) : lips.length > 0 ? (
             <>
               <RadioCardGroup
                 onValueChange={(value) => {
+                  if (!pollLips?.gitCommitHash) return;
+
                   setSelectedProposal({
-                    gitCommitHash,
+                    gitCommitHash: pollLips.gitCommitHash,
                     text: lips[value].text,
                   });
                 }}
@@ -188,7 +193,7 @@ const CreatePoll = ({
                       }}
                       target="_blank"
                       rel="noopener noreferrer"
-                      href={`https://github.com/${projectOwner}/${projectName}/blob/master/LIPs/LIP-${lip.attributes.lip}.md`}
+                      href={`https://github.com/${pollLips?.projectOwner}/${pollLips?.projectName}/blob/master/LIPs/LIP-${lip.attributes.lip}.md`}
                     >
                       View Proposal
                       <ArrowTopRightIcon />
@@ -262,136 +267,3 @@ const CreatePoll = ({
 CreatePoll.getLayout = getLayout;
 
 export default CreatePoll;
-
-type TransformedProposal = {
-  attributes: {
-    lip: string;
-  };
-};
-
-type TransformedLip = {
-  attributes: {
-    lip: string;
-    title: string;
-    status: string;
-    created: string;
-    "part-of"?: string;
-  };
-  text: string;
-};
-
-export async function getStaticProps() {
-  try {
-    const lipsQuery = `
-    {
-      repository(owner: "${
-        process.env.NEXT_PUBLIC_GITHUB_LIP_NAMESPACE
-          ? process.env.NEXT_PUBLIC_GITHUB_LIP_NAMESPACE
-          : "livepeer"
-      }", name: "LIPS") {
-        owner {
-          login
-        }
-        name
-        defaultBranchRef {
-          target {
-            oid
-          }
-        }
-        content: object(expression: "master:LIPs/") {
-          ... on Tree {
-            entries {
-              content: object {
-                commitResourcePath
-                ... on Blob {
-                  text
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    `;
-
-    const apolloFetch = createApolloFetch({
-      uri: "https://api.github.com/graphql",
-    });
-
-    apolloFetch.use(({ options }, next) => {
-      if (!options.headers) {
-        options.headers = {}; // Create the headers object if needed.
-      }
-      options.headers[
-        "authorization"
-      ] = `Bearer ${process.env.GITHUB_ACCESS_TOKEN}`;
-
-      next();
-    });
-    const result = await apolloFetch({ query: lipsQuery });
-    const apolloSubgraphFetch = createApolloFetch({
-      uri: CHAIN_INFO[DEFAULT_CHAIN_ID].subgraph,
-    });
-    const { data: pollsData } = await apolloSubgraphFetch({
-      query: `{ polls { proposal } }`,
-    });
-
-    const createdPolls: string[] = [];
-    if (pollsData) {
-      await Promise.all(
-        pollsData.polls.map(async (poll) => {
-          const obj = await catIpfsJson<IpfsPoll>(poll?.proposal);
-
-          // check if proposal is valid format {text, gitCommitHash}
-          if (obj?.text && obj?.gitCommitHash) {
-            const transformedProposal = fm(obj.text) as TransformedProposal;
-            createdPolls.push(transformedProposal.attributes.lip);
-          }
-        })
-      );
-    }
-
-    const lips: TransformedLip[] = [];
-    if (result.data) {
-      for (const lip of result.data.repository.content.entries) {
-        const transformedLip = fm(
-          lip.content.text
-        ) as unknown as TransformedLip;
-        transformedLip.attributes.created =
-          transformedLip.attributes.created.toString();
-        if (
-          transformedLip.attributes.status === "Proposed" &&
-          !transformedLip.attributes["part-of"] &&
-          !createdPolls.includes(transformedLip.attributes.lip)
-        )
-          lips.push({ ...transformedLip, text: lip.content.text });
-      }
-    } else {
-      console.log(
-        `No data from apollo fetch: ${JSON.stringify(result, null, 2)}`
-      );
-    }
-
-    return {
-      props: {
-        projectOwner: result?.data ? result.data.repository.owner.login : null,
-        projectName: result?.data ? result.data.repository.name : null,
-        gitCommitHash: result?.data
-          ? result.data.repository.defaultBranchRef.target.oid
-          : null,
-        lips: lips.sort((a, b) =>
-          a?.attributes?.lip < b?.attributes?.lip ? 1 : -1
-        ),
-      },
-      revalidate: 30,
-    };
-  } catch (e) {
-    console.log(e);
-    return {
-      props: {
-        hadError: true,
-      },
-      revalidate: 60,
-    };
-  }
-}

--- a/pages/voting/create-poll.tsx
+++ b/pages/voting/create-poll.tsx
@@ -383,7 +383,7 @@ export async function getStaticProps() {
           a?.attributes?.lip < b?.attributes?.lip ? 1 : -1
         ),
       },
-      revalidate: 300,
+      revalidate: 30,
     };
   } catch (e) {
     console.log(e);

--- a/pages/voting/create-poll.tsx
+++ b/pages/voting/create-poll.tsx
@@ -21,10 +21,9 @@ import { useHandleTransaction } from "hooks/useHandleTransaction";
 import { LAYOUT_MAX_WIDTH } from "layouts/constants";
 import { getLayout } from "layouts/main";
 import Head from "next/head";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
 import { addIpfs } from "utils/ipfs";
-import { Address } from "viem";
 import { useSimulateContract, useWriteContract } from "wagmi";
 
 const pollCreatorAddress = getPollCreatorAddress();
@@ -34,9 +33,9 @@ const CreatePoll = () => {
   const [sufficientStake, setSufficientStake] = useState(false);
   const [isCreatePollLoading, setIsCreatePollLoading] = useState(false);
   const { data: pollLips, error: lipsError } = useSWR<PollLips>("/polls/lips");
-  const lips = pollLips?.lips ?? [];
+  const lips = useMemo(() => pollLips?.lips ?? [], [pollLips?.lips]);
 
-  const [hash, setHash] = useState<Address | null>(null);
+  const [hash, setHash] = useState<string | null>(null);
 
   const { data, loading } = useAccountQuery({
     variables: {
@@ -64,13 +63,19 @@ const CreatePoll = () => {
   }, [delegatorPendingStakeAndFees]);
 
   const [selectedProposal, setSelectedProposal] = useState<{
+    lip: string;
     gitCommitHash: string;
     text: string;
   } | null>(null);
 
   useEffect(() => {
-    setSelectedProposal(null);
-  }, [pollLips?.gitCommitHash]);
+    if (
+      selectedProposal &&
+      !lips.some((lip) => lip.attributes.lip === selectedProposal.lip)
+    ) {
+      setSelectedProposal(null);
+    }
+  }, [lips, selectedProposal]);
 
   const { data: config } = useSimulateContract({
     query: { enabled: Boolean(pollCreatorAddress && hash) },
@@ -131,9 +136,12 @@ const CreatePoll = () => {
               if (!selectedProposal) {
                 return;
               }
-              const hash = await addIpfs(selectedProposal);
+              const hash = await addIpfs({
+                gitCommitHash: selectedProposal.gitCommitHash,
+                text: selectedProposal.text,
+              });
 
-              setHash(hash as Address);
+              setHash(hash);
             } catch (err) {
               console.error(err);
               return {
@@ -157,18 +165,25 @@ const CreatePoll = () => {
             <>
               <RadioCardGroup
                 onValueChange={(value) => {
-                  if (!pollLips?.gitCommitHash) return;
+                  const selectedLip = lips.find(
+                    (lip) => lip.attributes.lip === value
+                  );
+                  if (!selectedLip) {
+                    setSelectedProposal(null);
+                    return;
+                  }
 
                   setSelectedProposal({
-                    gitCommitHash: pollLips.gitCommitHash,
-                    text: lips[value].text,
+                    lip: selectedLip.attributes.lip,
+                    gitCommitHash: pollLips!.gitCommitHash,
+                    text: selectedLip.text,
                   });
                 }}
               >
-                {lips.map((lip, i) => (
+                {lips.map((lip) => (
                   <RadioCard
-                    key={i}
-                    value={i.toString()}
+                    key={lip.attributes.lip}
+                    value={lip.attributes.lip}
                     css={{
                       width: "100%",
                       justifyContent: "space-between",
@@ -193,7 +208,11 @@ const CreatePoll = () => {
                       }}
                       target="_blank"
                       rel="noopener noreferrer"
-                      href={`https://github.com/${pollLips?.projectOwner}/${pollLips?.projectName}/blob/master/LIPs/LIP-${lip.attributes.lip}.md`}
+                      href={`https://github.com/${pollLips!.projectOwner}/${
+                        pollLips!.projectName
+                      }/blob/${pollLips!.gitCommitHash}/LIPs/LIP-${
+                        lip.attributes.lip
+                      }.md`}
                     >
                       View Proposal
                       <ArrowTopRightIcon />


### PR DESCRIPTION
## Description

This updates Create Poll so eligible LIPs are loaded at runtime through a short-cached API route instead of being baked into the page with ISR. That makes new proposed LIPs appear after reload almost immediately, while preserving the existing filtering for LIPs that are proposed, not part of another LIP, and do not already have a poll.

## Type of Change

<!-- Check all that apply -->

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [ ] style: Code style/formatting changes (no logic changes)
- [ ] refactor: Code refactoring (no behavior change)
- [ ] perf: Performance improvement
- [ ] test: Adding or updating tests
- [ ] build: Build system or dependency changes
- [ ] ci: CI/CD changes
- [ ] chore: Other changes

## Related Issue(s)

Closes: #562 

## Changes Made

- Moves Create Poll LIP loading from getStaticProps ISR to a runtime API route.
- Adds `GET /api/polls/lips` with short CDN stale-while-revalidate caching.
- Updates `/voting/create-poll` to fetch LIPs via SWR and show loading/error states.
- Keeps existing filtering for proposed LIPs without existing polls.

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests passing

### How to test

- Somewhat cumbersome to test
- You could either temporarily add a new LIP on the official Livepeer repo, or you could fork the LIP repo and update the envs locally or in the preview
- Considering that this is cumbersome, I am noting that this worked with a local build and a Vercel preview build using a forked LIP repo

## Impact / Risk

Risk level: Low

Impacted areas: UI / API

User impact: Those trying to put their LIP on-chain through `/voting/create-poll` no longer have to wait until the site is redeployed to see their GitHub version of the proposal.

Rollback plan: Vercel rollback, then manual git revert.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `GET /api/polls/lips` endpoint to fetch the latest available Poll LIPs at runtime.
  * Updated the create-poll page to load Poll LIPs via SWR and construct the “View Proposal” link from the fetched project metadata.

* **Bug Fixes**
  * Prevent stale submissions by clearing the selected LIP when the available list changes.
  * Improved request handling with GET-only enforcement and safer cache behavior (including no-store on fetch failures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->