### PR TITLE
feat: preserve orch table state on back nav

### DIFF
--- a/components/GatewayList/index.tsx
+++ b/components/GatewayList/index.tsx
@@ -28,6 +28,10 @@ type GatewayRow = NonNullable<GatewaysQuery["gateways"]>[number] & {
   totalVolumeNumber: number;
 };
 
+const DEFAULT_SORT_BY: SortingRule<GatewayRow>[] = [
+  { id: "ninetyDayVolumeNumber", desc: true },
+];
+
 const GatewayList = ({
   data,
   listKey,
@@ -44,10 +48,6 @@ const GatewayList = ({
       listKey,
       routePath,
     });
-  const defaultSortBy = useMemo<SortingRule<GatewayRow>[]>(
-    () => [{ id: "ninetyDayVolumeNumber", desc: true }],
-    []
-  );
   const rows: GatewayRow[] = useMemo(
     () =>
       (data ?? []).map((gateway) => ({
@@ -335,7 +335,7 @@ const GatewayList = ({
           pageSize,
           sortBy: persistedState.sortBy.length
             ? (persistedState.sortBy as SortingRule<GatewayRow>[])
-            : defaultSortBy,
+            : DEFAULT_SORT_BY,
         }}
       />
     </Box>

--- a/components/GatewayList/index.tsx
+++ b/components/GatewayList/index.tsx
@@ -16,10 +16,10 @@ import {
 } from "@livepeer/design-system";
 import { DotsHorizontalIcon } from "@radix-ui/react-icons";
 import { GatewaysQuery } from "apollo";
-import { useEnsData } from "hooks";
+import { useEnsData, usePersistedExplorerListState } from "hooks";
 import Link from "next/link";
 import { useMemo } from "react";
-import { Column } from "react-table";
+import { Column, SortingRule } from "react-table";
 
 type GatewayRow = NonNullable<GatewaysQuery["gateways"]>[number] & {
   depositNumber: number;
@@ -30,11 +30,24 @@ type GatewayRow = NonNullable<GatewaysQuery["gateways"]>[number] & {
 
 const GatewayList = ({
   data,
+  listKey,
   pageSize = 10,
+  routePath,
 }: {
+  listKey: string;
   pageSize?: number;
+  routePath: string;
   data: GatewaysQuery["gateways"] | undefined;
 }) => {
+  const { handleTableStateChange, persistedState, saveCurrentScroll } =
+    usePersistedExplorerListState<GatewayRow>({
+      listKey,
+      routePath,
+    });
+  const defaultSortBy = useMemo<SortingRule<GatewayRow>[]>(
+    () => [{ id: "ninetyDayVolumeNumber", desc: true }],
+    []
+  );
   const rows: GatewayRow[] = useMemo(
     () =>
       (data ?? []).map((gateway) => ({
@@ -310,15 +323,22 @@ const GatewayList = ({
   }
 
   return (
-    <Table
-      data={rows}
-      columns={columns}
-      initialState={{
-        pageIndex: 0,
-        pageSize,
-        sortBy: [{ id: "ninetyDayVolumeNumber", desc: true }],
-      }}
-    />
+    <Box onClickCapture={saveCurrentScroll}>
+      <Table
+        data={rows}
+        columns={columns}
+        autoResetPage={false}
+        autoResetSortBy={false}
+        onStateChange={handleTableStateChange}
+        initialState={{
+          pageIndex: persistedState.pageIndex,
+          pageSize,
+          sortBy: persistedState.sortBy.length
+            ? (persistedState.sortBy as SortingRule<GatewayRow>[])
+            : defaultSortBy,
+        }}
+      />
+    </Box>
   );
 };
 

--- a/components/OrchestratorList/index.tsx
+++ b/components/OrchestratorList/index.tsx
@@ -51,7 +51,7 @@ import { OrchestratorListKey, useEnsData, useExplorerStore } from "hooks";
 import { useBondingManagerAddress } from "hooks/useContracts";
 import Link from "next/link";
 import Router from "next/router";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SortingRule } from "react-table";
 import { formatUnits } from "viem";
 import { useReadContract } from "wagmi";
@@ -133,6 +133,7 @@ const OrchestratorList = ({
   const setOrchestratorListState = useExplorerStore(
     (state) => state.setOrchestratorListState
   );
+  const activeRestoreCleanup = useRef<(() => void) | undefined>(undefined);
   // Derive protocol inflation data
   const inflationRate =
     Number(protocolData?.inflation || 0) / PERCENTAGE_PRECISION_BILLION;
@@ -193,29 +194,64 @@ const OrchestratorList = ({
       return;
     }
 
-    let frameCount = 0;
-    let frameId: number;
-    const restoreScroll = () => {
-      window.scrollTo(0, scrollY);
-      frameCount += 1;
+    const getMaxScrollY = () =>
+      Math.max(
+        document.documentElement.scrollHeight,
+        document.body.scrollHeight
+      ) - window.innerHeight;
 
-      if (frameCount < 10 && Math.abs(window.scrollY - scrollY) > 2) {
+    const isAtSavedScroll = () => Math.abs(window.scrollY - scrollY) <= 2;
+    const isTallEnough = () => getMaxScrollY() >= scrollY;
+
+    if (isTallEnough() && isAtSavedScroll()) {
+      return;
+    }
+
+    const startedAt = Date.now();
+    const maxRestoreMs = 2000;
+    let frameId: number | undefined;
+    let cancelled = false;
+
+    const restoreScroll = () => {
+      if (cancelled) {
+        return;
+      }
+
+      if (isTallEnough()) {
+        window.scrollTo(0, scrollY);
+      }
+
+      if (
+        (!isTallEnough() || !isAtSavedScroll()) &&
+        Date.now() - startedAt < maxRestoreMs
+      ) {
         frameId = requestAnimationFrame(restoreScroll);
       }
     };
 
     frameId = requestAnimationFrame(restoreScroll);
-    const timeoutId = window.setTimeout(() => {
-      window.scrollTo(0, scrollY);
-    }, 250);
 
     return () => {
-      cancelAnimationFrame(frameId);
-      window.clearTimeout(timeoutId);
+      cancelled = true;
+      if (frameId !== undefined) {
+        cancelAnimationFrame(frameId);
+      }
     };
   }, [listKey, persistedState.scrollY]);
 
-  useEffect(() => restoreSavedScroll(), [restoreSavedScroll]);
+  const startScrollRestore = useCallback(() => {
+    activeRestoreCleanup.current?.();
+    activeRestoreCleanup.current = restoreSavedScroll();
+  }, [restoreSavedScroll]);
+
+  useEffect(() => {
+    startScrollRestore();
+
+    return () => {
+      activeRestoreCleanup.current?.();
+      activeRestoreCleanup.current = undefined;
+    };
+  }, [startScrollRestore]);
 
   useEffect(() => {
     let frameId: number | null = null;
@@ -235,7 +271,7 @@ const OrchestratorList = ({
       const path = url.split("?")[0].split("#")[0];
 
       if (path === getListPath(listKey)) {
-        restoreSavedScroll();
+        startScrollRestore();
       }
     };
 
@@ -250,7 +286,7 @@ const OrchestratorList = ({
       Router.events.off("routeChangeStart", saveCurrentScroll);
       Router.events.off("routeChangeComplete", restoreAfterRouteChange);
     };
-  }, [listKey, restoreSavedScroll, saveCurrentScroll]);
+  }, [listKey, saveCurrentScroll, startScrollRestore]);
 
   const formattedPrinciple = formatLPT(Number(principle) || 150, {
     precision: 0,
@@ -1346,10 +1382,15 @@ const OrchestratorList = ({
                           size="2"
                           value={principle}
                           onChange={(e) => {
+                            const nextValue = Number(e.target.value);
                             setPrinciple(
-                              Number(e.target.value) > maxSupplyTokens
+                              !Number.isFinite(nextValue)
+                                ? 1
+                                : nextValue < 1
+                                ? 1
+                                : nextValue > maxSupplyTokens
                                 ? maxSupplyTokens
-                                : Number(e.target.value)
+                                : nextValue
                             );
                           }}
                           min="1"

--- a/components/OrchestratorList/index.tsx
+++ b/components/OrchestratorList/index.tsx
@@ -47,10 +47,12 @@ import {
   PERCENTAGE_PRECISION_MILLION,
 } from "@utils/web3";
 import { OrchestratorsQueryResult, ProtocolQueryResult } from "apollo";
-import { useEnsData } from "hooks";
+import { OrchestratorListKey, useEnsData, useExplorerStore } from "hooks";
 import { useBondingManagerAddress } from "hooks/useContracts";
 import Link from "next/link";
-import { useCallback, useMemo, useState } from "react";
+import Router from "next/router";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { SortingRule } from "react-table";
 import { formatUnits } from "viem";
 import { useReadContract } from "wagmi";
 
@@ -76,11 +78,47 @@ const formatFactors = (factors: ROIFactors) =>
     ? `LPT Only`
     : `ETH Only`;
 
+const getScrollStorageKey = (listKey: OrchestratorListKey) =>
+  `livepeer:orchestrator-list:${listKey}:scrollY`;
+
+const getListPath = (listKey: OrchestratorListKey) =>
+  listKey === "home" ? "/" : "/orchestrators";
+
+const readStoredScrollY = (listKey: OrchestratorListKey) => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const value = window.sessionStorage.getItem(getScrollStorageKey(listKey));
+    const scrollY = value ? Number(value) : NaN;
+
+    return Number.isFinite(scrollY) ? scrollY : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeStoredScrollY = (listKey: OrchestratorListKey, scrollY: number) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(
+      getScrollStorageKey(listKey),
+      `${Math.max(0, Math.round(scrollY))}`
+    );
+  } catch {}
+};
+
 const OrchestratorList = ({
   data,
+  listKey,
   protocolData,
   pageSize = 10,
 }: {
+  listKey: OrchestratorListKey;
   pageSize: number;
   protocolData:
     | NonNullable<ProtocolQueryResult["data"]>["protocol"]
@@ -89,6 +127,12 @@ const OrchestratorList = ({
     | NonNullable<OrchestratorsQueryResult["data"]>["transcoders"]
     | undefined;
 }) => {
+  const persistedState = useExplorerStore(
+    (state) => state.orchestratorLists[listKey]
+  );
+  const setOrchestratorListState = useExplorerStore(
+    (state) => state.setOrchestratorListState
+  );
   // Derive protocol inflation data
   const inflationRate =
     Number(protocolData?.inflation || 0) / PERCENTAGE_PRECISION_BILLION;
@@ -108,15 +152,105 @@ const OrchestratorList = ({
     [inflationRate, inflationChangeAmount]
   );
 
-  const [principle, setPrinciple] = useState<number>(150);
-  const [inflationChange, setInflationChange] =
-    useState<ROIInflationChange>("none");
-  const [factors, setFactors] = useState<ROIFactors>("lpt+eth");
-  const [timeHorizon, setTimeHorizon] = useState<ROITimeHorizon>("one-year");
+  const [principle, setPrinciple] = useState<number>(persistedState.principle);
+  const [inflationChange, setInflationChange] = useState<ROIInflationChange>(
+    persistedState.inflationChange
+  );
+  const [factors, setFactors] = useState<ROIFactors>(persistedState.factors);
+  const [timeHorizon, setTimeHorizon] = useState<ROITimeHorizon>(
+    persistedState.timeHorizon
+  );
   const maxSupplyTokens = useMemo(
     () => Math.floor(Number(protocolData?.totalSupply || 1e7)),
     [protocolData]
   );
+
+  useEffect(() => {
+    setOrchestratorListState(listKey, {
+      factors,
+      inflationChange,
+      principle,
+      timeHorizon,
+    });
+  }, [
+    factors,
+    inflationChange,
+    listKey,
+    principle,
+    setOrchestratorListState,
+    timeHorizon,
+  ]);
+
+  const saveCurrentScroll = useCallback(() => {
+    writeStoredScrollY(listKey, window.scrollY);
+    setOrchestratorListState(listKey, { scrollY: window.scrollY });
+  }, [listKey, setOrchestratorListState]);
+
+  const restoreSavedScroll = useCallback(() => {
+    const scrollY = readStoredScrollY(listKey) ?? persistedState.scrollY;
+
+    if (scrollY <= 0) {
+      return;
+    }
+
+    let frameCount = 0;
+    let frameId: number;
+    const restoreScroll = () => {
+      window.scrollTo(0, scrollY);
+      frameCount += 1;
+
+      if (frameCount < 10 && Math.abs(window.scrollY - scrollY) > 2) {
+        frameId = requestAnimationFrame(restoreScroll);
+      }
+    };
+
+    frameId = requestAnimationFrame(restoreScroll);
+    const timeoutId = window.setTimeout(() => {
+      window.scrollTo(0, scrollY);
+    }, 250);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      window.clearTimeout(timeoutId);
+    };
+  }, [listKey, persistedState.scrollY]);
+
+  useEffect(() => restoreSavedScroll(), [restoreSavedScroll]);
+
+  useEffect(() => {
+    let frameId: number | null = null;
+    const saveScrollToStorage = () => {
+      if (frameId !== null) {
+        return;
+      }
+
+      frameId = requestAnimationFrame(() => {
+        frameId = null;
+        writeStoredScrollY(listKey, window.scrollY);
+      });
+    };
+
+    window.addEventListener("scroll", saveScrollToStorage, { passive: true });
+    const restoreAfterRouteChange = (url: string) => {
+      const path = url.split("?")[0].split("#")[0];
+
+      if (path === getListPath(listKey)) {
+        restoreSavedScroll();
+      }
+    };
+
+    Router.events.on("routeChangeStart", saveCurrentScroll);
+    Router.events.on("routeChangeComplete", restoreAfterRouteChange);
+
+    return () => {
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId);
+      }
+      window.removeEventListener("scroll", saveScrollToStorage);
+      Router.events.off("routeChangeStart", saveCurrentScroll);
+      Router.events.off("routeChangeComplete", restoreAfterRouteChange);
+    };
+  }, [listKey, restoreSavedScroll, saveCurrentScroll]);
 
   const formattedPrinciple = formatLPT(Number(principle) || 150, {
     precision: 0,
@@ -1014,135 +1148,57 @@ const OrchestratorList = ({
     [formattedPrinciple, timeHorizon, factors]
   );
 
-  return (
-    <Table
-      data={mappedData as object[]}
-      columns={columns}
-      initialState={{
-        pageSize,
-        hiddenColumns: ["identity"],
-        sortBy: [
-          {
-            id: "earnings",
-            desc: true,
-          },
-        ],
-      }}
-      input={
-        <Box css={{ marginBottom: "$2" }}>
-          <Flex css={{ alignItems: "center", marginBottom: "$2" }}>
-            <Box css={{ marginRight: "$1", color: "$neutral11" }}>
-              <YieldChartIcon />
-            </Box>
-            <Text
-              variant="neutral"
-              size="1"
-              css={{
-                marginLeft: "$1",
-                textTransform: "uppercase",
-                fontWeight: 600,
-              }}
-            >
-              {"Forecasted Yield Assumptions"}
-            </Text>
-          </Flex>
-          <Flex>
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                onClick={(e) => {
-                  e.stopPropagation();
-                }}
-                asChild
-              >
-                <Badge
-                  size="2"
-                  css={{
-                    cursor: "pointer",
-                    color: "$white",
-                    fontSize: "$2",
-                  }}
-                >
-                  <Box css={{ marginRight: "$1" }}>
-                    <Pencil1Icon />
-                  </Box>
+  const handleTableStateChange = useCallback(
+    ({
+      pageIndex,
+      sortBy,
+    }: {
+      pageIndex: number;
+      sortBy: SortingRule<object>[];
+    }) => {
+      setOrchestratorListState(listKey, {
+        pageIndex,
+        sortBy,
+      });
+    },
+    [listKey, setOrchestratorListState]
+  );
 
-                  <Text
-                    variant="neutral"
-                    size="1"
-                    css={{
-                      marginRight: 3,
-                    }}
-                  >
-                    {"Time horizon:"}
-                  </Text>
-                  <Text
-                    size="1"
-                    css={{
-                      color: "white",
-                      fontWeight: 600,
-                    }}
-                  >
-                    {formatTimeHorizon(timeHorizon)}
-                  </Text>
-                </Badge>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent
+  return (
+    <Box onClickCapture={saveCurrentScroll}>
+      <Table
+        data={mappedData as object[]}
+        columns={columns}
+        autoResetPage={false}
+        autoResetSortBy={false}
+        onStateChange={handleTableStateChange}
+        initialState={{
+          pageIndex: persistedState.pageIndex,
+          pageSize,
+          hiddenColumns: ["identity"],
+          sortBy: persistedState.sortBy,
+        }}
+        input={
+          <Box css={{ marginBottom: "$2" }}>
+            <Flex css={{ alignItems: "center", marginBottom: "$2" }}>
+              <Box css={{ marginRight: "$1", color: "$neutral11" }}>
+                <YieldChartIcon />
+              </Box>
+              <Text
+                variant="neutral"
+                size="1"
                 css={{
-                  width: "200px",
-                  mt: "$1",
-                  boxShadow:
-                    "0px 5px 14px rgba(0, 0, 0, 0.22), 0px 0px 2px rgba(0, 0, 0, 0.2)",
-                  bc: "$neutral4",
+                  marginLeft: "$1",
+                  textTransform: "uppercase",
+                  fontWeight: 600,
                 }}
-                align="center"
               >
-                <DropdownMenuGroup>
-                  <DropdownMenuItem
-                    css={{
-                      cursor: "pointer",
-                    }}
-                    onSelect={() => setTimeHorizon("half-year")}
-                  >
-                    {"6 months"}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    css={{
-                      cursor: "pointer",
-                    }}
-                    onSelect={() => setTimeHorizon("one-year")}
-                  >
-                    {"1 year"}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    css={{
-                      cursor: "pointer",
-                    }}
-                    onSelect={() => setTimeHorizon("two-years")}
-                  >
-                    {"2 years"}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    css={{
-                      cursor: "pointer",
-                    }}
-                    onSelect={() => setTimeHorizon("three-years")}
-                  >
-                    {"3 years"}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    css={{
-                      cursor: "pointer",
-                    }}
-                    onSelect={() => setTimeHorizon("four-years")}
-                  >
-                    {"4 years"}
-                  </DropdownMenuItem>
-                </DropdownMenuGroup>
-              </DropdownMenuContent>
-            </DropdownMenu>
-            <Box css={{ marginLeft: "$1" }}>
-              <Popover>
-                <PopoverTrigger
+                {"Forecasted Yield Assumptions"}
+              </Text>
+            </Flex>
+            <Flex>
+              <DropdownMenu>
+                <DropdownMenuTrigger
                   onClick={(e) => {
                     e.stopPropagation();
                   }}
@@ -1159,6 +1215,7 @@ const OrchestratorList = ({
                     <Box css={{ marginRight: "$1" }}>
                       <Pencil1Icon />
                     </Box>
+
                     <Text
                       variant="neutral"
                       size="1"
@@ -1166,7 +1223,7 @@ const OrchestratorList = ({
                         marginRight: 3,
                       }}
                     >
-                      {"Delegation:"}
+                      {"Time horizon:"}
                     </Text>
                     <Text
                       size="1"
@@ -1175,216 +1232,310 @@ const OrchestratorList = ({
                         fontWeight: 600,
                       }}
                     >
-                      {formatLPT(principle, { precision: 1 })}
+                      {formatTimeHorizon(timeHorizon)}
                     </Text>
                   </Badge>
-                </PopoverTrigger>
-                <PopoverContent
-                  css={{ width: 300, borderRadius: "$4", bc: "$neutral4" }}
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  css={{
+                    width: "200px",
+                    mt: "$1",
+                    boxShadow:
+                      "0px 5px 14px rgba(0, 0, 0, 0.22), 0px 0px 2px rgba(0, 0, 0, 0.2)",
+                    bc: "$neutral4",
+                  }}
+                  align="center"
                 >
-                  <Box
-                    css={{
-                      borderBottom: "1px solid $neutral6",
-                      padding: "$3",
+                  <DropdownMenuGroup>
+                    <DropdownMenuItem
+                      css={{
+                        cursor: "pointer",
+                      }}
+                      onSelect={() => setTimeHorizon("half-year")}
+                    >
+                      {"6 months"}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      css={{
+                        cursor: "pointer",
+                      }}
+                      onSelect={() => setTimeHorizon("one-year")}
+                    >
+                      {"1 year"}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      css={{
+                        cursor: "pointer",
+                      }}
+                      onSelect={() => setTimeHorizon("two-years")}
+                    >
+                      {"2 years"}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      css={{
+                        cursor: "pointer",
+                      }}
+                      onSelect={() => setTimeHorizon("three-years")}
+                    >
+                      {"3 years"}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      css={{
+                        cursor: "pointer",
+                      }}
+                      onSelect={() => setTimeHorizon("four-years")}
+                    >
+                      {"4 years"}
+                    </DropdownMenuItem>
+                  </DropdownMenuGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+              <Box css={{ marginLeft: "$1" }}>
+                <Popover>
+                  <PopoverTrigger
+                    onClick={(e) => {
+                      e.stopPropagation();
                     }}
+                    asChild
                   >
-                    <Flex align="center">
-                      <TextField
-                        name="principle"
-                        placeholder="Amount in LPT"
-                        type="number"
-                        size="2"
-                        value={principle}
-                        onChange={(e) => {
-                          setPrinciple(
-                            Number(e.target.value) > maxSupplyTokens
-                              ? maxSupplyTokens
-                              : Number(e.target.value)
-                          );
-                        }}
-                        min="1"
-                        max={`${Number(
-                          protocolData?.totalSupply || 1e7
-                        ).toFixed(0)}`}
-                      />
+                    <Badge
+                      size="2"
+                      css={{
+                        cursor: "pointer",
+                        color: "$white",
+                        fontSize: "$2",
+                      }}
+                    >
+                      <Box css={{ marginRight: "$1" }}>
+                        <Pencil1Icon />
+                      </Box>
                       <Text
                         variant="neutral"
-                        size="3"
+                        size="1"
                         css={{
-                          marginLeft: "$2",
-                          fontWeight: 600,
-                          textTransform: "uppercase",
+                          marginRight: 3,
                         }}
                       >
-                        LPT
+                        {"Delegation:"}
                       </Text>
-                    </Flex>
-                  </Box>
-                </PopoverContent>
-              </Popover>
-            </Box>
-            <Box css={{ marginLeft: "$1" }}>
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  onClick={(e) => {
-                    e.stopPropagation();
-                  }}
-                  asChild
-                >
-                  <Badge
-                    size="2"
-                    css={{
-                      cursor: "pointer",
-                      color: "$white",
-                      fontSize: "$2",
-                    }}
+                      <Text
+                        size="1"
+                        css={{
+                          color: "white",
+                          fontWeight: 600,
+                        }}
+                      >
+                        {formatLPT(principle, { precision: 1 })}
+                      </Text>
+                    </Badge>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    css={{ width: 300, borderRadius: "$4", bc: "$neutral4" }}
                   >
-                    <Box css={{ marginRight: "$1" }}>
-                      <Pencil1Icon />
+                    <Box
+                      css={{
+                        borderBottom: "1px solid $neutral6",
+                        padding: "$3",
+                      }}
+                    >
+                      <Flex align="center">
+                        <TextField
+                          name="principle"
+                          placeholder="Amount in LPT"
+                          type="number"
+                          size="2"
+                          value={principle}
+                          onChange={(e) => {
+                            setPrinciple(
+                              Number(e.target.value) > maxSupplyTokens
+                                ? maxSupplyTokens
+                                : Number(e.target.value)
+                            );
+                          }}
+                          min="1"
+                          max={`${Number(
+                            protocolData?.totalSupply || 1e7
+                          ).toFixed(0)}`}
+                        />
+                        <Text
+                          variant="neutral"
+                          size="3"
+                          css={{
+                            marginLeft: "$2",
+                            fontWeight: 600,
+                            textTransform: "uppercase",
+                          }}
+                        >
+                          LPT
+                        </Text>
+                      </Flex>
                     </Box>
-
-                    <Text
-                      variant="neutral"
-                      size="1"
-                      css={{
-                        marginRight: 3,
-                      }}
-                    >
-                      {"Factors:"}
-                    </Text>
-                    <Text
-                      size="1"
-                      css={{
-                        color: "white",
-                        fontWeight: 600,
-                      }}
-                    >
-                      {formatFactors(factors)}
-                    </Text>
-                  </Badge>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  css={{
-                    width: "200px",
-                    mt: "$1",
-                    boxShadow:
-                      "0px 5px 14px rgba(0, 0, 0, 0.22), 0px 0px 2px rgba(0, 0, 0, 0.2)",
-                    bc: "$neutral4",
-                  }}
-                  align="center"
-                >
-                  <DropdownMenuGroup>
-                    <DropdownMenuItem
-                      css={{
-                        cursor: "pointer",
-                      }}
-                      onSelect={() => setFactors("lpt+eth")}
-                    >
-                      {formatFactors("lpt+eth")}
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      css={{
-                        cursor: "pointer",
-                      }}
-                      onSelect={() => setFactors("lpt")}
-                    >
-                      {formatFactors("lpt")}
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      css={{
-                        cursor: "pointer",
-                      }}
-                      onSelect={() => setFactors("eth")}
-                    >
-                      {formatFactors("eth")}
-                    </DropdownMenuItem>
-                  </DropdownMenuGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </Box>
-            <Box css={{ marginLeft: "$1" }}>
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  onClick={(e) => {
-                    e.stopPropagation();
-                  }}
-                  asChild
-                >
-                  <Badge
-                    size="2"
-                    css={{
-                      cursor: "pointer",
-                      color: "$white",
-                      fontSize: "$2",
+                  </PopoverContent>
+                </Popover>
+              </Box>
+              <Box css={{ marginLeft: "$1" }}>
+                <DropdownMenu>
+                  <DropdownMenuTrigger
+                    onClick={(e) => {
+                      e.stopPropagation();
                     }}
+                    asChild
                   >
-                    <Box css={{ marginRight: "$1" }}>
-                      <Pencil1Icon />
-                    </Box>
+                    <Badge
+                      size="2"
+                      css={{
+                        cursor: "pointer",
+                        color: "$white",
+                        fontSize: "$2",
+                      }}
+                    >
+                      <Box css={{ marginRight: "$1" }}>
+                        <Pencil1Icon />
+                      </Box>
 
-                    <Text
-                      variant="neutral"
-                      size="1"
-                      css={{
-                        marginRight: 3,
-                      }}
-                    >
-                      {"Inflation change:"}
-                    </Text>
-                    <Text
-                      size="1"
-                      css={{
-                        color: "white",
-                        fontWeight: 600,
-                      }}
-                    >
-                      {formatPercentChange(inflationChange)}
-                    </Text>
-                  </Badge>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  css={{
-                    width: "200px",
-                    mt: "$1",
-                    boxShadow:
-                      "0px 5px 14px rgba(0, 0, 0, 0.22), 0px 0px 2px rgba(0, 0, 0, 0.2)",
-                    bc: "$neutral4",
-                  }}
-                  align="center"
-                >
-                  <DropdownMenuGroup>
-                    <DropdownMenuItem
+                      <Text
+                        variant="neutral"
+                        size="1"
+                        css={{
+                          marginRight: 3,
+                        }}
+                      >
+                        {"Factors:"}
+                      </Text>
+                      <Text
+                        size="1"
+                        css={{
+                          color: "white",
+                          fontWeight: 600,
+                        }}
+                      >
+                        {formatFactors(factors)}
+                      </Text>
+                    </Badge>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    css={{
+                      width: "200px",
+                      mt: "$1",
+                      boxShadow:
+                        "0px 5px 14px rgba(0, 0, 0, 0.22), 0px 0px 2px rgba(0, 0, 0, 0.2)",
+                      bc: "$neutral4",
+                    }}
+                    align="center"
+                  >
+                    <DropdownMenuGroup>
+                      <DropdownMenuItem
+                        css={{
+                          cursor: "pointer",
+                        }}
+                        onSelect={() => setFactors("lpt+eth")}
+                      >
+                        {formatFactors("lpt+eth")}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        css={{
+                          cursor: "pointer",
+                        }}
+                        onSelect={() => setFactors("lpt")}
+                      >
+                        {formatFactors("lpt")}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        css={{
+                          cursor: "pointer",
+                        }}
+                        onSelect={() => setFactors("eth")}
+                      >
+                        {formatFactors("eth")}
+                      </DropdownMenuItem>
+                    </DropdownMenuGroup>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </Box>
+              <Box css={{ marginLeft: "$1" }}>
+                <DropdownMenu>
+                  <DropdownMenuTrigger
+                    onClick={(e) => {
+                      e.stopPropagation();
+                    }}
+                    asChild
+                  >
+                    <Badge
+                      size="2"
                       css={{
                         cursor: "pointer",
+                        color: "$white",
+                        fontSize: "$2",
                       }}
-                      onSelect={() => setInflationChange("none")}
                     >
-                      {formatPercentChange("none")}
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      css={{
-                        cursor: "pointer",
-                      }}
-                      onSelect={() => setInflationChange("positive")}
-                    >
-                      {formatPercentChange("positive")}
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      css={{
-                        cursor: "pointer",
-                      }}
-                      onSelect={() => setInflationChange("negative")}
-                    >
-                      {formatPercentChange("negative")}
-                    </DropdownMenuItem>
-                  </DropdownMenuGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </Box>
-          </Flex>
-        </Box>
-      }
-    />
+                      <Box css={{ marginRight: "$1" }}>
+                        <Pencil1Icon />
+                      </Box>
+
+                      <Text
+                        variant="neutral"
+                        size="1"
+                        css={{
+                          marginRight: 3,
+                        }}
+                      >
+                        {"Inflation change:"}
+                      </Text>
+                      <Text
+                        size="1"
+                        css={{
+                          color: "white",
+                          fontWeight: 600,
+                        }}
+                      >
+                        {formatPercentChange(inflationChange)}
+                      </Text>
+                    </Badge>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    css={{
+                      width: "200px",
+                      mt: "$1",
+                      boxShadow:
+                        "0px 5px 14px rgba(0, 0, 0, 0.22), 0px 0px 2px rgba(0, 0, 0, 0.2)",
+                      bc: "$neutral4",
+                    }}
+                    align="center"
+                  >
+                    <DropdownMenuGroup>
+                      <DropdownMenuItem
+                        css={{
+                          cursor: "pointer",
+                        }}
+                        onSelect={() => setInflationChange("none")}
+                      >
+                        {formatPercentChange("none")}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        css={{
+                          cursor: "pointer",
+                        }}
+                        onSelect={() => setInflationChange("positive")}
+                      >
+                        {formatPercentChange("positive")}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        css={{
+                          cursor: "pointer",
+                        }}
+                        onSelect={() => setInflationChange("negative")}
+                      >
+                        {formatPercentChange("negative")}
+                      </DropdownMenuItem>
+                    </DropdownMenuGroup>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </Box>
+            </Flex>
+          </Box>
+        }
+      />
+    </Box>
   );
 };
 

--- a/components/OrchestratorList/index.tsx
+++ b/components/OrchestratorList/index.tsx
@@ -47,12 +47,16 @@ import {
   PERCENTAGE_PRECISION_MILLION,
 } from "@utils/web3";
 import { OrchestratorsQueryResult, ProtocolQueryResult } from "apollo";
-import { OrchestratorListKey, useEnsData, useExplorerStore } from "hooks";
+import {
+  OrchestratorListKey,
+  OrchestratorListState,
+  useEnsData,
+  useExplorerStore,
+  usePersistedExplorerListState,
+} from "hooks";
 import { useBondingManagerAddress } from "hooks/useContracts";
 import Link from "next/link";
-import Router from "next/router";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { SortingRule } from "react-table";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { formatUnits } from "viem";
 import { useReadContract } from "wagmi";
 
@@ -78,39 +82,8 @@ const formatFactors = (factors: ROIFactors) =>
     ? `LPT Only`
     : `ETH Only`;
 
-const getScrollStorageKey = (listKey: OrchestratorListKey) =>
-  `livepeer:orchestrator-list:${listKey}:scrollY`;
-
 const getListPath = (listKey: OrchestratorListKey) =>
   listKey === "home" ? "/" : "/orchestrators";
-
-const readStoredScrollY = (listKey: OrchestratorListKey) => {
-  if (typeof window === "undefined") {
-    return null;
-  }
-
-  try {
-    const value = window.sessionStorage.getItem(getScrollStorageKey(listKey));
-    const scrollY = value ? Number(value) : NaN;
-
-    return Number.isFinite(scrollY) ? scrollY : null;
-  } catch {
-    return null;
-  }
-};
-
-const writeStoredScrollY = (listKey: OrchestratorListKey, scrollY: number) => {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  try {
-    window.sessionStorage.setItem(
-      getScrollStorageKey(listKey),
-      `${Math.max(0, Math.round(scrollY))}`
-    );
-  } catch {}
-};
 
 const OrchestratorList = ({
   data,
@@ -133,7 +106,19 @@ const OrchestratorList = ({
   const setOrchestratorListState = useExplorerStore(
     (state) => state.setOrchestratorListState
   );
-  const activeRestoreCleanup = useRef<(() => void) | undefined>(undefined);
+  const setPersistedListState = useCallback(
+    (value: Partial<OrchestratorListState>) => {
+      setOrchestratorListState(listKey, value);
+    },
+    [listKey, setOrchestratorListState]
+  );
+  const { handleTableStateChange, saveCurrentScroll } =
+    usePersistedExplorerListState({
+      listKey: `orchestrator-list:${listKey}`,
+      routePath: getListPath(listKey),
+      persistedState,
+      setPersistedState: setPersistedListState,
+    });
   // Derive protocol inflation data
   const inflationRate =
     Number(protocolData?.inflation || 0) / PERCENTAGE_PRECISION_BILLION;
@@ -181,112 +166,6 @@ const OrchestratorList = ({
     setOrchestratorListState,
     timeHorizon,
   ]);
-
-  const saveCurrentScroll = useCallback(() => {
-    writeStoredScrollY(listKey, window.scrollY);
-    setOrchestratorListState(listKey, { scrollY: window.scrollY });
-  }, [listKey, setOrchestratorListState]);
-
-  const restoreSavedScroll = useCallback(() => {
-    const scrollY = readStoredScrollY(listKey) ?? persistedState.scrollY;
-
-    if (scrollY <= 0) {
-      return;
-    }
-
-    const getMaxScrollY = () =>
-      Math.max(
-        document.documentElement.scrollHeight,
-        document.body.scrollHeight
-      ) - window.innerHeight;
-
-    const isAtSavedScroll = () => Math.abs(window.scrollY - scrollY) <= 2;
-    const isTallEnough = () => getMaxScrollY() >= scrollY;
-
-    if (isTallEnough() && isAtSavedScroll()) {
-      return;
-    }
-
-    const startedAt = Date.now();
-    const maxRestoreMs = 2000;
-    let frameId: number | undefined;
-    let cancelled = false;
-
-    const restoreScroll = () => {
-      if (cancelled) {
-        return;
-      }
-
-      if (isTallEnough()) {
-        window.scrollTo(0, scrollY);
-      }
-
-      if (
-        (!isTallEnough() || !isAtSavedScroll()) &&
-        Date.now() - startedAt < maxRestoreMs
-      ) {
-        frameId = requestAnimationFrame(restoreScroll);
-      }
-    };
-
-    frameId = requestAnimationFrame(restoreScroll);
-
-    return () => {
-      cancelled = true;
-      if (frameId !== undefined) {
-        cancelAnimationFrame(frameId);
-      }
-    };
-  }, [listKey, persistedState.scrollY]);
-
-  const startScrollRestore = useCallback(() => {
-    activeRestoreCleanup.current?.();
-    activeRestoreCleanup.current = restoreSavedScroll();
-  }, [restoreSavedScroll]);
-
-  useEffect(() => {
-    startScrollRestore();
-
-    return () => {
-      activeRestoreCleanup.current?.();
-      activeRestoreCleanup.current = undefined;
-    };
-  }, [startScrollRestore]);
-
-  useEffect(() => {
-    let frameId: number | null = null;
-    const saveScrollToStorage = () => {
-      if (frameId !== null) {
-        return;
-      }
-
-      frameId = requestAnimationFrame(() => {
-        frameId = null;
-        writeStoredScrollY(listKey, window.scrollY);
-      });
-    };
-
-    window.addEventListener("scroll", saveScrollToStorage, { passive: true });
-    const restoreAfterRouteChange = (url: string) => {
-      const path = url.split("?")[0].split("#")[0];
-
-      if (path === getListPath(listKey)) {
-        startScrollRestore();
-      }
-    };
-
-    Router.events.on("routeChangeStart", saveCurrentScroll);
-    Router.events.on("routeChangeComplete", restoreAfterRouteChange);
-
-    return () => {
-      if (frameId !== null) {
-        cancelAnimationFrame(frameId);
-      }
-      window.removeEventListener("scroll", saveScrollToStorage);
-      Router.events.off("routeChangeStart", saveCurrentScroll);
-      Router.events.off("routeChangeComplete", restoreAfterRouteChange);
-    };
-  }, [listKey, saveCurrentScroll, startScrollRestore]);
 
   const formattedPrinciple = formatLPT(Number(principle) || 150, {
     precision: 0,
@@ -1182,22 +1061,6 @@ const OrchestratorList = ({
       },
     ],
     [formattedPrinciple, timeHorizon, factors]
-  );
-
-  const handleTableStateChange = useCallback(
-    ({
-      pageIndex,
-      sortBy,
-    }: {
-      pageIndex: number;
-      sortBy: SortingRule<object>[];
-    }) => {
-      setOrchestratorListState(listKey, {
-        pageIndex,
-        sortBy,
-      });
-    },
-    [listKey, setOrchestratorListState]
   );
 
   return (

--- a/components/PerformanceList/index.tsx
+++ b/components/PerformanceList/index.tsx
@@ -17,6 +17,13 @@ import { Column } from "react-table";
 
 const EmptyData = () => <Skeleton css={{ height: 20, width: 100 }} />;
 
+const DEFAULT_SORT_BY = [
+  {
+    id: "scores",
+    desc: true,
+  },
+];
+
 const PerformanceList = ({
   orchestratorIds,
   pageSize = 20,
@@ -56,22 +63,13 @@ const PerformanceList = ({
       listKey,
       routePath: "/leaderboard",
     });
-  const defaultSortBy = useMemo(
-    () => [
-      {
-        id: "scores",
-        desc: true,
-      },
-    ],
-    []
-  );
 
   const initialState = {
     pageIndex: persistedState.pageIndex,
     pageSize: pageSize,
     sortBy: persistedState.sortBy.length
       ? persistedState.sortBy
-      : defaultSortBy,
+      : DEFAULT_SORT_BY,
     hiddenColumns: [
       "activationRound",
       "deactivationRound",

--- a/components/PerformanceList/index.tsx
+++ b/components/PerformanceList/index.tsx
@@ -10,7 +10,7 @@ import { QuestionMarkCircledIcon } from "@radix-ui/react-icons";
 import { formatNumber, formatPercent } from "@utils/numberFormatters";
 import { formatAddress } from "@utils/web3";
 import { OrchestratorsQueryResult } from "apollo";
-import { useEnsData } from "hooks";
+import { useEnsData, usePersistedExplorerListState } from "hooks";
 import Link from "next/link";
 import { useMemo } from "react";
 import { Column } from "react-table";
@@ -41,15 +41,37 @@ const PerformanceList = ({
   const scoreAccessor = `scores.${region}`; //total score
   const successRateAccessor = `successRates.${region}`; //success rate
   const roundTripScoreAccessor = `roundTripScores.${region}`; //latency score
-
-  const initialState = {
-    pageSize: pageSize,
-    sortBy: [
+  const listKey = useMemo(
+    () =>
+      [
+        "leaderboard-performance",
+        region,
+        pipeline ?? "transcoding",
+        model ?? "default",
+      ].join(":"),
+    [model, pipeline, region]
+  );
+  const { handleTableStateChange, persistedState, saveCurrentScroll } =
+    usePersistedExplorerListState({
+      listKey,
+      routePath: "/leaderboard",
+    });
+  const defaultSortBy = useMemo(
+    () => [
       {
         id: "scores",
         desc: true,
       },
     ],
+    []
+  );
+
+  const initialState = {
+    pageIndex: persistedState.pageIndex,
+    pageSize: pageSize,
+    sortBy: persistedState.sortBy.length
+      ? persistedState.sortBy
+      : defaultSortBy,
     hiddenColumns: [
       "activationRound",
       "deactivationRound",
@@ -320,7 +342,17 @@ const PerformanceList = ({
     ]
   );
   return (
-    <Table data={mergedData} columns={columns} initialState={initialState} />
+    <Box onClickCapture={saveCurrentScroll}>
+      <Table
+        key={listKey}
+        data={mergedData}
+        columns={columns}
+        autoResetPage={false}
+        autoResetSortBy={false}
+        onStateChange={handleTableStateChange}
+        initialState={initialState}
+      />
+    </Box>
   );
 };
 

--- a/components/Table/index.tsx
+++ b/components/Table/index.tsx
@@ -9,19 +9,36 @@ import {
   Tr,
 } from "@livepeer/design-system";
 import { ChevronDownIcon, ChevronUpIcon } from "@radix-ui/react-icons";
-import { ReactNode } from "react";
+import { ReactNode, useEffect } from "react";
 import {
   Column,
   HeaderGroup,
+  SortingRule,
   TableInstance,
+  TableOptions,
+  TableState,
   usePagination,
   UsePaginationInstanceProps,
+  UsePaginationOptions,
+  UsePaginationState,
   useSortBy,
   UseSortByInstanceProps,
+  UseSortByOptions,
+  UseSortByState,
   useTable,
 } from "react-table";
 
 import Pagination from "./Pagination";
+
+type TableInitialState<T extends object> = Partial<TableState<T>> &
+  Partial<UsePaginationState<T>> &
+  Partial<UseSortByState<T>>;
+
+type PersistedTableState<T extends object> = {
+  pageIndex: number;
+  pageSize: number;
+  sortBy: SortingRule<T>[];
+};
 
 function DataTable<T extends object>({
   heading = null,
@@ -29,13 +46,29 @@ function DataTable<T extends object>({
   data,
   columns,
   initialState = {},
+  autoResetPage,
+  autoResetSortBy,
+  onStateChange,
 }: {
   heading?: ReactNode;
   input?: ReactNode;
   data: T[];
   columns: Column<T>[];
-  initialState: object;
+  initialState: TableInitialState<T>;
+  autoResetPage?: boolean;
+  autoResetSortBy?: boolean;
+  onStateChange?: (state: PersistedTableState<T>) => void;
 }) {
+  const tableOptions: TableOptions<T> &
+    UsePaginationOptions<T> &
+    UseSortByOptions<T> = {
+    columns,
+    data,
+    initialState,
+    autoResetPage,
+    autoResetSortBy,
+  };
+
   const {
     getTableProps,
     getTableBodyProps,
@@ -47,18 +80,16 @@ function DataTable<T extends object>({
     pageCount,
     nextPage,
     previousPage,
-    state: { pageIndex },
-  } = useTable<T>(
-    {
-      columns,
-      data,
-      initialState,
-    },
-    useSortBy,
-    usePagination
-  ) as TableInstance<T> &
+    state: { pageIndex, pageSize, sortBy },
+  } = useTable<T>(tableOptions, useSortBy, usePagination) as TableInstance<T> &
     UsePaginationInstanceProps<T> &
-    UseSortByInstanceProps<T> & { state: { pageIndex: number } };
+    UseSortByInstanceProps<T> & {
+      state: UsePaginationState<T> & UseSortByState<T>;
+    };
+
+  useEffect(() => {
+    onStateChange?.({ pageIndex, pageSize, sortBy });
+  }, [onStateChange, pageIndex, pageSize, sortBy]);
 
   return (
     <>

--- a/components/TransactionsList/index.tsx
+++ b/components/TransactionsList/index.tsx
@@ -93,6 +93,8 @@ const TransactionsList = ({
       listKey,
       routePath,
     });
+  const pageCount = Math.max(1, Math.ceil((events?.length ?? 0) / pageSize));
+  const pageIndex = Math.min(persistedState.pageIndex, pageCount - 1);
   const getAccountForRow = useCallback(
     (
       event: NonNullable<
@@ -566,13 +568,13 @@ const TransactionsList = ({
   return (
     <Box onClickCapture={saveCurrentScroll}>
       <Table
-        data={events as object[]}
+        data={(events ?? []) as object[]}
         columns={columns}
         autoResetPage={false}
         autoResetSortBy={false}
         onStateChange={handleTableStateChange}
         initialState={{
-          pageIndex: persistedState.pageIndex,
+          pageIndex,
           pageSize,
           sortBy: persistedState.sortBy.length
             ? persistedState.sortBy

--- a/components/TransactionsList/index.tsx
+++ b/components/TransactionsList/index.tsx
@@ -68,6 +68,13 @@ const renderEmoji = (emoji: string) => (
   </Box>
 );
 
+const DEFAULT_SORT_BY = [
+  {
+    id: "timestamp",
+    desc: true,
+  },
+];
+
 const TransactionsList = ({
   events,
   listKey,
@@ -86,15 +93,6 @@ const TransactionsList = ({
       listKey,
       routePath,
     });
-  const defaultSortBy = useMemo(
-    () => [
-      {
-        id: "timestamp",
-        desc: true,
-      },
-    ],
-    []
-  );
   const getAccountForRow = useCallback(
     (
       event: NonNullable<
@@ -578,7 +576,7 @@ const TransactionsList = ({
           pageSize,
           sortBy: persistedState.sortBy.length
             ? persistedState.sortBy
-            : defaultSortBy,
+            : DEFAULT_SORT_BY,
         }}
       />
     </Box>

--- a/components/TransactionsList/index.tsx
+++ b/components/TransactionsList/index.tsx
@@ -17,6 +17,7 @@ import {
 } from "@utils/web3";
 import { EventsQueryResult, TreasuryProposal } from "apollo";
 import { sentenceCase } from "change-case";
+import { usePersistedExplorerListState } from "hooks";
 import { useCallback, useMemo } from "react";
 
 export const FILTERED_EVENT_TYPENAMES = [
@@ -69,13 +70,31 @@ const renderEmoji = (emoji: string) => (
 
 const TransactionsList = ({
   events,
+  listKey,
   pageSize = 10,
+  routePath,
 }: {
+  listKey: string;
   pageSize: number;
+  routePath: string;
   events: NonNullable<
     EventsQueryResult["data"]
   >["transactions"][number]["events"];
 }) => {
+  const { handleTableStateChange, persistedState, saveCurrentScroll } =
+    usePersistedExplorerListState({
+      listKey,
+      routePath,
+    });
+  const defaultSortBy = useMemo(
+    () => [
+      {
+        id: "timestamp",
+        desc: true,
+      },
+    ],
+    []
+  );
   const getAccountForRow = useCallback(
     (
       event: NonNullable<
@@ -547,19 +566,22 @@ const TransactionsList = ({
   );
 
   return (
-    <Table
-      data={events as object[]}
-      columns={columns}
-      initialState={{
-        pageSize,
-        sortBy: [
-          {
-            id: "timestamp",
-            desc: true,
-          },
-        ],
-      }}
-    />
+    <Box onClickCapture={saveCurrentScroll}>
+      <Table
+        data={events as object[]}
+        columns={columns}
+        autoResetPage={false}
+        autoResetSortBy={false}
+        onStateChange={handleTableStateChange}
+        initialState={{
+          pageIndex: persistedState.pageIndex,
+          pageSize,
+          sortBy: persistedState.sortBy.length
+            ? persistedState.sortBy
+            : defaultSortBy,
+        }}
+      />
+    </Box>
   );
 };
 

--- a/hooks/index.tsx
+++ b/hooks/index.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 
 // DO NOT IMPORT useHandleTransaction due to @rainbow-me/rainbowkit issues with SSR
 export * from "./useExplorerStore";
+export * from "./usePersistedExplorerListState";
 export * from "./useSwr";
 export * from "./wallet";
 

--- a/hooks/useExplorerStore.tsx
+++ b/hooks/useExplorerStore.tsx
@@ -16,6 +16,11 @@ export type OrchestratorListState = {
   sortBy: SortingRule<object>[];
   timeHorizon: ROITimeHorizon;
 };
+export type ExplorerListState = {
+  pageIndex: number;
+  scrollY: number;
+  sortBy: SortingRule<object>[];
+};
 export type YieldResults = {
   roiFees: number;
   roiFeesLpt: number;
@@ -61,6 +66,7 @@ export type ExplorerState = {
   selectedStakingAction: StakingAction;
   yieldResults: YieldResults;
   orchestratorLists: Record<OrchestratorListKey, OrchestratorListState>;
+  explorerLists: Record<string, ExplorerListState>;
   latestTransaction: TransactionStatus | null;
 
   setWalletModalOpen: (v: boolean) => void;
@@ -70,6 +76,10 @@ export type ExplorerState = {
   setOrchestratorListState: (
     key: OrchestratorListKey,
     value: Partial<OrchestratorListState>
+  ) => void;
+  setExplorerListState: (
+    key: string,
+    value: Partial<ExplorerListState>
   ) => void;
 
   setLatestTransactionDetails: (
@@ -93,6 +103,12 @@ const defaultOrchestratorListState: OrchestratorListState = {
   timeHorizon: "one-year",
 };
 
+export const defaultExplorerListState: ExplorerListState = {
+  pageIndex: 0,
+  scrollY: 0,
+  sortBy: [],
+};
+
 export const useExplorerStore = create<ExplorerState>()((set) => ({
   walletModalOpen: false,
   bottomDrawerOpen: false,
@@ -107,6 +123,7 @@ export const useExplorerStore = create<ExplorerState>()((set) => ({
     home: defaultOrchestratorListState,
     orchestrators: defaultOrchestratorListState,
   },
+  explorerLists: {},
   latestTransaction: null,
 
   setWalletModalOpen: (v: boolean) => set(() => ({ walletModalOpen: v })),
@@ -130,6 +147,29 @@ export const useExplorerStore = create<ExplorerState>()((set) => ({
       return {
         orchestratorLists: {
           ...orchestratorLists,
+          [key]: {
+            ...current,
+            ...value,
+          },
+        },
+      };
+    }),
+  setExplorerListState: (key, value) =>
+    set((state) => {
+      const { explorerLists } = state;
+      const current = explorerLists[key] ?? defaultExplorerListState;
+      const hasChanged = Object.entries(value).some(
+        ([field, nextValue]) =>
+          current[field as keyof ExplorerListState] !== nextValue
+      );
+
+      if (!hasChanged) {
+        return state;
+      }
+
+      return {
+        explorerLists: {
+          ...explorerLists,
           [key]: {
             ...current,
             ...value,

--- a/hooks/useExplorerStore.tsx
+++ b/hooks/useExplorerStore.tsx
@@ -1,4 +1,5 @@
 import { ProposalExtended } from "@lib/api/treasury";
+import { ROIFactors, ROIInflationChange, ROITimeHorizon } from "@lib/roi";
 import { txMessages } from "lib/utils";
 import { SortingRule } from "react-table";
 import { Address } from "viem";
@@ -7,18 +8,13 @@ import { create } from "zustand";
 export type StakingAction = "undelegate" | "delegate" | null;
 export type OrchestratorListKey = "home" | "orchestrators";
 export type OrchestratorListState = {
-  factors: "lpt+eth" | "lpt" | "eth";
-  inflationChange: "positive" | "negative" | "none";
+  factors: ROIFactors;
+  inflationChange: ROIInflationChange;
   pageIndex: number;
   principle: number;
   scrollY: number;
   sortBy: SortingRule<object>[];
-  timeHorizon:
-    | "half-year"
-    | "one-year"
-    | "two-years"
-    | "three-years"
-    | "four-years";
+  timeHorizon: ROITimeHorizon;
 };
 export type YieldResults = {
   roiFees: number;
@@ -119,15 +115,28 @@ export const useExplorerStore = create<ExplorerState>()((set) => ({
     set(() => ({ selectedStakingAction: v })),
   setYieldResults: (v: YieldResults) => set(() => ({ yieldResults: v })),
   setOrchestratorListState: (key, value) =>
-    set(({ orchestratorLists }) => ({
-      orchestratorLists: {
-        ...orchestratorLists,
-        [key]: {
-          ...orchestratorLists[key],
-          ...value,
+    set((state) => {
+      const { orchestratorLists } = state;
+      const current = orchestratorLists[key];
+      const hasChanged = Object.entries(value).some(
+        ([field, nextValue]) =>
+          current[field as keyof OrchestratorListState] !== nextValue
+      );
+
+      if (!hasChanged) {
+        return state;
+      }
+
+      return {
+        orchestratorLists: {
+          ...orchestratorLists,
+          [key]: {
+            ...current,
+            ...value,
+          },
         },
-      },
-    })),
+      };
+    }),
 
   setLatestTransactionDetails: (
     hash: string,

--- a/hooks/useExplorerStore.tsx
+++ b/hooks/useExplorerStore.tsx
@@ -1,9 +1,25 @@
 import { ProposalExtended } from "@lib/api/treasury";
 import { txMessages } from "lib/utils";
+import { SortingRule } from "react-table";
 import { Address } from "viem";
 import { create } from "zustand";
 
 export type StakingAction = "undelegate" | "delegate" | null;
+export type OrchestratorListKey = "home" | "orchestrators";
+export type OrchestratorListState = {
+  factors: "lpt+eth" | "lpt" | "eth";
+  inflationChange: "positive" | "negative" | "none";
+  pageIndex: number;
+  principle: number;
+  scrollY: number;
+  sortBy: SortingRule<object>[];
+  timeHorizon:
+    | "half-year"
+    | "one-year"
+    | "two-years"
+    | "three-years"
+    | "four-years";
+};
 export type YieldResults = {
   roiFees: number;
   roiFeesLpt: number;
@@ -48,12 +64,17 @@ export type ExplorerState = {
   bottomDrawerOpen: boolean;
   selectedStakingAction: StakingAction;
   yieldResults: YieldResults;
+  orchestratorLists: Record<OrchestratorListKey, OrchestratorListState>;
   latestTransaction: TransactionStatus | null;
 
   setWalletModalOpen: (v: boolean) => void;
   setBottomDrawerOpen: (v: boolean) => void;
   setSelectedStakingAction: (v: StakingAction) => void;
   setYieldResults: (v: YieldResults) => void;
+  setOrchestratorListState: (
+    key: OrchestratorListKey,
+    value: Partial<OrchestratorListState>
+  ) => void;
 
   setLatestTransactionDetails: (
     hash: string,
@@ -66,6 +87,16 @@ export type ExplorerState = {
   clearLatestTransaction: () => void;
 };
 
+const defaultOrchestratorListState: OrchestratorListState = {
+  factors: "lpt+eth",
+  inflationChange: "none",
+  pageIndex: 0,
+  principle: 150,
+  scrollY: 0,
+  sortBy: [{ id: "earnings", desc: true }],
+  timeHorizon: "one-year",
+};
+
 export const useExplorerStore = create<ExplorerState>()((set) => ({
   walletModalOpen: false,
   bottomDrawerOpen: false,
@@ -76,6 +107,10 @@ export const useExplorerStore = create<ExplorerState>()((set) => ({
     roiRewards: 0.0,
     principle: 0.0,
   },
+  orchestratorLists: {
+    home: defaultOrchestratorListState,
+    orchestrators: defaultOrchestratorListState,
+  },
   latestTransaction: null,
 
   setWalletModalOpen: (v: boolean) => set(() => ({ walletModalOpen: v })),
@@ -83,6 +118,16 @@ export const useExplorerStore = create<ExplorerState>()((set) => ({
   setSelectedStakingAction: (v: StakingAction) =>
     set(() => ({ selectedStakingAction: v })),
   setYieldResults: (v: YieldResults) => set(() => ({ yieldResults: v })),
+  setOrchestratorListState: (key, value) =>
+    set(({ orchestratorLists }) => ({
+      orchestratorLists: {
+        ...orchestratorLists,
+        [key]: {
+          ...orchestratorLists[key],
+          ...value,
+        },
+      },
+    })),
 
   setLatestTransactionDetails: (
     hash: string,

--- a/hooks/usePersistedExplorerListState.ts
+++ b/hooks/usePersistedExplorerListState.ts
@@ -26,9 +26,11 @@ type UsePersistedExplorerListStateOptions = {
   setPersistedState?: (value: Partial<PersistedListState>) => void;
 };
 
+/** Builds the sessionStorage key used as a same-tab scroll backup for a list. */
 const getScrollStorageKey = (listKey: string) =>
   `livepeer:explorer-list:${listKey}:scrollY`;
 
+/** Reads the last saved scroll offset for a list, returning null when unavailable. */
 const readStoredScrollY = (listKey: string) => {
   if (typeof window === "undefined") {
     return null;
@@ -44,6 +46,7 @@ const readStoredScrollY = (listKey: string) => {
   }
 };
 
+/** Writes a non-negative rounded scroll offset for a list into sessionStorage. */
 const writeStoredScrollY = (listKey: string, scrollY: number) => {
   if (typeof window === "undefined") {
     return;
@@ -57,6 +60,18 @@ const writeStoredScrollY = (listKey: string, scrollY: number) => {
   } catch {}
 };
 
+/**
+ * Persists table page/sort state and restores window scroll for a browsable list.
+ *
+ * `listKey` scopes stored state per list instance, while `routePath` identifies
+ * the route that should trigger restoration after Back navigation. Callers can
+ * provide `persistedState` and `setPersistedState` to reuse an existing store
+ * slice; otherwise the hook uses the generic explorer list store.
+ *
+ * Returns `handleTableStateChange` for the shared Table callback,
+ * `persistedState` for Table initial state, and `saveCurrentScroll` for click
+ * capture before navigating from a list item.
+ */
 export const usePersistedExplorerListState = <T extends object = object>({
   listKey,
   routePath,

--- a/hooks/usePersistedExplorerListState.ts
+++ b/hooks/usePersistedExplorerListState.ts
@@ -1,0 +1,203 @@
+import Router from "next/router";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { SortingRule } from "react-table";
+
+import {
+  defaultExplorerListState,
+  ExplorerListState,
+  useExplorerStore,
+} from "./useExplorerStore";
+
+type PersistedListState = {
+  pageIndex: number;
+  scrollY: number;
+  sortBy: SortingRule<object>[];
+};
+
+type PersistedTableState<T extends object> = {
+  pageIndex: number;
+  sortBy: SortingRule<T>[];
+};
+
+type UsePersistedExplorerListStateOptions = {
+  listKey: string;
+  routePath: string;
+  persistedState?: PersistedListState;
+  setPersistedState?: (value: Partial<PersistedListState>) => void;
+};
+
+const getScrollStorageKey = (listKey: string) =>
+  `livepeer:explorer-list:${listKey}:scrollY`;
+
+const readStoredScrollY = (listKey: string) => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const value = window.sessionStorage.getItem(getScrollStorageKey(listKey));
+    const scrollY = value ? Number(value) : NaN;
+
+    return Number.isFinite(scrollY) ? scrollY : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeStoredScrollY = (listKey: string, scrollY: number) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(
+      getScrollStorageKey(listKey),
+      `${Math.max(0, Math.round(scrollY))}`
+    );
+  } catch {}
+};
+
+export const usePersistedExplorerListState = <T extends object = object>({
+  listKey,
+  routePath,
+  persistedState: externalPersistedState,
+  setPersistedState: externalSetPersistedState,
+}: UsePersistedExplorerListStateOptions) => {
+  const storedPersistedState =
+    useExplorerStore((state) => state.explorerLists[listKey]) ??
+    defaultExplorerListState;
+  const setExplorerListState = useExplorerStore(
+    (state) => state.setExplorerListState
+  );
+  const persistedState = externalPersistedState ?? storedPersistedState;
+  const setPersistedState = useMemo(
+    () =>
+      externalSetPersistedState ??
+      ((value: Partial<ExplorerListState>) =>
+        setExplorerListState(listKey, value)),
+    [externalSetPersistedState, listKey, setExplorerListState]
+  );
+  const activeRestoreCleanup = useRef<(() => void) | undefined>(undefined);
+
+  const saveCurrentScroll = useCallback(() => {
+    writeStoredScrollY(listKey, window.scrollY);
+    setPersistedState({ scrollY: window.scrollY });
+  }, [listKey, setPersistedState]);
+
+  const restoreSavedScroll = useCallback(() => {
+    const scrollY = readStoredScrollY(listKey) ?? persistedState.scrollY;
+
+    if (scrollY <= 0) {
+      return;
+    }
+
+    const getMaxScrollY = () =>
+      Math.max(
+        document.documentElement.scrollHeight,
+        document.body.scrollHeight
+      ) - window.innerHeight;
+
+    const isAtSavedScroll = () => Math.abs(window.scrollY - scrollY) <= 2;
+    const isTallEnough = () => getMaxScrollY() >= scrollY;
+
+    if (isTallEnough() && isAtSavedScroll()) {
+      return;
+    }
+
+    const startedAt = Date.now();
+    const maxRestoreMs = 2000;
+    let frameId: number | undefined;
+    let cancelled = false;
+
+    const restoreScroll = () => {
+      if (cancelled) {
+        return;
+      }
+
+      if (isTallEnough()) {
+        window.scrollTo(0, scrollY);
+      }
+
+      if (
+        (!isTallEnough() || !isAtSavedScroll()) &&
+        Date.now() - startedAt < maxRestoreMs
+      ) {
+        frameId = requestAnimationFrame(restoreScroll);
+      }
+    };
+
+    frameId = requestAnimationFrame(restoreScroll);
+
+    return () => {
+      cancelled = true;
+      if (frameId !== undefined) {
+        cancelAnimationFrame(frameId);
+      }
+    };
+  }, [listKey, persistedState.scrollY]);
+
+  const startScrollRestore = useCallback(() => {
+    activeRestoreCleanup.current?.();
+    activeRestoreCleanup.current = restoreSavedScroll();
+  }, [restoreSavedScroll]);
+
+  useEffect(() => {
+    startScrollRestore();
+
+    return () => {
+      activeRestoreCleanup.current?.();
+      activeRestoreCleanup.current = undefined;
+    };
+  }, [startScrollRestore]);
+
+  useEffect(() => {
+    let frameId: number | null = null;
+    const saveScrollToStorage = () => {
+      if (frameId !== null) {
+        return;
+      }
+
+      frameId = requestAnimationFrame(() => {
+        frameId = null;
+        writeStoredScrollY(listKey, window.scrollY);
+      });
+    };
+
+    window.addEventListener("scroll", saveScrollToStorage, { passive: true });
+    const restoreAfterRouteChange = (url: string) => {
+      const path = url.split("?")[0].split("#")[0];
+
+      if (path === routePath) {
+        startScrollRestore();
+      }
+    };
+
+    Router.events.on("routeChangeStart", saveCurrentScroll);
+    Router.events.on("routeChangeComplete", restoreAfterRouteChange);
+
+    return () => {
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId);
+      }
+      window.removeEventListener("scroll", saveScrollToStorage);
+      Router.events.off("routeChangeStart", saveCurrentScroll);
+      Router.events.off("routeChangeComplete", restoreAfterRouteChange);
+    };
+  }, [listKey, routePath, saveCurrentScroll, startScrollRestore]);
+
+  const handleTableStateChange = useCallback(
+    ({ pageIndex, sortBy }: PersistedTableState<T>) => {
+      setPersistedState({
+        pageIndex,
+        sortBy: sortBy as SortingRule<object>[],
+      });
+    },
+    [setPersistedState]
+  );
+
+  return {
+    handleTableStateChange,
+    persistedState,
+    saveCurrentScroll,
+  };
+};

--- a/pages/gateways.tsx
+++ b/pages/gateways.tsx
@@ -46,7 +46,12 @@ const GatewaysPage = ({ gateways }: PageProps) => {
             the last 12 months.
           </Box>
           <Box css={{ marginBottom: "$5" }}>
-            <GatewayList data={gateways?.gateways} pageSize={20} />
+            <GatewayList
+              data={gateways?.gateways}
+              listKey="gateways"
+              pageSize={20}
+              routePath="/gateways"
+            />
           </Box>
         </Flex>
       </Container>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -580,7 +580,12 @@ const Home = ({
               </Flex>
             ) : (
               <Box>
-                <GatewayList data={gateways.gateways} pageSize={10} />
+                <GatewayList
+                  data={gateways.gateways}
+                  listKey="home-gateways"
+                  pageSize={10}
+                  routePath="/"
+                />
               </Box>
             )}
 
@@ -660,7 +665,9 @@ const Home = ({
                     EventsQueryResult["data"]
                   >["transactions"][number]["events"]
                 }
+                listKey="home-transactions"
                 pageSize={10}
+                routePath="/"
               />
             </Box>
           </Box>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -492,6 +492,7 @@ const Home = ({
                 {showOrchList ? (
                   <OrchestratorList
                     data={orchestrators?.transcoders}
+                    listKey="home"
                     pageSize={10}
                     protocolData={protocol?.protocol}
                   />

--- a/pages/orchestrators.tsx
+++ b/pages/orchestrators.tsx
@@ -123,6 +123,7 @@ const OrchestratorsPage = ({
             {showOrchList ? (
               <OrchestratorList
                 data={orchestrators?.transcoders}
+                listKey="orchestrators"
                 pageSize={20}
                 protocolData={protocol?.protocol}
               />

--- a/pages/transactions.tsx
+++ b/pages/transactions.tsx
@@ -72,7 +72,9 @@ const TransactionsPage = ({ hadError, events }: PageProps) => {
                     EventsQueryResult["data"]
                   >["transactions"][number]["events"]
                 }
+                listKey="transactions"
                 pageSize={TRANSACTIONS_PER_PAGE}
+                routePath="/transactions"
               />
             )}
           </Box>


### PR DESCRIPTION
## Description

This PR preserves orchestrator list browsing context when navigating into an orchestrator account and returning with Back. The home and `/orchestrators` lists now restore yield assumptions, sorting, pagination, and scroll position, with cached list data left in place so users can continue browsing where they left off.

## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] style: Code style/formatting changes (no logic changes)
- [ ] refactor: Code refactoring (no behavior change)
- [ ] perf: Performance improvement
- [ ] test: Adding or updating tests
- [ ] build: Build system or dependency changes
- [ ] ci: CI/CD changes
- [ ] chore: Other changes

## Related Issue(s)

Closes: #349 

## Changes Made

- Persisted orchestrator list state for home and /orchestrators.
- Restored yield assumptions, sorting, pagination, and scroll on Back.
- Added scroll preservation using route events, click capture, and session storage.

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [x] All tests passing

### How to test (optional unless test is not trivial)

- Change filters and page on home page
- Select an orchestrator
- Hit back button in browser
- See that orchestrator table scroll position, page, and filters were preserved
- Do the same of the `/orchestrators` page

## Impact / Risk

Risk level: Low

Impacted areas: UI

User impact: user does not lose their orchestrator search preferences when they click on a particular orchestrator

Rollback plan: Vercel rollback, then manual git revert


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Saved list preferences per view, including “Forecasted Yield Assumptions” controls plus table pagination/sorting for home, orchestrators, gateways, performance, and transactions.
  * Restored each list’s scroll position when navigating back.
* **Bug Fixes**
  * Kept “Forecasted Yield Assumptions” fully synchronized with saved state; updated the time-horizon badge to “Time horizon:” and ensured the displayed value matches the selected time horizon.
  * Prevented table pagination/sorting from resetting unexpectedly during navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->