### PR TITLE
fix: preserve migration UI when no active unbonding locks

### DIFF
--- a/pages/migrate/delegator/index.tsx
+++ b/pages/migrate/delegator/index.tsx
@@ -462,16 +462,30 @@ const MigrateUndelegatedStake = () => {
     const init = async () => {
       if (accountAddress && l1SignerOrAddress) {
         const locks = l1SignerOrAddress.activeLocks.map((e) => e.id);
+        const addr = state.signer ? state.signer : accountAddress;
+
+        // Empty lock array reverts EMPTY_LOCK_IDS; short-circuit to initialize.
+        if (!locks.length) {
+          dispatch({
+            type: "initialize",
+            payload: {
+              migrationCallData: null,
+              migrationParams: {
+                l1Addr: addr,
+                l2Addr: addr,
+                total: BigInt(0),
+                unbondingLockIds: [],
+              },
+            },
+          });
+          return;
+        }
 
         const [data, params] = await l1PublicClient.readContract({
           address: CHAIN_INFO[DEFAULT_CHAIN_ID].contracts.l1Migrator,
           abi: l1Migrator,
           functionName: "getMigrateUnbondingLocksParams",
-          args: [
-            state.signer ? state.signer : accountAddress,
-            state.signer ? state.signer : accountAddress,
-            locks.map((e) => BigInt(e)),
-          ],
+          args: [addr, addr, locks.map((e) => BigInt(e))],
         });
         dispatch({
           type: "initialize",


### PR DESCRIPTION
## Problem

The protocol team patched a vurnability in the migration flow on 24-05-26 (see https://forum.livepeer.org/t/security-vulnerability-disclosure-fixed-l1-l2-migrator-address-validation/3259). In this patch the `arbitrum-lpt-bridge` L1Migrator upgrade ([livepeer/arbitrum-lpt-bridge#98](https://github.com/livepeer/arbitrum-lpt-bridge/pull/98)) added `require(unbondingLockIdsLen > 0, "EMPTY_LOCK_IDS")` to `getMigrateUnbondingLocksParams`. Previously an empty lock array was tolerated (returned a zero-total result); it now reverts.

The Migrate Undelegated Stake page (`pages/migrate/delegator`) calls this read with `l1SignerOrAddress.activeLocks`. In the signing flow the connected account has no locks, so before a signer address with locks is entered the array is empty and the read reverts:

```
ContractFunctionExecutionError: ... reverted ... EMPTY_LOCK_IDS
getMigrateUnbondingLocksParams(0xDEfA…51f4, 0xDEfA…51f4, [])
```

## Fix

Skip the read when `locks.length === 0`. The empty call was always a no-op, and the effect re-runs once a signer with real locks is set.

## Scope

Only the delegator page is affected. The orchestrator (`getMigrateDelegatorParams`) and broadcaster (`getMigrateSenderParams`) pages don't pass lock arrays, and all three already pass identical L1/L2 addresses so the new `L2_ADDR_MISMATCH` check never trips.

## Related

Upstream protocol change: https://github.com/livepeer/arbitrum-lpt-bridge/pull/98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the migration flow when there are no active unbonding locks, so it now completes without making unnecessary contract reads.
  * Ensured initialization uses empty migration data and zeroed totals in the no-lock case.
  * Refined handling of migration parameters for accounts with locks to keep the process more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->