### PR TITLE
docs: use relative README link in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for considering contributing to the Livepeer Explorer. We welcome any 
 
 Contributions are made to this repo via Issues and Pull Requests (PRs).
 
-To run the code locally, you will need to fork the code and follow the [local setup instructions in the README](https://github.com/livepeer/explorer/blob/main/README.md).
+To run the code locally, you will need to fork the code and follow the [local setup instructions in the README](README.md).
 
 For debugging (including with a wallet extension), see [docs/debugging.md](docs/debugging.md).
 


### PR DESCRIPTION
## What

CONTRIBUTING.md linked to the README via a hard-coded `https://github.com/livepeer/explorer/blob/main/README.md` URL. That pins the `main` branch and breaks in forks, branches, and offline checkouts.

Replaced it with a relative link (`README.md`), matching the already-relative `docs/debugging.md` link right below it.

Follow-up to #716, addressing a Copilot review comment.