### PR TITLE
feat: add history events filter

### DIFF
--- a/components/HistoryView/HistoryFilter.tsx
+++ b/components/HistoryView/HistoryFilter.tsx
@@ -77,6 +77,15 @@ export const ALL_FILTER_KEYS: EventFilterKey[] = EVENT_FILTERS.map(
   (f) => f.key
 );
 
+// Shared style for the "All"/"None" text buttons in the popover header.
+const headerActionCss = {
+  all: "unset",
+  cursor: "pointer",
+  fontSize: "$1",
+  color: "$primary11",
+  "&:hover": { textDecoration: "underline" },
+} as const;
+
 // Reverse lookup from an event's __typename to the filter key it belongs to.
 export const TYPENAME_TO_FILTER: Record<string, EventFilterKey> =
   EVENT_FILTERS.reduce((acc, filter) => {
@@ -160,13 +169,7 @@ const HistoryFilter = ({
               as="button"
               type="button"
               onClick={onSelectAll}
-              css={{
-                all: "unset",
-                cursor: "pointer",
-                fontSize: "$1",
-                color: "$primary11",
-                "&:hover": { textDecoration: "underline" },
-              }}
+              css={headerActionCss}
             >
               All
             </Box>
@@ -174,13 +177,7 @@ const HistoryFilter = ({
               as="button"
               type="button"
               onClick={onClear}
-              css={{
-                all: "unset",
-                cursor: "pointer",
-                fontSize: "$1",
-                color: "$primary11",
-                "&:hover": { textDecoration: "underline" },
-              }}
+              css={headerActionCss}
             >
               None
             </Box>
@@ -192,7 +189,16 @@ const HistoryFilter = ({
             return (
               <Flex
                 key={filter.key}
+                role="checkbox"
+                aria-checked={checked}
+                tabIndex={0}
                 onClick={() => onToggle(filter.key)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onToggle(filter.key);
+                  }
+                }}
                 css={{
                   alignItems: "center",
                   gap: "$2",
@@ -201,6 +207,7 @@ const HistoryFilter = ({
                   cursor: "pointer",
                   userSelect: "none",
                   "&:hover": { bc: "$neutral5" },
+                  "&:focus-visible": { outline: "2px solid $primary11" },
                 }}
               >
                 <Checkbox

--- a/components/HistoryView/HistoryFilter.tsx
+++ b/components/HistoryView/HistoryFilter.tsx
@@ -9,7 +9,7 @@ import {
   PopoverTrigger,
   Text,
 } from "@livepeer/design-system";
-import { MixerHorizontalIcon } from "@radix-ui/react-icons";
+import { CheckIcon, MixerHorizontalIcon } from "@radix-ui/react-icons";
 
 export type EventFilterKey =
   | "delegated"
@@ -77,13 +77,12 @@ export const ALL_FILTER_KEYS: EventFilterKey[] = EVENT_FILTERS.map(
   (f) => f.key
 );
 
-// Shared style for the "All"/"None" text buttons in the popover header.
-const headerActionCss = {
-  all: "unset",
-  cursor: "pointer",
-  fontSize: "$1",
-  color: "$primary11",
-  "&:hover": { textDecoration: "underline" },
+// Shared checkbox styling: a solid fill plus a stronger border so the box
+// reads clearly against the $neutral4 popover background (the design-system
+// default $neutral7 outline is too faint here).
+const checkboxCss = {
+  backgroundColor: "$loContrast",
+  boxShadow: "inset 0 0 0 1px $colors$neutral8",
 } as const;
 
 // Reverse lookup from an event's __typename to the filter key it belongs to.
@@ -111,6 +110,10 @@ const HistoryFilter = ({
   const activeCount = selected.size;
   // A filter is "active" whenever the selection differs from showing everything.
   const isFiltered = activeCount !== EVENT_FILTERS.length;
+  const allSelected = activeCount === EVENT_FILTERS.length;
+  const noneSelected = activeCount === 0;
+  // Single toggle: when everything is on, clicking clears; otherwise select all.
+  const handleToggleAll = () => (allSelected ? onClear() : onSelectAll());
 
   return (
     <Popover>
@@ -154,34 +157,59 @@ const HistoryFilter = ({
         }}
       >
         <Flex
+          role="checkbox"
+          aria-checked={allSelected ? true : noneSelected ? false : "mixed"}
+          aria-label="Select all event types"
+          tabIndex={0}
+          onClick={handleToggleAll}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              handleToggleAll();
+            }
+          }}
           css={{
             alignItems: "center",
-            justifyContent: "space-between",
+            gap: "$2",
             padding: "$3",
             borderBottom: "1px solid $neutral6",
+            cursor: "pointer",
+            userSelect: "none",
+            "&:hover": { bc: "$neutral5" },
+            "&:focus-visible": { outline: "2px solid $primary11" },
           }}
         >
+          <Flex
+            aria-hidden
+            css={{
+              ...checkboxCss,
+              width: "$3",
+              height: "$3",
+              flexShrink: 0,
+              alignItems: "center",
+              justifyContent: "center",
+              borderRadius: "$1",
+              overflow: "hidden",
+              color: "$hiContrast",
+            }}
+          >
+            {allSelected && (
+              <Box as={CheckIcon} css={{ width: 15, height: 15 }} />
+            )}
+            {!allSelected && !noneSelected && (
+              <Box
+                css={{
+                  width: 8,
+                  height: 2,
+                  borderRadius: "$1",
+                  backgroundColor: "$hiContrast",
+                }}
+              />
+            )}
+          </Flex>
           <Text size="1" css={{ fontWeight: 600, textTransform: "uppercase" }}>
             Event types
           </Text>
-          <Flex css={{ gap: "$3" }}>
-            <Box
-              as="button"
-              type="button"
-              onClick={onSelectAll}
-              css={headerActionCss}
-            >
-              All
-            </Box>
-            <Box
-              as="button"
-              type="button"
-              onClick={onClear}
-              css={headerActionCss}
-            >
-              None
-            </Box>
-          </Flex>
         </Flex>
         <Box css={{ padding: "$2", maxHeight: 320, overflowY: "auto" }}>
           {EVENT_FILTERS.map((filter) => {
@@ -213,7 +241,7 @@ const HistoryFilter = ({
                 <Checkbox
                   checked={checked}
                   // The row's onClick is the single source of truth for toggling.
-                  css={{ pointerEvents: "none" }}
+                  css={{ ...checkboxCss, pointerEvents: "none" }}
                   tabIndex={-1}
                 />
                 <Text size="2">{filter.label}</Text>

--- a/components/HistoryView/HistoryFilter.tsx
+++ b/components/HistoryView/HistoryFilter.tsx
@@ -1,0 +1,222 @@
+import {
+  Badge,
+  Box,
+  Button,
+  Checkbox,
+  Flex,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Text,
+} from "@livepeer/design-system";
+import { MixerHorizontalIcon } from "@radix-ui/react-icons";
+
+export type EventFilterKey =
+  | "delegated"
+  | "redelegated"
+  | "undelegated"
+  | "reward"
+  | "transcoderUpdate"
+  | "withdrawStake"
+  | "withdrawFees"
+  | "winningTicket"
+  | "deposit"
+  | "reserve"
+  | "votes"
+  | "round";
+
+// Each filter maps a human-readable label to one or more event __typenames.
+export const EVENT_FILTERS: {
+  key: EventFilterKey;
+  label: string;
+  typenames: string[];
+}[] = [
+  { key: "delegated", label: "Delegated", typenames: ["BondEvent"] },
+  { key: "redelegated", label: "Redelegated", typenames: ["RebondEvent"] },
+  { key: "undelegated", label: "Undelegated", typenames: ["UnbondEvent"] },
+  { key: "reward", label: "Reward calls", typenames: ["RewardEvent"] },
+  {
+    key: "transcoderUpdate",
+    label: "Reward cut & fee changes",
+    typenames: ["TranscoderUpdateEvent"],
+  },
+  {
+    key: "withdrawStake",
+    label: "Stake withdrawals",
+    typenames: ["WithdrawStakeEvent"],
+  },
+  {
+    key: "withdrawFees",
+    label: "Fee withdrawals",
+    typenames: ["WithdrawFeesEvent"],
+  },
+  {
+    key: "winningTicket",
+    label: "Winning tickets",
+    typenames: ["WinningTicketRedeemedEvent"],
+  },
+  {
+    key: "deposit",
+    label: "Deposit funded",
+    typenames: ["DepositFundedEvent"],
+  },
+  {
+    key: "reserve",
+    label: "Reserve funded",
+    typenames: ["ReserveFundedEvent"],
+  },
+  {
+    key: "votes",
+    label: "Votes",
+    typenames: ["VoteEvent", "TreasuryVoteEvent"],
+  },
+  { key: "round", label: "Round initialized", typenames: ["NewRoundEvent"] },
+];
+
+export const ALL_FILTER_KEYS: EventFilterKey[] = EVENT_FILTERS.map(
+  (f) => f.key
+);
+
+// Reverse lookup from an event's __typename to the filter key it belongs to.
+export const TYPENAME_TO_FILTER: Record<string, EventFilterKey> =
+  EVENT_FILTERS.reduce((acc, filter) => {
+    filter.typenames.forEach((typename) => {
+      acc[typename] = filter.key;
+    });
+    return acc;
+  }, {} as Record<string, EventFilterKey>);
+
+interface HistoryFilterProps {
+  selected: Set<EventFilterKey>;
+  onToggle: (key: EventFilterKey) => void;
+  onSelectAll: () => void;
+  onClear: () => void;
+}
+
+const HistoryFilter = ({
+  selected,
+  onToggle,
+  onSelectAll,
+  onClear,
+}: HistoryFilterProps) => {
+  const activeCount = selected.size;
+  // A filter is "active" whenever the selection differs from showing everything.
+  const isFiltered = activeCount !== EVENT_FILTERS.length;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          size="2"
+          variant={isFiltered ? "primary" : "neutral"}
+          css={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "$1",
+            cursor: "pointer",
+          }}
+        >
+          <Box as={MixerHorizontalIcon} css={{ width: 14, height: 14 }} />
+          <Box as="span">Filter</Box>
+          {isFiltered && (
+            <Badge
+              size="1"
+              css={{
+                backgroundColor: "$neutral1",
+                color: "$hiContrast",
+                fontWeight: 600,
+                minWidth: 18,
+                justifyContent: "center",
+              }}
+            >
+              {activeCount}
+            </Badge>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        css={{
+          minWidth: 240,
+          borderRadius: "$4",
+          bc: "$neutral4",
+          boxShadow:
+            "0px 5px 14px rgba(0, 0, 0, 0.22), 0px 0px 2px rgba(0, 0, 0, 0.2)",
+        }}
+      >
+        <Flex
+          css={{
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "$3",
+            borderBottom: "1px solid $neutral6",
+          }}
+        >
+          <Text size="1" css={{ fontWeight: 600, textTransform: "uppercase" }}>
+            Event types
+          </Text>
+          <Flex css={{ gap: "$3" }}>
+            <Box
+              as="button"
+              type="button"
+              onClick={onSelectAll}
+              css={{
+                all: "unset",
+                cursor: "pointer",
+                fontSize: "$1",
+                color: "$primary11",
+                "&:hover": { textDecoration: "underline" },
+              }}
+            >
+              All
+            </Box>
+            <Box
+              as="button"
+              type="button"
+              onClick={onClear}
+              css={{
+                all: "unset",
+                cursor: "pointer",
+                fontSize: "$1",
+                color: "$primary11",
+                "&:hover": { textDecoration: "underline" },
+              }}
+            >
+              None
+            </Box>
+          </Flex>
+        </Flex>
+        <Box css={{ padding: "$2", maxHeight: 320, overflowY: "auto" }}>
+          {EVENT_FILTERS.map((filter) => {
+            const checked = selected.has(filter.key);
+            return (
+              <Flex
+                key={filter.key}
+                onClick={() => onToggle(filter.key)}
+                css={{
+                  alignItems: "center",
+                  gap: "$2",
+                  padding: "$2",
+                  borderRadius: "$2",
+                  cursor: "pointer",
+                  userSelect: "none",
+                  "&:hover": { bc: "$neutral5" },
+                }}
+              >
+                <Checkbox
+                  checked={checked}
+                  // The row's onClick is the single source of truth for toggling.
+                  css={{ pointerEvents: "none" }}
+                  tabIndex={-1}
+                />
+                <Text size="2">{filter.label}</Text>
+              </Flex>
+            );
+          })}
+        </Box>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default HistoryFilter;

--- a/components/HistoryView/index.tsx
+++ b/components/HistoryView/index.tsx
@@ -11,6 +11,7 @@ import {
   Flex,
   Link as A,
   styled,
+  Text,
 } from "@livepeer/design-system";
 import {
   formatETH,
@@ -32,6 +33,12 @@ import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { catIpfsJson, IpfsPoll } from "utils/ipfs";
 
+import {
+  ALL_FILTER_KEYS,
+  EventFilterKey,
+  TYPENAME_TO_FILTER,
+} from "./HistoryFilter";
+
 const PAGE_SIZE = 25;
 
 const Card = styled(CardBase, {
@@ -41,7 +48,27 @@ const Card = styled(CardBase, {
   p: "$4",
 });
 
-const Index = () => {
+// Matches the empty-state card used by GatewayList / DelegatorList so empty
+// account lists look consistent across the app.
+const EmptyState = ({ children }: { children: React.ReactNode }) => (
+  <Box
+    css={{
+      marginTop: "$3",
+      border: "1px solid $neutral4",
+      borderRadius: "$4",
+      padding: "$4",
+      backgroundColor: "$neutral3",
+    }}
+  >
+    <Text>{children}</Text>
+  </Box>
+);
+
+const Index = ({
+  selectedFilters,
+}: {
+  selectedFilters: Set<EventFilterKey>;
+}) => {
   const router = useRouter();
   const query = router.query;
   const account = query.account as string;
@@ -61,6 +88,13 @@ const Index = () => {
   });
 
   const [reachedEnd, setReachedEnd] = useState(false);
+
+  // Event-type filter selection is owned by the account layout (so the filter
+  // button can live on the nav row); here we only consume it.
+  const isFiltered = selectedFilters.size !== ALL_FILTER_KEYS.length;
+  // Zero types selected — the user explicitly wants nothing shown, so we must
+  // never auto-load history chasing matches that cannot exist.
+  const noneSelected = selectedFilters.size === 0;
 
   const events = useMemo(() => {
     // First reverse the order of the array of events per transaction to have events in descending order
@@ -196,6 +230,18 @@ const Index = () => {
     ]
   );
 
+  const visibleEvents = useMemo(
+    () =>
+      mergedEvents.filter((event) => {
+        const key = TYPENAME_TO_FILTER[event?.__typename ?? ""];
+        // Only event types we actually render (and can filter on) are shown.
+        // Unmapped types render as null anyway, so excluding them keeps the
+        // visible count accurate (e.g. so the empty state shows for "None").
+        return key ? selectedFilters.has(key) : false;
+      }),
+    [mergedEvents, selectedFilters]
+  );
+
   const totalLoaded = Math.max(
     data?.transactions?.length ?? 0,
     data?.winningTicketRedeemedEvents?.length ?? 0
@@ -203,8 +249,10 @@ const Index = () => {
 
   const fetchingRef = useRef(false);
   const fetchNext = useCallback(async () => {
-    // Concurrency lock — ref so it's synchronous.
-    if (fetchingRef.current || loading) return;
+    // Concurrency lock — ref so it's synchronous. Also stop once we've reached
+    // the end or there was never more than a page to begin with.
+    if (fetchingRef.current || loading || reachedEnd || totalLoaded < PAGE_SIZE)
+      return;
     fetchingRef.current = true;
 
     try {
@@ -238,22 +286,42 @@ const Index = () => {
     } finally {
       fetchingRef.current = false;
     }
-  }, [loading, totalLoaded, fetchMoreTransactions]);
+  }, [loading, reachedEnd, totalLoaded, fetchMoreTransactions]);
 
-  // Create a sentinel ref and observe it while more pages are available.
-  const sentinelRef = useRef<HTMLDivElement>(null);
+  // Keep the latest fetchNext / noneSelected in refs so the sentinel observer
+  // can read them without being torn down and re-created on every render.
+  // Re-creating the observer re-fires on the already-in-view sentinel, which
+  // (for a short, filtered list) would crawl the entire history.
+  const fetchNextRef = useRef(fetchNext);
+  const noneSelectedRef = useRef(noneSelected);
   useEffect(() => {
-    const el = sentinelRef.current;
-    if (!el || reachedEnd || totalLoaded < PAGE_SIZE) return;
+    fetchNextRef.current = fetchNext;
+    noneSelectedRef.current = noneSelected;
+  });
+
+  // Infinite scroll: load the next page when the sentinel scrolls into view.
+  // Loading is filter-agnostic — identical to the unfiltered view — so the
+  // filter only changes what is displayed, never what is fetched. fetchNext()
+  // no-ops once the end is reached. The callback ref attaches the observer once
+  // when the sentinel mounts, so paging never self-retriggers.
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const sentinelRef = useCallback((node: HTMLDivElement | null) => {
+    observerRef.current?.disconnect();
+    if (!node) {
+      observerRef.current = null;
+      return;
+    }
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting) fetchNext();
+        if (entry.isIntersecting && !noneSelectedRef.current) {
+          fetchNextRef.current();
+        }
       },
       { rootMargin: "200px" }
     );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [fetchNext, reachedEnd, totalLoaded]);
+    observer.observe(node);
+    observerRef.current = observer;
+  }, []);
 
   if (error) {
     console.error(error);
@@ -278,7 +346,7 @@ const Index = () => {
     !data?.transactions?.length &&
     !data?.winningTicketRedeemedEvents?.length
   ) {
-    return <Box css={{ paddingTop: "$3" }}>No history</Box>;
+    return <EmptyState>No history</EmptyState>;
   }
 
   return (
@@ -291,9 +359,18 @@ const Index = () => {
       }}
     >
       <Box css={{ paddingBottom: "$3" }}>
-        {mergedEvents.map((event, i: number) => renderSwitch(event, i))}
+        {visibleEvents.map((event, i: number) => renderSwitch(event, i))}
       </Box>
-      {totalLoaded >= PAGE_SIZE && !reachedEnd && (
+      {visibleEvents.length === 0 && !loading && (
+        <EmptyState>
+          {noneSelected
+            ? "Select at least one event type to view history."
+            : isFiltered
+            ? "No events match the selected filters."
+            : "No history"}
+        </EmptyState>
+      )}
+      {!noneSelected && loading && !reachedEnd && (
         <Flex
           css={{
             position: "absolute",

--- a/components/HorizontalScrollContainer/index.tsx
+++ b/components/HorizontalScrollContainer/index.tsx
@@ -12,6 +12,10 @@ type HorizontalScrollContainerProps = {
   ariaLabel?: string;
   role?: "navigation";
   activeItemKey?: string | number;
+  // When true, the bottom border is omitted so a parent can draw a divider that
+  // also spans an action placed beside the scroll container (e.g. the history
+  // filter button sitting on the account nav row).
+  hideBorder?: boolean;
 };
 
 const getTabs = (container: HTMLDivElement) =>
@@ -68,7 +72,7 @@ const scrollActiveTabIntoView = (container: HTMLDivElement) => {
 const HorizontalScrollContainer = forwardRef<
   HTMLDivElement,
   HorizontalScrollContainerProps
->(({ children, ariaLabel, role, activeItemKey }, ref) => {
+>(({ children, ariaLabel, role, activeItemKey, hideBorder }, ref) => {
   const innerRef = useRef<HTMLDivElement | null>(null);
   const [hasOverflow, setHasOverflow] = useState(false);
 
@@ -136,14 +140,18 @@ const HorizontalScrollContainer = forwardRef<
     <Box
       css={{
         position: "relative",
-        "&::after": {
-          content: '""',
-          position: "absolute",
-          left: 0,
-          right: 0,
-          bottom: 0,
-          borderBottom: "1px solid $neutral6",
-        },
+        ...(hideBorder
+          ? {}
+          : {
+              "&::after": {
+                content: '""',
+                position: "absolute",
+                left: 0,
+                right: 0,
+                bottom: 0,
+                borderBottom: "1px solid $neutral6",
+              },
+            }),
       }}
     >
       <Box

--- a/layouts/account.tsx
+++ b/layouts/account.tsx
@@ -298,11 +298,11 @@ const AccountLayout = ({
                 ariaLabel="Account navigation tabs"
                 activeItemKey={view ?? "delegating"}
               >
-                {tabs.map((tab: TabType, i: number) => (
+                {tabs.map((tab: TabType) => (
                   <A
                     as={Link}
                     scroll={false}
-                    key={i}
+                    key={tab.href}
                     href={tab.href}
                     passHref
                     variant="subtle"

--- a/layouts/account.tsx
+++ b/layouts/account.tsx
@@ -1,6 +1,10 @@
 import BottomDrawer from "@components/BottomDrawer";
 import BroadcastingView from "@components/BroadcastingView";
 import HistoryView from "@components/HistoryView";
+import HistoryFilter, {
+  ALL_FILTER_KEYS,
+  EventFilterKey,
+} from "@components/HistoryView/HistoryFilter";
 import HorizontalScrollContainer from "@components/HorizontalScrollContainer";
 import OrchestratingView from "@components/OrchestratingView";
 import Profile from "@components/Profile";
@@ -24,7 +28,7 @@ import { useBondingManagerAddress } from "hooks/useContracts";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useWindowSize } from "react-use";
 import { useReadContract } from "wagmi";
 
@@ -72,6 +76,32 @@ const AccountLayout = ({
   const view = useMemo(
     () => ACCOUNT_VIEWS.find((v) => asPath.split("/")[3] === v),
     [asPath]
+  );
+
+  // History event-type filter. Lifted here (rather than inside HistoryView) so
+  // the filter button can sit on the nav row beside the tabs, while HistoryView
+  // consumes the selection to decide what to display. Defaults to all selected.
+  const [selectedHistoryFilters, setSelectedHistoryFilters] = useState<
+    Set<EventFilterKey>
+  >(() => new Set(ALL_FILTER_KEYS));
+  const toggleHistoryFilter = useCallback((key: EventFilterKey) => {
+    setSelectedHistoryFilters((current) => {
+      const next = new Set(current);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }, []);
+  const selectAllHistoryFilters = useCallback(
+    () => setSelectedHistoryFilters(new Set(ALL_FILTER_KEYS)),
+    []
+  );
+  const clearHistoryFilters = useCallback(
+    () => setSelectedHistoryFilters(new Set()),
+    []
   );
 
   const { setSelectedStakingAction, setBottomDrawerOpen, latestTransaction } =
@@ -255,54 +285,83 @@ const AccountLayout = ({
               </Button>
             )}
           </Flex>
-          <HorizontalScrollContainer
-            role="navigation"
-            ariaLabel="Account navigation tabs"
-            activeItemKey={view ?? "delegating"}
+          <Flex
+            css={{
+              alignItems: "flex-end",
+              borderBottom: "1px solid $neutral6",
+            }}
           >
-            {tabs.map((tab: TabType, i: number) => (
-              <A
-                as={Link}
-                scroll={false}
-                key={i}
-                href={tab.href}
-                passHref
-                variant="subtle"
-                data-active={tab.isActive ? "true" : undefined}
-                aria-current={tab.isActive ? "page" : undefined}
+            <Box css={{ flex: 1, minWidth: 0 }}>
+              <HorizontalScrollContainer
+                hideBorder
+                role="navigation"
+                ariaLabel="Account navigation tabs"
+                activeItemKey={view ?? "delegating"}
+              >
+                {tabs.map((tab: TabType, i: number) => (
+                  <A
+                    as={Link}
+                    scroll={false}
+                    key={i}
+                    href={tab.href}
+                    passHref
+                    variant="subtle"
+                    data-active={tab.isActive ? "true" : undefined}
+                    aria-current={tab.isActive ? "page" : undefined}
+                    css={{
+                      color: tab.isActive ? "$hiContrast" : "$neutral11",
+                      marginRight: "$4",
+                      fontSize: "$3",
+                      fontWeight: 500,
+                      flex: "0 0 auto",
+                      whiteSpace: "nowrap",
+                      "&:hover": {
+                        textDecoration: "none",
+                      },
+                      display: "flex",
+                      alignItems: "center",
+                    }}
+                  >
+                    <Box
+                      as="span"
+                      css={{
+                        display: "flex",
+                        alignItems: "center",
+                        minHeight: 33,
+                        paddingBottom: "$2",
+                        marginBottom: "-1px",
+                        position: "relative",
+                        zIndex: 2,
+                        borderBottom: "3px solid",
+                        borderColor: tab.isActive
+                          ? "$primary11"
+                          : "transparent",
+                      }}
+                    >
+                      {tab.name}
+                    </Box>
+                  </A>
+                ))}
+              </HorizontalScrollContainer>
+            </Box>
+            {view === "history" && (
+              <Flex
                 css={{
-                  color: tab.isActive ? "$hiContrast" : "$neutral11",
-                  marginRight: "$4",
-                  fontSize: "$3",
-                  fontWeight: 500,
                   flex: "0 0 auto",
-                  whiteSpace: "nowrap",
-                  "&:hover": {
-                    textDecoration: "none",
-                  },
-                  display: "flex",
                   alignItems: "center",
+                  marginLeft: "$3",
+                  paddingBottom: "$2",
                 }}
               >
-                <Box
-                  as="span"
-                  css={{
-                    display: "flex",
-                    alignItems: "center",
-                    minHeight: 33,
-                    paddingBottom: "$2",
-                    marginBottom: "-1px",
-                    position: "relative",
-                    zIndex: 2,
-                    borderBottom: "3px solid",
-                    borderColor: tab.isActive ? "$primary11" : "transparent",
-                  }}
-                >
-                  {tab.name}
-                </Box>
-              </A>
-            ))}
-          </HorizontalScrollContainer>
+                <HistoryFilter
+                  selected={selectedHistoryFilters}
+                  onToggle={toggleHistoryFilter}
+                  onSelectAll={selectAllHistoryFilters}
+                  onClear={clearHistoryFilters}
+                />
+              </Flex>
+            )}
+          </Flex>
           {view === "orchestrating" && (
             <OrchestratingView
               isActive={isActive}
@@ -318,7 +377,9 @@ const AccountLayout = ({
               currentRound={viewedAccount?.protocol?.currentRound}
             />
           )}
-          {view === "history" && <HistoryView />}
+          {view === "history" && (
+            <HistoryView selectedFilters={selectedHistoryFilters} />
+          )}
           {view === "broadcasting" && (
             <BroadcastingView
               gateway={account?.gateway}


### PR DESCRIPTION
## Description

Adds an **event-type filter** to the account History tab. A "Filter" popover on the nav row lets you show/hide history by event type (12 categories: Delegated, Reward calls, Reward cut & fee changes, Winning tickets, Votes, etc.), with All/None shortcuts and an active-count badge. Filter state is lifted to `AccountLayout` so the button sits beside the tabs while `HistoryView` consumes it.

Filtering is purely display-side: paging/loading is filter-agnostic, so the filter only changes what's shown, never what's fetched.

## Type of Change

- [x] feat: New feature

## Related Issue(s)

Related: #711
Closes: #511

## Changes Made

**Filter**
- New `components/HistoryView/HistoryFilter.tsx`. A popover that filters history events by type. `EVENT_FILTERS` maps each human-readable label to one or more event `__typename`s, with a reverse `TYPENAME_TO_FILTER` lookup; includes All/None shortcuts and an active-count badge
- Lift filter state (`selectedHistoryFilters`) into `layouts/account.tsx` so the Filter button renders on the nav row beside the tabs; `HistoryView` takes a `selectedFilters` prop and renders only matching events (`visibleEvents`)
- Add a `hideBorder` prop to `components/HorizontalScrollContainer` so the parent can draw a divider that spans both the tabs and the filter button on the nav row
- Rework HistoryView infinite-scroll to a callback-ref `IntersectionObserver` that attaches once on sentinel mount, so paging never self-retriggers (a re-created observer would re-fire on the in-view sentinel and crawl the entire history on a short filtered list)
- "None selected" suppresses auto-loading and shows a prompt; shared `EmptyState` card (matching Gateway/Delegator lists) with contextual messages

## Testing

<!-- Check all that apply and add notes if useful -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] All tests passing

### How to test (optional unless test is not trivial)

**Filter**
- On the History tab, open **Filter** → toggle event types; the list updates to show only selected types. Check the active-count badge, All/None shortcuts, and that "None" shows the "Select at least one event type" prompt without crawling history. Confirm infinite scroll still pages normally with a partial filter.
- `pnpm typecheck`, `pnpm exec eslint … --max-warnings 0`, `prettier` all clean.

## Impact / Risk

Risk level: **Low**

Impacted areas: **UI** only (History tab nav row + filter popover). Display-only filtering. No DB, infra, config, API, or server code.

User impact: The History tab gains a Filter popover to narrow events by type. Default shows all events (current behavior), so the change is purely additive. Nothing existing is altered.

Rollback plan: Plain PR revert. The change is additive (new `HistoryFilter` component + a `selectedFilters` prop + a `hideBorder` prop), so reverting removes the filter with no migration or config cleanup.

## Screenshots / Recordings (if applicable)
<img width="954" height="194" alt="Screenshot 2026-06-28 at 00 56 23" src="https://github.com/user-attachments/assets/0d417419-7291-48a2-b2d6-afb48486abbf" />
<img width="968" height="488" alt="Screenshot 2026-06-28 at 00 56 43" src="https://github.com/user-attachments/assets/ff8d43aa-b94d-4054-8cd9-13173642ca35" />

## Additional Notes

- **History filtering is display-only.** Loading/paging is identical to the unfiltered view (`fetchNext` no-ops at the end); the filter never changes what's fetched, only what's rendered.
- Filter state is in-component, so it resets on tab switch (each tab is a separate route). Making it sticky (URL param) is a possible follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added event-type filter controls to the history view, including select all/none, an active filter count badge, and per-type toggles.
  * History results are now filtered by the selected event types, with tailored empty states when nothing matches.
* **Bug Fixes**
  * Improved infinite scrolling so additional items load only when appropriate, including while filtering is active.
* **Style**
  * Added a `hideBorder` option to horizontal scroll containers for cases where the bottom border should be removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->