### PR TITLE
fix: return partial score data when a metrics upstream is down

### DIFF
--- a/components/OrchestratingView/index.tsx
+++ b/components/OrchestratingView/index.tsx
@@ -97,7 +97,7 @@ const Index = ({ currentRound, transcoder, isActive }: Props) => {
   const maxScore = useMemo(() => {
     const topTransData = Object.keys(scores?.scores ?? {}).reduce(
       (prev, curr) => {
-        const score = scores?.scores[curr];
+        const score = scores?.scores?.[curr];
         const region =
           knownRegions?.regions?.find((r) => r.id === curr)?.name ?? "N/A";
         if (
@@ -107,7 +107,7 @@ const Index = ({ currentRound, transcoder, isActive }: Props) => {
         ) {
           return {
             region: region,
-            score: scores?.scores[curr],
+            score,
           };
         }
         return prev;
@@ -128,8 +128,9 @@ const Index = ({ currentRound, transcoder, isActive }: Props) => {
           precision: 1,
         })} - ${maxScore.transcoding.region}`
       : "";
-    return outputTrans ? transcodingInfo : "N/A";
-  }, [maxScore]);
+    if (outputTrans) return transcodingInfo;
+    return scores?.scores === null ? "Unavailable" : "N/A";
+  }, [maxScore, scores]);
 
   const maxAIScoreOutput = useMemo(() => {
     const outputAI = maxScore.ai?.value && maxScore.ai?.value > 0;
@@ -148,8 +149,11 @@ const Index = ({ currentRound, transcoder, isActive }: Props) => {
           score: aiInfo,
           modelText: `. The pipeline and model for this Orchestrator was '${maxScore.ai?.pipeline}' and '${maxScore.ai?.model}'`,
         }
-      : { score: "N/A", modelText: "" };
-  }, [knownRegions?.regions, maxScore]);
+      : {
+          score: scores?.topAIScore === null ? "Unavailable" : "N/A",
+          modelText: "",
+        };
+  }, [knownRegions?.regions, maxScore, scores]);
 
   return (
     <Box
@@ -223,7 +227,13 @@ const Index = ({ currentRound, transcoder, isActive }: Props) => {
           className="masonry-grid_item"
           label="Price / Pixel"
           tooltip="The most recent price for transcoding which the orchestrator is currently advertising off-chain to gateways. This may be different from on-chain pricing."
-          value={scores ? `${formatNumber(scores.pricePerPixel)} WEI` : "N/A"}
+          value={
+            !scores
+              ? "N/A"
+              : scores.pricePerPixel === null
+              ? "Unavailable"
+              : `${formatNumber(scores.pricePerPixel)} WEI`
+          }
         />
         {/* <Stat
           className="masonry-grid_item"

--- a/lib/api/types/get-performance.ts
+++ b/lib/api/types/get-performance.ts
@@ -9,15 +9,16 @@ export type Score = {
   orchestrator: string;
 };
 
+// Null means the upstream could not be reached; empty or zero means no data.
 export type PerformanceMetrics = {
-  successRates: RegionalValues;
-  roundTripScores: RegionalValues;
+  successRates: RegionalValues | null;
+  roundTripScores: RegionalValues | null;
 
-  scores: RegionalValues;
+  scores: RegionalValues | null;
 
-  pricePerPixel: number;
+  pricePerPixel: number | null;
 
-  topAIScore: Score;
+  topAIScore: Score | null;
 };
 
 export type AllPerformanceMetrics = {

--- a/pages/api/score/[address].tsx
+++ b/pages/api/score/[address].tsx
@@ -8,6 +8,7 @@ import {
 import {
   PerformanceMetrics,
   RegionalValues,
+  Score,
 } from "@lib/api/types/get-performance";
 import { CHAIN_INFO, DEFAULT_CHAIN_ID } from "@lib/chains";
 import { fetchWithRetry } from "@lib/fetchWithRetry";
@@ -30,14 +31,6 @@ export type MetricsResponse = {
     | undefined;
 };
 
-type ScoreResponse = {
-  value: number;
-  region: string;
-  model: string;
-  pipeline: string;
-  orchestrator: string;
-};
-
 export type PriceResponse = {
   Address: string;
   ServiceURI: string;
@@ -53,6 +46,34 @@ export type PriceResponse = {
   UpdatedAt: number;
 }[];
 
+/**
+ * Fetch and parse JSON from a given URL.
+ * @returns The parsed JSON, or null if the fetch fails. Never rejects, so one
+ * failed upstream cannot reject a Promise.all.
+ */
+const fetchJson = async <T,>(url: string): Promise<T | null> => {
+  try {
+    const response = await fetchWithRetry(url);
+
+    if (!response.ok) {
+      console.error(
+        `Fetch error: ${url}`,
+        response.status,
+        (await response.text()).slice(0, 500)
+      );
+      return null;
+    }
+
+    return await response.json();
+  } catch (err) {
+    console.error(
+      `Fetch error: ${url}`,
+      err instanceof Error ? err.message : err
+    );
+    return null;
+  }
+};
+
 const handler = async (
   req: NextApiRequest,
   res: NextApiResponse<PerformanceMetrics | null>
@@ -63,8 +84,6 @@ const handler = async (
     if (method === "GET") {
       const { address } = req.query;
 
-      res.setHeader("Cache-Control", getCacheControlHeader("hour"));
-
       if (!!address && !Array.isArray(address) && isAddress(address)) {
         const transcoderId = address.toLowerCase();
 
@@ -72,54 +91,32 @@ const handler = async (
         const metricsUrl = `${process.env.NEXT_PUBLIC_METRICS_SERVER_URL}/api/aggregated_stats?orchestrator=${transcoderId}`;
         const pricingUrl = `${CHAIN_INFO[DEFAULT_CHAIN_ID].pricingUrl}?excludeUnavailable=False`;
 
-        const [topScoreResponse, metricsResponse, priceResponse] =
-          await Promise.all([
-            fetchWithRetry(topScoreUrl),
-            fetchWithRetry(metricsUrl),
-            fetchWithRetry(pricingUrl),
-          ]);
+        const [topAIScore, metrics, transcodersWithPrice] = await Promise.all([
+          fetchJson<Score>(topScoreUrl),
+          fetchJson<MetricsResponse>(metricsUrl),
+          fetchJson<PriceResponse>(pricingUrl),
+        ]);
 
-        if (!topScoreResponse.ok) {
-          const errorText = await topScoreResponse.text();
-          console.error(
-            "Top AI score fetch error:",
-            topScoreResponse.status,
-            errorText
-          );
-          return externalApiError(res, "AI metrics server");
+        // Every upstream being down is never a legitimate empty state, so fail
+        // loudly rather than rendering a healthy-looking orchestrator with no data.
+        if (!topAIScore && !metrics && !transcodersWithPrice) {
+          return externalApiError(res, "all metrics servers");
         }
 
-        if (!metricsResponse.ok) {
-          const errorText = await metricsResponse.text();
-          console.error(
-            "Metrics fetch error:",
-            metricsResponse.status,
-            errorText
-          );
-          return externalApiError(res, "metrics server");
-        }
+        // Expire quickly so upstream recovery is not hidden for an hour.
+        const degraded = !topAIScore || !metrics || !transcodersWithPrice;
+        res.setHeader(
+          "Cache-Control",
+          getCacheControlHeader(degraded ? "minute" : "hour")
+        );
 
-        if (!priceResponse.ok) {
-          const errorText = await priceResponse.text();
-          console.error(
-            "Transcoder price fetch error:",
-            priceResponse.status,
-            errorText
-          );
-          return externalApiError(res, "pricing server");
-        }
-
-        const topAIScore: ScoreResponse = await topScoreResponse.json();
-        const metrics: MetricsResponse = await metricsResponse.json();
-        const transcodersWithPrice: PriceResponse = await priceResponse.json();
-
-        const transcoderWithPrice = transcodersWithPrice.find((t) =>
+        const transcoderWithPrice = transcodersWithPrice?.find((t) =>
           checkAddressEquality(t.Address, transcoderId)
         );
 
         const uniqueRegions = (() => {
           const keys = new Set<string>();
-          Object.values(metrics).forEach((metric) => {
+          Object.values(metrics ?? {}).forEach((metric) => {
             if (metric) {
               Object.keys(metric).forEach((key) => keys.add(key));
             }
@@ -130,8 +127,10 @@ const handler = async (
         const createMetricsObject = (
           metricKey: keyof Metric,
           transcoderId: string,
-          metrics: MetricsResponse
-        ): RegionalValues => {
+          metrics: MetricsResponse | null
+        ): RegionalValues | null => {
+          if (!metrics) return null;
+
           const metricsObject: RegionalValues = uniqueRegions.reduce(
             (acc, metricsRegionKey) => {
               const value =
@@ -153,7 +152,9 @@ const handler = async (
         };
 
         const combined: PerformanceMetrics = {
-          pricePerPixel: transcoderWithPrice?.PricePerPixel ?? 0,
+          pricePerPixel: transcodersWithPrice
+            ? transcoderWithPrice?.PricePerPixel ?? 0
+            : null,
           successRates: createMetricsObject(
             "success_rate",
             transcoderId,


### PR DESCRIPTION
## Problem

The AI metrics server (`leaderboard-api.livepeer.cloud`) currently returns 404 for **every** route — `/`, `/healthz`, and `/api/docs` all return the bare Go `404 page not found`, so it is a router serving nothing rather than a URL change on our side.

Because `/api/score/[address]` fetched all three upstreams and failed on any non-OK response, this meant **every** per-orchestrator score request returned a 502, even though the transcoding metrics and pricing upstreams were healthy. One optional upstream took down the whole orchestrator page.

## Change

Each upstream is now fetched independently and falls back to `null` for its own field. A `null` means "we could not reach this upstream"; an empty or zeroed value keeps its existing meaning of "the upstream answered and has no data". Those stay distinguishable because the upstreams return `{}` with a 200 for an unknown orchestrator, so no extra bookkeeping field is needed.

- **502 only when every upstream is down**, since that is never a legitimate empty state.
- **Partial responses cache for a minute** instead of an hour, so upstream recovery is not hidden. The `Cache-Control` header moved below the address check because the TTL now depends on the fetch results.
- **The UI shows "Unavailable" rather than "N/A"** for unreachable fields. An orchestrator with a good AI score rendering "N/A" during our outage reads as *"this orchestrator does not do AI work"* — a claim about them caused by a fault on our side.
- **`pricePerPixel` is `null` rather than `0`** when the pricing server is unreachable, so an outage cannot advertise an orchestrator as free. A `0` from a healthy server still means genuinely unpriced.

Also fixes network errors and timeouts skipping the per-upstream error logging entirely — those threw out of `Promise.all` and surfaced as a generic 500 with no indication of which upstream failed.

## Verification

Against the live outage:

```
$ curl -i localhost:3000/api/score/0x847791cbf03be716a7fe9dc8c9affe17bd49ae5e
HTTP/1.1 200 OK
Cache-Control: public, s-maxage=60, stale-while-revalidate=60

{"pricePerPixel":245.796,"successRates":{...,"GLOBAL":99.26},"scores":{...},"topAIScore":null}
```

200 instead of the previous 502, `topAIScore: null`, price and transcoding scores intact, and the one-minute TTL. `tsc`, ESLint, and Prettier all pass.

Not verified: the healthy path (`s-maxage≈3600`) and the all-upstreams-down 502, since the AI server cannot currently be brought back and the other two cannot be taken down locally.

## Notes for reviewers

- Invalid-address 400s are no longer CDN-cached, a side effect of moving the `Cache-Control` header below the address check. Previously they were cached for an hour. Easy to restore if unwanted.
- `pages/api/score/index.tsx:86-89` has a pre-existing bug where `pricePerPixel` is assigned the whole `.find()` result instead of `.PricePerPixel`. Left untouched for a separate PR — it sits on the field this PR makes nullable, so it is adjacent but unrelated.
- `pages/api/regions/index.ts` duplicates this fetch-or-null pattern without the try/catch or logging. Hoisting `fetchJson` into `lib/` would let it drop the copy, but that is out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Performance metrics now clearly distinguish unavailable data from missing or zero-valued results.
  * Regional AI and transcoding scores, price-per-pixel values, and related statistics display “Unavailable” when source data cannot be provided, instead of misleading defaults.
  * Score retrieval now tolerates partial upstream failures and continues displaying available information.
  * Degraded responses use shorter-lived caching so refreshed data becomes available sooner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->