### PR TITLE
fix: source current round timing on-chain instead of the subgraph

### DIFF
--- a/pages/api/current-round.tsx
+++ b/pages/api/current-round.tsx
@@ -1,7 +1,9 @@
-import { getCacheControlHeader, getCurrentRound } from "@lib/api";
+import { getCacheControlHeader } from "@lib/api";
+import { roundsManager } from "@lib/api/abis/main/RoundsManager";
+import { getContractAddress } from "@lib/api/contracts";
 import { internalError, methodNotAllowed } from "@lib/api/errors";
 import { CurrentRoundInfo } from "@lib/api/types/get-current-round";
-import { l1PublicClient } from "@lib/chains";
+import { l2PublicClient } from "@lib/chains";
 import { NextApiRequest, NextApiResponse } from "next";
 
 const handler = async (
@@ -14,28 +16,38 @@ const handler = async (
     if (method === "GET") {
       res.setHeader("Cache-Control", getCacheControlHeader("minute"));
 
-      const {
-        data: { protocol, _meta },
-      } = await getCurrentRound();
-      const currentRound = protocol?.currentRound;
+      const roundsManagerAddress = await getContractAddress("RoundsManager");
 
-      if (!currentRound) {
-        throw new Error("No current round found");
-      }
+      const contract = {
+        address: roundsManagerAddress,
+        abi: roundsManager,
+      } as const;
 
-      if (!_meta?.block) {
-        throw new Error("No block number found");
-      }
-
-      const { id, startBlock, initialized } = currentRound;
-
-      const currentL2Block = _meta.block.number;
-      const currentL1Block = await l1PublicClient.getBlockNumber();
+      const [id, startBlock, initialized, currentL1Block, currentL2Block] =
+        await Promise.all([
+          l2PublicClient.readContract({
+            ...contract,
+            functionName: "currentRound",
+          }),
+          l2PublicClient.readContract({
+            ...contract,
+            functionName: "currentRoundStartBlock",
+          }),
+          l2PublicClient.readContract({
+            ...contract,
+            functionName: "currentRoundInitialized",
+          }),
+          l2PublicClient.readContract({
+            ...contract,
+            functionName: "blockNum",
+          }),
+          l2PublicClient.getBlockNumber(),
+        ]);
 
       const roundInfo: CurrentRoundInfo = {
         id: Number(id),
         startBlock: Number(startBlock),
-        initialized,
+        initialized: Boolean(initialized),
         currentL1Block: Number(currentL1Block),
         currentL2Block: Number(currentL2Block),
       };


### PR DESCRIPTION
## What
Read the current round's timing (`id`, `startBlock`, `initialized`, current block) directly from the `RoundsManager` contract via `l2PublicClient`, instead of from the subgraph.

## Why
`/current-round` previously read `id`/`startBlock`/`initialized` from the subgraph but the current block from a live RPC call. That mixes two sources: the round state depends on subgraph freshness, and when subgraph indexing stalls the stale round is compared against a live block, so the tracker shows a stale round number and its counters run past the round length.

Reading `currentRoundStartBlock` and `blockNum` from the same contract in one snapshot makes the computation self-consistent and independent of subgraph health. Response shape is unchanged, no client/type changes.

Aggregate stats (fees, rewards, total supply) still come from the subgraph; they have no cheap on-chain equivalent, and a stale fee number isn't misleading the way a wrong round number is.

The old subgraph null-guards (`No current round found` / `No block number found`) are dropped, contract reads always return a value, and RPC failures surface via the existing `try/catch`.

The display-clamp changes originally bundled here are split into #732 so this data-source change can be reverted independently.

## Testing
- `tsc`/eslint clean on the changed file
- `/api/current-round` returns on-chain-matching values with a live block