### PR TITLE
feat: warn when subgraph indexing falls behind

### DIFF
--- a/apollo/subgraph.ts
+++ b/apollo/subgraph.ts
@@ -9656,7 +9656,7 @@ export type GatewaysQuery = { __typename: 'Query', gateways: Array<{ __typename:
 export type MetaQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MetaQuery = { __typename: 'Query', _meta?: { __typename: '_Meta_', hasIndexingErrors: boolean } | null };
+export type MetaQuery = { __typename: 'Query', _meta?: { __typename: '_Meta_', hasIndexingErrors: boolean, block: { __typename: '_Block_', number: number } } | null };
 
 export type OrchestratorsQueryVariables = Exact<{
   currentRound?: InputMaybe<Scalars['BigInt']>;
@@ -10310,6 +10310,9 @@ export type GatewaysQueryResult = Apollo.QueryResult<GatewaysQuery, GatewaysQuer
 export const MetaDocument = gql`
     query meta {
   _meta {
+    block {
+      number
+    }
     hasIndexingErrors
   }
 }

--- a/hooks/index.tsx
+++ b/hooks/index.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 // DO NOT IMPORT useHandleTransaction due to @rainbow-me/rainbowkit issues with SSR
 export * from "./useExplorerStore";
 export * from "./usePersistedExplorerListState";
+export * from "./useSubgraphHealth";
 export * from "./useSwr";
 export * from "./wallet";
 

--- a/hooks/useSubgraphHealth.ts
+++ b/hooks/useSubgraphHealth.ts
@@ -1,0 +1,16 @@
+import useSWR from "swr";
+
+// How often the client re-checks the shared subgraph-health signal, in ms.
+const HEALTH_POLL_INTERVAL = 60_000;
+
+/**
+ * Polls the server-side drift check (/api/subgraph-health) and returns true when
+ * Explorer data may be stale because the subgraph is behind chain head.
+ */
+export const useSubgraphDegraded = (): boolean => {
+  const { data } = useSWR<{ degraded: boolean }>("/subgraph-health", {
+    refreshInterval: HEALTH_POLL_INTERVAL,
+  });
+
+  return data?.degraded === true;
+};

--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -59,6 +59,7 @@ import React, {
 } from "react";
 import { isMobile } from "react-device-detect";
 import ReactGA from "react-ga";
+import { FiInfo } from "react-icons/fi";
 import { LuRadioTower } from "react-icons/lu";
 import { useWindowSize } from "react-use";
 import { Chain } from "viem";
@@ -71,6 +72,7 @@ import {
   useExplorerStore,
   useOnClickOutside,
   usePendingFeesAndStakeData,
+  useSubgraphDegraded,
 } from "../hooks";
 import Ballot from "../public/img/ballot.svg";
 import DNS from "../public/img/dns.svg";
@@ -142,6 +144,7 @@ const Layout = ({ children, title = "Livepeer Explorer" }) => {
   const currentRound = useCurrentRoundData();
   const pendingFeesAndStake = usePendingFeesAndStakeData(accountAddress);
   const isBannerDisabledByQuery = query.disableUrlVerificationBanner === "true";
+  const subgraphDegraded = useSubgraphDegraded();
 
   const viewedAccountId = query?.account?.toString().toLowerCase();
   const { data: viewedAccountData } = useAccountQuery({
@@ -412,6 +415,45 @@ const Layout = ({ children, title = "Livepeer Explorer" }) => {
             )}
             {bannerActive && (
               <URLVerificationBanner onDismiss={onBannerDismiss} />
+            )}
+            {subgraphDegraded && (
+              <Flex
+                role="status"
+                css={{
+                  width: "100%",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  backgroundColor: "$blue3",
+                  borderBottom: "1px solid $blue6",
+                  fontSize: "$2",
+                  gap: "$2",
+                  paddingLeft: "$4",
+                  paddingRight: "$4",
+                  paddingTop: "$2",
+                  paddingBottom: "$2",
+                  textAlign: "center",
+                  "@bp3": {
+                    fontSize: "$3",
+                  },
+                }}
+              >
+                <Box
+                  as={FiInfo}
+                  aria-hidden="true"
+                  css={{
+                    color: "$blue11",
+                    width: 16,
+                    height: 16,
+                    flexShrink: 0,
+                  }}
+                />
+                <Text
+                  css={{ color: "$blue11", fontWeight: 400, lineHeight: 1.4 }}
+                >
+                  Some Explorer data may be temporarily out of date due to a
+                  subgraph indexing issue — the protocol is operating normally.
+                </Text>
+              </Flex>
             )}
 
             <Box css={{}}>

--- a/pages/api/subgraph-health.tsx
+++ b/pages/api/subgraph-health.tsx
@@ -1,0 +1,49 @@
+import { l2PublicClient } from "@lib/chains";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getApollo, MetaDocument, MetaQuery } from "../../apollo";
+
+// Block lag before data is stale. ~3,600 Arbitrum One blocks (~4/s) ≈ 15 min.
+const MAX_BLOCK_DRIFT = 3_600;
+
+/**
+ * Reports whether the subgraph is far enough behind the L2 chain head that
+ * Explorer data may be stale. Uses block drift, not hasIndexingErrors, which
+ * stays false during a fatal halt. Fails open on a failed probe.
+ */
+const subgraphHealth = async (req: NextApiRequest, res: NextApiResponse) => {
+  const method = req.method;
+  if (method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).end(`Method ${method} Not Allowed`);
+  }
+
+  const [metaResult, chainHeadResult] = await Promise.allSettled([
+    getApollo().query<MetaQuery>({
+      query: MetaDocument,
+      // Bypass the shared InMemoryCache, which would pin a stale block.
+      fetchPolicy: "no-cache",
+    }),
+    l2PublicClient.getBlockNumber(),
+  ]);
+
+  const servedBlock =
+    metaResult.status === "fulfilled"
+      ? metaResult.value.data._meta?.block?.number
+      : undefined;
+  const chainHead =
+    chainHeadResult.status === "fulfilled"
+      ? Number(chainHeadResult.value)
+      : undefined;
+
+  const degraded =
+    servedBlock != null && chainHead != null
+      ? chainHead - servedBlock > MAX_BLOCK_DRIFT
+      : false;
+
+  // Cache briefly so one server-side check is shared across clients.
+  res.setHeader("Cache-Control", "s-maxage=60, stale-while-revalidate=60");
+  return res.status(200).json({ degraded });
+};
+
+export default subgraphHealth;

--- a/queries/meta.graphql
+++ b/queries/meta.graphql
@@ -1,5 +1,8 @@
 query meta {
   _meta {
+    block {
+      number
+    }
     hasIndexingErrors
   }
 }


### PR DESCRIPTION
## Summary

Adds a site-wide info banner that appears automatically when the subgraph is significantly behind the L2 chain head (e.g. a halt like livepeer/subgraph#243), signalling that Explorer data may be temporarily out of date. The Livepeer protocol itself is unaffected.

## How it works

- `/api/subgraph-health` computes **block drift** server-side: the subgraph's served `_meta.block.number` vs `l2PublicClient` chain head. Drift beyond ~15 min (~3,600 Arbitrum One blocks) → `degraded`.
- Uses drift, **not** `hasIndexingErrors` — that flag stays `false` during a fatal halt (verified against the live failed deployment), so it can't be trusted for this.
- `useSubgraphDegraded` polls the endpoint every 60s; a blue info banner renders below the URL verification banner and clears itself on recovery.
- Runs server-side with `Cache-Control: s-maxage=60`, so one check is shared across all clients (no per-tab subgraph/RPC calls).

Banner copy:
> Some Explorer data may be temporarily out of date due to a subgraph indexing issue — the protocol is operating normally.

## Testing

- `tsc` + `eslint` pass.
- Local preview (no shared cache in dev): temporarily make `useSubgraphDegraded` return `true`, or lower `MAX_BLOCK_DRIFT`.