### PR TITLE
fix: manually surface LIP-118 poll while subgraph indexing is behind

### DIFF
--- a/constants/manualPolls.ts
+++ b/constants/manualPolls.ts
@@ -1,0 +1,58 @@
+import { PollsQuery } from "apollo";
+
+/**
+ * TEMPORARY stopgap: manually surface governance polls that were created while
+ * the subgraph was behind on indexing, so voting stays functional during the
+ * outage. Entries are shaped like subgraph poll results and merged into the
+ * voting list/detail pages, deduped by poll address — once the subgraph
+ * reindexes a poll, its real (tallied) copy wins and the manual entry drops out.
+ *
+ * These carry no vote tally (the subgraph computes the stake-weighted counts),
+ * so the UI shows a "counts not loaded" note for them; voting itself is on-chain
+ * and works regardless.
+ *
+ * Remove entries (or delete this file and its imports) once indexing recovers.
+ */
+type SubgraphPoll = PollsQuery["polls"][number];
+
+export const MANUAL_POLLS: SubgraphPoll[] = [
+  {
+    // LIP-118 "Delegated Reward Calling" — created during the subgraph indexing halt.
+    // tx: 0xb8ab2a824b4a5b16b76be99f1313a8238f35acc2259b139562277e1df8ba02e4
+    __typename: "Poll",
+    id: "0x74479927117d4158b32c03d5400c14bdd7e6a46a",
+    proposal: "QmcYGZp3SipMEz699bpeZqocdouYWTE2zHG8TMdaSYqowF",
+    endBlock: "25622119",
+    quorum: "333300",
+    quota: "500000",
+    tally: null,
+    votes: [],
+  },
+];
+
+const norm = (id: string) => id.toLowerCase();
+
+/** The manually-listed poll for `id`, if any. */
+export const getManualPoll = (
+  id: string | undefined | null
+): SubgraphPoll | undefined =>
+  id ? MANUAL_POLLS.find((p) => norm(p.id) === norm(id)) : undefined;
+
+/** Whether `id` is a manually-listed poll (i.e. not sourced from the subgraph). */
+export const isManualPoll = (id: string | undefined | null): boolean =>
+  Boolean(getManualPoll(id));
+
+/**
+ * Merge manual polls into a subgraph poll list, deduped by address. The subgraph
+ * copy takes precedence, so a poll that has since been indexed is not duplicated.
+ */
+export const mergeManualPolls = (
+  polls: SubgraphPoll[] | undefined
+): SubgraphPoll[] => {
+  const list = polls ? [...polls] : [];
+  const seen = new Set(list.map((p) => norm(p.id)));
+  for (const poll of MANUAL_POLLS) {
+    if (!seen.has(norm(poll.id))) list.push(poll);
+  }
+  return list;
+};

--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -40,6 +40,7 @@ import {
   useTreasuryProposalsQuery,
 } from "apollo";
 import { BRIDGE_LPT_URL, GET_LPT_URL } from "constants/links";
+import { mergeManualPolls } from "constants/manualPolls";
 import { BigNumber } from "ethers";
 import { CHAIN_INFO, DEFAULT_CHAIN_ID } from "lib/chains";
 import dynamic from "next/dynamic";
@@ -178,7 +179,7 @@ const Layout = ({ children, title = "Livepeer Explorer" }) => {
 
   const totalActivePolls = useMemo(
     () =>
-      pollData?.polls.filter(
+      mergeManualPolls(pollData?.polls).filter(
         (p) =>
           (currentRound?.currentL1Block ?? Number.MAX_VALUE) <=
           parseInt(p.endBlock)

--- a/lib/api/polls.ts
+++ b/lib/api/polls.ts
@@ -170,24 +170,33 @@ const getEstimatedEndTimeByBlockNumber = async (
 };
 
 const getTotalStake = async (l2BlockNumber?: number | undefined) => {
-  const client = getApollo();
+  try {
+    const client = getApollo();
 
-  const protocolResponse = await client.query<
-    ProtocolByBlockQuery,
-    ProtocolByBlockQueryVariables
-  >({
-    query: ProtocolByBlockDocument,
-    variables: l2BlockNumber
-      ? {
-          block: {
-            number: l2BlockNumber,
-          },
-        }
-      : undefined,
-    fetchPolicy: "network-only",
-  });
+    const protocolResponse = await client.query<
+      ProtocolByBlockQuery,
+      ProtocolByBlockQueryVariables
+    >({
+      query: ProtocolByBlockDocument,
+      variables: l2BlockNumber
+        ? {
+            block: {
+              number: l2BlockNumber,
+            },
+          }
+        : undefined,
+      fetchPolicy: "network-only",
+    });
 
-  return protocolResponse?.data?.protocol?.totalActiveStake;
+    return protocolResponse?.data?.protocol?.totalActiveStake;
+  } catch (err) {
+    // The subgraph can be unavailable (e.g. an indexing halt). Total stake only
+    // feeds participation percentages, so degrade gracefully instead of failing
+    // the whole poll render — this keeps manually-listed polls viewable/votable.
+    const detail = err instanceof Error ? err.message : String(err);
+    console.warn(`Could not fetch total stake from subgraph (${detail})`);
+    return undefined;
+  }
 };
 
 const getL2BlockRangeForL1 = async (l1BlockNumber: number) => {

--- a/pages/voting/[poll].tsx
+++ b/pages/voting/[poll].tsx
@@ -28,6 +28,7 @@ import {
   useVoteQuery,
 } from "apollo";
 import { sentenceCase } from "change-case";
+import { getManualPoll, isManualPoll } from "constants/manualPolls";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -90,18 +91,22 @@ const Poll = () => {
 
   useEffect(() => {
     const init = async () => {
-      if (data && currentRound?.currentL1Block) {
+      // Fall back to a manually-listed poll when the subgraph doesn't have it
+      // (e.g. created while indexing was down), so it stays viewable/votable.
+      const source = data?.poll ?? getManualPoll(pollId);
+      if (source && currentRound?.currentL1Block) {
         const response = await getPollExtended(
-          data.poll,
+          source,
           currentRound.currentL1Block
         );
         setPollData(response);
       }
     };
     init();
-  }, [data, currentRound?.currentL1Block]);
+  }, [data, pollId, currentRound?.currentL1Block]);
 
-  if (pollError) {
+  // Only 404 on a genuine subgraph error with no manual fallback for this poll.
+  if (pollError && !getManualPoll(pollId)) {
     return <FourZeroFour />;
   }
 
@@ -212,6 +217,23 @@ const Poll = () => {
             </Box>
 
             <Box>
+              {isManualPoll(pollData.id) && (
+                <Box
+                  css={{
+                    marginBottom: "$3",
+                    padding: "$3",
+                    borderRadius: "$3",
+                    border: "1px solid $blue5",
+                    backgroundColor: "$blue2",
+                  }}
+                >
+                  <Text size="1" css={{ color: "$blue11" }}>
+                    Live vote counts aren&apos;t available for this poll yet —
+                    the subgraph is still indexing it. The totals below may read
+                    0 until indexing catches up. Voting works normally.
+                  </Text>
+                </Box>
+              )}
               <Box
                 css={{
                   display: "grid",

--- a/pages/voting/index.tsx
+++ b/pages/voting/index.tsx
@@ -15,6 +15,7 @@ import {
 } from "@livepeer/design-system";
 import { usePollsQuery } from "apollo";
 import { sentenceCase } from "change-case";
+import { mergeManualPolls } from "constants/manualPolls";
 import { useCurrentRoundData } from "hooks";
 import { LAYOUT_MAX_WIDTH } from "layouts/constants";
 import { getLayout } from "layouts/main";
@@ -50,11 +51,14 @@ const Voting = () => {
   const currentRound = useCurrentRoundData();
 
   useEffect(() => {
-    if (data && currentRound?.currentL1Block) {
+    // Render as soon as the (on-chain) current round is available, even if the
+    // subgraph query returned nothing, so manually-listed polls still show while
+    // indexing is down. mergeManualPolls tolerates `data` being undefined.
+    if (currentRound?.currentL1Block) {
       const init = async () => {
         setPolls(
           await Promise.all(
-            (data?.polls ?? []).map((p) =>
+            mergeManualPolls(data?.polls).map((p) =>
               getPollExtended(p, currentRound.currentL1Block)
             )
           )


### PR DESCRIPTION
## Summary

A governance poll created while the subgraph was behind on indexing — **LIP-118 "Delegated Reward Calling"** ([creation tx](https://arbiscan.io/tx/0xb8ab2a824b4a5b16b76be99f1313a8238f35acc2259b139562277e1df8ba02e4)), doesn't show up on the voting pages or in the Governance nav badge, because those are sourced entirely from the subgraph. Voting itself is an on-chain action, but the poll was unreachable through the UI.

This adds a **temporary** manual entry so the poll is listed and votable during the outage. It self-cleans once the subgraph reindexes the poll.

## What changed

- **`constants/manualPolls.ts`** (new) — `MANUAL_POLLS` (subgraph-shaped entries) seeded with LIP-118, plus `mergeManualPolls` / `getManualPoll` / `isManualPoll` helpers. Merges are **deduped by poll address**, so the real subgraph copy wins once indexed and the manual entry drops out automatically.
- **`pages/voting/index.tsx`** — merge manual polls into the list; render as soon as the on-chain current round is available (so the list shows even if the subgraph query returns nothing).
- **`pages/voting/[poll].tsx`** — fall back to the manual entry on the detail page; don't 404 when a manual entry exists; show a blue "counts not loaded" note above the tally for manual polls.
- **`layouts/main.tsx`** — include manual polls in the active-poll count so the green **Governance** badge reflects the live LIP.
- **`lib/api/polls.ts`** — `getTotalStake` degrades gracefully (returns `undefined`) if the subgraph is unavailable, so a manual poll still renders during a full outage.

## Behavior

- **Casting votes works normally** — it's on-chain (`Poll.vote`), and the eligibility gate reads on-chain pending stake, not the subgraph.
- **Live tallies are not reconstructed** — manual polls carry no tally, so vote counts read 0 until indexing catches up (hence the note). Cast votes are recorded on-chain and backfill automatically on recovery.

## Reverting

Delete `constants/manualPolls.ts` and its imports (or just empty the `MANUAL_POLLS` array) once the subgraph has reindexed the poll.

## Testing

- `pnpm typecheck` + `pnpm lint` pass.
- Pre-commit prettier/eslint hooks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback support for manually configured governance polls when indexing is unavailable.
  * Added a notice on manually recovered polls indicating that live vote counts may be delayed.
  * Active governance poll counts now include available manual poll entries.

* **Bug Fixes**
  * Voting pages can load when poll indexing data is temporarily unavailable.
  * Poll rendering now handles active stake query failures without breaking the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->