### PR TITLE
fix: source round length and lock state on-chain in the round tracker

### DIFF
--- a/components/RoundStatus/index.tsx
+++ b/components/RoundStatus/index.tsx
@@ -37,14 +37,16 @@ const Index = ({
 
   const currentRoundInfo = useCurrentRoundData();
 
+  // Round timing/lock come entirely from the RoundsManager (via /current-round),
+  // so the tracker stays consistent and live even when the subgraph is behind.
   const blocksRemaining = useMemo(
     () =>
-      currentRoundInfo?.initialized && protocol
-        ? +protocol.roundLength -
-          (+Number(currentRoundInfo.currentL1Block) -
-            +Number(currentRoundInfo.startBlock))
+      currentRoundInfo?.initialized
+        ? currentRoundInfo.roundLength -
+          (Number(currentRoundInfo.currentL1Block) -
+            Number(currentRoundInfo.startBlock))
         : 0,
-    [protocol, currentRoundInfo]
+    [currentRoundInfo]
   );
   const timeRemaining = useMemo(
     () => AVERAGE_L1_BLOCK_TIME * blocksRemaining,
@@ -61,19 +63,13 @@ const Index = ({
 
   const percentage = useMemo(
     () =>
-      protocol
-        ? (blocksSinceCurrentRoundStart / +protocol.roundLength) * 100
+      currentRoundInfo?.roundLength
+        ? (blocksSinceCurrentRoundStart / currentRoundInfo.roundLength) * 100
         : 0,
-    [blocksSinceCurrentRoundStart, protocol]
+    [blocksSinceCurrentRoundStart, currentRoundInfo]
   );
 
-  const isRoundLocked = useMemo(
-    () =>
-      protocol && currentRoundInfo
-        ? blocksRemaining <= Number(protocol?.lockPeriod)
-        : false,
-    [protocol, blocksRemaining, currentRoundInfo]
-  );
+  const isRoundLocked = currentRoundInfo?.locked ?? false;
 
   const rewardTokensClaimed = useMemo(
     () =>
@@ -178,7 +174,7 @@ const Index = ({
           marginTop: "$2",
         }}
       >
-        {!currentRoundInfo || !protocol ? (
+        {!currentRoundInfo ? (
           <Flex
             css={{
               width: "100%",
@@ -222,7 +218,7 @@ const Index = ({
                     {blocksSinceCurrentRoundStart}
                   </Box>
                   <Box css={{ fontSize: "$1" }}>
-                    of {protocol.roundLength} blocks
+                    of {currentRoundInfo.roundLength} blocks
                   </Box>
                 </Box>
               </Box>
@@ -259,212 +255,218 @@ const Index = ({
                 begins.
               </Text>
             </Box>
-            <ExplorerTooltip
-              multiline
-              content={
-                <Box>
-                  The amount of fees that have been paid out in the current
-                  round. Equivalent to{" "}
-                  {formatUSD(protocol?.currentRound?.volumeUSD, {
-                    precision: 0,
-                    abbreviate: true,
-                  })}{" "}
-                  at recent prices of ETH.
-                </Box>
-              }
-            >
-              <Flex
-                css={{
-                  marginTop: "$3",
-                  width: "100%",
-                  justifyContent: "space-between",
-                }}
-              >
-                <Flex
-                  css={{
-                    alignItems: "center",
-                  }}
-                >
-                  <Text
-                    css={{
-                      fontSize: "$2",
-                    }}
-                    variant="neutral"
-                  >
-                    Fees
-                  </Text>
-                  <Box css={{ marginLeft: "$1" }}>
-                    <Box
-                      as={QuestionMarkCircledIcon}
-                      css={{ color: "$neutral11" }}
-                    />
-                  </Box>
-                </Flex>
-
-                <Text
-                  css={{
-                    fontSize: "$2",
-                    color: "white",
-                  }}
-                >
-                  {formatETH(protocol?.currentRound?.volumeETH, {
-                    precision: 2,
-                  })}
-                </Text>
-              </Flex>
-            </ExplorerTooltip>
-            <ExplorerTooltip
-              multiline
-              content={
-                <Box>
-                  The amount of rewards which have been claimed by orchestrators
-                  in the current round.
-                </Box>
-              }
-            >
-              <Flex
-                css={{
-                  marginTop: "$1",
-                  width: "100%",
-                  justifyContent: "space-between",
-                }}
-              >
-                <Flex
-                  css={{
-                    alignItems: "center",
-                  }}
-                >
-                  <Text
-                    css={{
-                      fontSize: "$2",
-                    }}
-                    variant="neutral"
-                  >
-                    Rewards
-                  </Text>
-                  <Box css={{ marginLeft: "$1" }}>
-                    <Box
-                      as={QuestionMarkCircledIcon}
-                      css={{ color: "$neutral11" }}
-                    />
-                  </Box>
-                </Flex>
-
-                <Text
-                  css={{
-                    fontSize: "$2",
-                    color: "white",
-                  }}
-                >
-                  {rewards}
-                </Text>
-              </Flex>
-            </ExplorerTooltip>
-            <Box
-              css={{
-                width: "100%",
-                borderTop: "1px solid $neutral6",
-                paddingTop: "8px",
-                marginTop: "8px",
-              }}
-            >
-              <ExplorerTooltip
-                multiline
-                content={<Box>The current total supply of LPT.</Box>}
-              >
-                <Flex
-                  css={{
-                    width: "100%",
-                    justifyContent: "space-between",
-                  }}
+            {protocol && (
+              <>
+                <ExplorerTooltip
+                  multiline
+                  content={
+                    <Box>
+                      The amount of fees that have been paid out in the current
+                      round. Equivalent to{" "}
+                      {formatUSD(protocol?.currentRound?.volumeUSD, {
+                        precision: 0,
+                        abbreviate: true,
+                      })}{" "}
+                      at recent prices of ETH.
+                    </Box>
+                  }
                 >
                   <Flex
                     css={{
-                      alignItems: "center",
+                      marginTop: "$3",
+                      width: "100%",
+                      justifyContent: "space-between",
                     }}
                   >
+                    <Flex
+                      css={{
+                        alignItems: "center",
+                      }}
+                    >
+                      <Text
+                        css={{
+                          fontSize: "$2",
+                        }}
+                        variant="neutral"
+                      >
+                        Fees
+                      </Text>
+                      <Box css={{ marginLeft: "$1" }}>
+                        <Box
+                          as={QuestionMarkCircledIcon}
+                          css={{ color: "$neutral11" }}
+                        />
+                      </Box>
+                    </Flex>
+
                     <Text
                       css={{
                         fontSize: "$2",
+                        color: "white",
                       }}
-                      variant="neutral"
                     >
-                      Total Supply
-                    </Text>
-                    <Box css={{ marginLeft: "$1" }}>
-                      <Box
-                        as={QuestionMarkCircledIcon}
-                        css={{ color: "$neutral11" }}
-                      />
-                    </Box>
-                  </Flex>
-
-                  <Text
-                    css={{
-                      fontSize: "$2",
-                      color: "white",
-                    }}
-                  >
-                    {totalSupply !== null
-                      ? formatLPT(totalSupply, {
-                          precision: 0,
-                          abbreviate: true,
-                        })
-                      : "--"}
-                  </Text>
-                </Flex>
-              </ExplorerTooltip>
-              <ExplorerTooltip
-                multiline
-                content={<Box>Total supply change over the past 365 days.</Box>}
-              >
-                <Flex
-                  css={{
-                    marginTop: "$1",
-                    width: "100%",
-                    justifyContent: "space-between",
-                  }}
-                >
-                  <Flex
-                    css={{
-                      alignItems: "center",
-                    }}
-                  >
-                    <Text
-                      css={{
-                        fontSize: "$2",
-                      }}
-                      variant="neutral"
-                    >
-                      Supply Change (1Y)
-                    </Text>
-                    <Box css={{ marginLeft: "$1" }}>
-                      <Box
-                        as={QuestionMarkCircledIcon}
-                        css={{ color: "$neutral11" }}
-                      />
-                    </Box>
-                  </Flex>
-
-                  <Text
-                    css={{
-                      fontSize: "$2",
-                      color: "white",
-                    }}
-                  >
-                    {isSupplyChangeLoading ? (
-                      <Skeleton css={{ height: 16, width: 80 }} />
-                    ) : supplyChangeData?.supplyChange != null ? (
-                      formatPercent(supplyChangeData.supplyChange, {
+                      {formatETH(protocol?.currentRound?.volumeETH, {
                         precision: 2,
-                      })
-                    ) : (
-                      "--"
-                    )}
-                  </Text>
-                </Flex>
-              </ExplorerTooltip>
-            </Box>
+                      })}
+                    </Text>
+                  </Flex>
+                </ExplorerTooltip>
+                <ExplorerTooltip
+                  multiline
+                  content={
+                    <Box>
+                      The amount of rewards which have been claimed by
+                      orchestrators in the current round.
+                    </Box>
+                  }
+                >
+                  <Flex
+                    css={{
+                      marginTop: "$1",
+                      width: "100%",
+                      justifyContent: "space-between",
+                    }}
+                  >
+                    <Flex
+                      css={{
+                        alignItems: "center",
+                      }}
+                    >
+                      <Text
+                        css={{
+                          fontSize: "$2",
+                        }}
+                        variant="neutral"
+                      >
+                        Rewards
+                      </Text>
+                      <Box css={{ marginLeft: "$1" }}>
+                        <Box
+                          as={QuestionMarkCircledIcon}
+                          css={{ color: "$neutral11" }}
+                        />
+                      </Box>
+                    </Flex>
+
+                    <Text
+                      css={{
+                        fontSize: "$2",
+                        color: "white",
+                      }}
+                    >
+                      {rewards}
+                    </Text>
+                  </Flex>
+                </ExplorerTooltip>
+                <Box
+                  css={{
+                    width: "100%",
+                    borderTop: "1px solid $neutral6",
+                    paddingTop: "8px",
+                    marginTop: "8px",
+                  }}
+                >
+                  <ExplorerTooltip
+                    multiline
+                    content={<Box>The current total supply of LPT.</Box>}
+                  >
+                    <Flex
+                      css={{
+                        width: "100%",
+                        justifyContent: "space-between",
+                      }}
+                    >
+                      <Flex
+                        css={{
+                          alignItems: "center",
+                        }}
+                      >
+                        <Text
+                          css={{
+                            fontSize: "$2",
+                          }}
+                          variant="neutral"
+                        >
+                          Total Supply
+                        </Text>
+                        <Box css={{ marginLeft: "$1" }}>
+                          <Box
+                            as={QuestionMarkCircledIcon}
+                            css={{ color: "$neutral11" }}
+                          />
+                        </Box>
+                      </Flex>
+
+                      <Text
+                        css={{
+                          fontSize: "$2",
+                          color: "white",
+                        }}
+                      >
+                        {totalSupply !== null
+                          ? formatLPT(totalSupply, {
+                              precision: 0,
+                              abbreviate: true,
+                            })
+                          : "--"}
+                      </Text>
+                    </Flex>
+                  </ExplorerTooltip>
+                  <ExplorerTooltip
+                    multiline
+                    content={
+                      <Box>Total supply change over the past 365 days.</Box>
+                    }
+                  >
+                    <Flex
+                      css={{
+                        marginTop: "$1",
+                        width: "100%",
+                        justifyContent: "space-between",
+                      }}
+                    >
+                      <Flex
+                        css={{
+                          alignItems: "center",
+                        }}
+                      >
+                        <Text
+                          css={{
+                            fontSize: "$2",
+                          }}
+                          variant="neutral"
+                        >
+                          Supply Change (1Y)
+                        </Text>
+                        <Box css={{ marginLeft: "$1" }}>
+                          <Box
+                            as={QuestionMarkCircledIcon}
+                            css={{ color: "$neutral11" }}
+                          />
+                        </Box>
+                      </Flex>
+
+                      <Text
+                        css={{
+                          fontSize: "$2",
+                          color: "white",
+                        }}
+                      >
+                        {isSupplyChangeLoading ? (
+                          <Skeleton css={{ height: 16, width: 80 }} />
+                        ) : supplyChangeData?.supplyChange != null ? (
+                          formatPercent(supplyChangeData.supplyChange, {
+                            precision: 2,
+                          })
+                        ) : (
+                          "--"
+                        )}
+                      </Text>
+                    </Flex>
+                  </ExplorerTooltip>
+                </Box>
+              </>
+            )}
           </Flex>
         ) : (
           <Text

--- a/components/RoundStatus/index.tsx
+++ b/components/RoundStatus/index.tsx
@@ -120,50 +120,54 @@ const Index = ({
             {currentRoundInfo?.id ? `#${currentRoundInfo.id}` : ""}
           </Text>
         </Box>
-        <ExplorerTooltip
-          multiline
-          content={
-            <Box>
-              {!isRoundLocked
-                ? "The current round is ongoing and orchestrators can currently update their parameters."
-                : "The current round is locked, which means that orchestrator parameters cannot be updated until the next round begins."}
-            </Box>
-          }
-        >
-          <Flex>
-            <Text
-              css={{
-                fontWeight: 600,
-                fontSize: "$2",
-                color: "white",
-              }}
-            >
-              {!isRoundLocked ? "Initialized " : "Locked "}
-            </Text>
+        {!currentRoundInfo ? (
+          <Skeleton css={{ height: 20, width: 90 }} />
+        ) : (
+          <ExplorerTooltip
+            multiline
+            content={
+              <Box>
+                {!isRoundLocked
+                  ? "The current round is ongoing and orchestrators can currently update their parameters."
+                  : "The current round is locked, which means that orchestrator parameters cannot be updated until the next round begins."}
+              </Box>
+            }
+          >
+            <Flex>
+              <Text
+                css={{
+                  fontWeight: 600,
+                  fontSize: "$2",
+                  color: "white",
+                }}
+              >
+                {!isRoundLocked ? "Initialized " : "Locked "}
+              </Text>
 
-            {isRoundLocked ? (
-              <Box
-                as={Cross1Icon}
-                css={{
-                  marginLeft: "$2",
-                  width: 20,
-                  height: 20,
-                  color: "$red11",
-                }}
-              />
-            ) : (
-              <Box
-                as={CheckIcon}
-                css={{
-                  marginLeft: "$1",
-                  width: 20,
-                  height: 20,
-                  color: "$primary11",
-                }}
-              />
-            )}
-          </Flex>
-        </ExplorerTooltip>
+              {isRoundLocked ? (
+                <Box
+                  as={Cross1Icon}
+                  css={{
+                    marginLeft: "$2",
+                    width: 20,
+                    height: 20,
+                    color: "$red11",
+                  }}
+                />
+              ) : (
+                <Box
+                  as={CheckIcon}
+                  css={{
+                    marginLeft: "$1",
+                    width: 20,
+                    height: 20,
+                    color: "$primary11",
+                  }}
+                />
+              )}
+            </Flex>
+          </ExplorerTooltip>
+        )}
       </Flex>
 
       <Box

--- a/components/RoundStatus/index.tsx
+++ b/components/RoundStatus/index.tsx
@@ -37,8 +37,6 @@ const Index = ({
 
   const currentRoundInfo = useCurrentRoundData();
 
-  // Round timing/lock come entirely from the RoundsManager (via /current-round),
-  // so the tracker stays consistent and live even when the subgraph is behind.
   const blocksRemaining = useMemo(
     () =>
       currentRoundInfo?.initialized

--- a/lib/api/types/get-current-round.ts
+++ b/lib/api/types/get-current-round.ts
@@ -2,6 +2,8 @@ export type CurrentRoundInfo = {
   id: number;
   startBlock: number;
   initialized: boolean;
+  locked: boolean;
+  roundLength: number;
   currentL1Block: number;
   currentL2Block: number;
 };

--- a/pages/api/current-round.tsx
+++ b/pages/api/current-round.tsx
@@ -23,31 +23,48 @@ const handler = async (
         abi: roundsManager,
       } as const;
 
-      const [id, startBlock, initialized, currentL1Block, currentL2Block] =
-        await Promise.all([
-          l2PublicClient.readContract({
-            ...contract,
-            functionName: "currentRound",
-          }),
-          l2PublicClient.readContract({
-            ...contract,
-            functionName: "currentRoundStartBlock",
-          }),
-          l2PublicClient.readContract({
-            ...contract,
-            functionName: "currentRoundInitialized",
-          }),
-          l2PublicClient.readContract({
-            ...contract,
-            functionName: "blockNum",
-          }),
-          l2PublicClient.getBlockNumber(),
-        ]);
+      const [
+        id,
+        startBlock,
+        initialized,
+        locked,
+        roundLength,
+        currentL1Block,
+        currentL2Block,
+      ] = await Promise.all([
+        l2PublicClient.readContract({
+          ...contract,
+          functionName: "currentRound",
+        }),
+        l2PublicClient.readContract({
+          ...contract,
+          functionName: "currentRoundStartBlock",
+        }),
+        l2PublicClient.readContract({
+          ...contract,
+          functionName: "currentRoundInitialized",
+        }),
+        l2PublicClient.readContract({
+          ...contract,
+          functionName: "currentRoundLocked",
+        }),
+        l2PublicClient.readContract({
+          ...contract,
+          functionName: "roundLength",
+        }),
+        l2PublicClient.readContract({
+          ...contract,
+          functionName: "blockNum",
+        }),
+        l2PublicClient.getBlockNumber(),
+      ]);
 
       const roundInfo: CurrentRoundInfo = {
         id: Number(id),
         startBlock: Number(startBlock),
         initialized: Boolean(initialized),
+        locked: Boolean(locked),
+        roundLength: Number(roundLength),
         currentL1Block: Number(currentL1Block),
         currentL2Block: Number(currentL2Block),
       };


### PR DESCRIPTION
## Summary

Follow-up to #731. That PR moved the round *timing* (round id, start block, current block, initialized) to the RoundsManager contract, but `RoundStatus` still read `roundLength` and the lock state from the subgraph — so the tracker remained a mixed source.

This finishes the job: the round tracker is now sourced entirely from one on-chain snapshot.

## What changed

- **`/api/current-round`** now also returns `roundLength` (`RoundsManager.roundLength`) and `locked` (`RoundsManager.currentRoundLocked`), alongside the existing timing reads, in the same cached call (`s-maxage=60`).
- **`RoundStatus`** reads `roundLength` and `locked` from `useCurrentRoundData` instead of `protocol`:
  - `isRoundLocked` now comes straight from `currentRoundLocked()` rather than re-deriving `blocksRemaining <= lockPeriod` client-side. The subgraph had to store `lockPeriod` and defer the comparison to the client because, being event-driven, it can't keep a per-block boolean fresh; reading the getter directly removes that indirection and is authoritative.
  - The progress ring, "blocks remaining", and lock badge are now fully on-chain and consistent (single snapshot, no cross-source skew at round boundaries).
- The spinner now only waits on the on-chain round data, so the tracker still renders during a **full** subgraph outage. The subgraph-only stat rows (Fees, Rewards, Total Supply, Supply Change) are hidden in that case; when the subgraph is merely behind (present but stale) everything renders as before.

## Notes

- Behavior/refresh cadence is unchanged: same `s-maxage=60` endpoint, polled every 10s by SWR. `locked` and the round timing now refresh from the same atomic snapshot.
- Aggregations that have no cheap on-chain equivalent (fees volume, rewards claimed, supply change) intentionally stay on the subgraph.

## Testing

- `pnpm typecheck` + `pnpm lint` pass; pre-commit hooks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Round status now displays lock state and round length using the latest round information.
  * Progress indicators and remaining-block counts are more accurate.

* **Bug Fixes**
  * Round status can load and display available information even when protocol details are temporarily unavailable.
  * Fee, reward, and supply details are safely hidden until the required protocol information is ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->