### PR TITLE
fix: source the round on-chain in the pending-stake endpoint

### DIFF
--- a/lib/api/ssr.ts
+++ b/lib/api/ssr.ts
@@ -75,12 +75,6 @@ export async function getGatewaySelfRedeem(
   return lastTimestamp >= cutoff;
 }
 
-export async function getCurrentRound(client = getApollo()) {
-  return client.query<CurrentRoundQuery, CurrentRoundQueryVariables>({
-    query: CurrentRoundDocument,
-  });
-}
-
 export async function getOrchestrators(client = getApollo()) {
   const protocolResponse = await client.query<
     CurrentRoundQuery,

--- a/pages/api/pending-stake/[address].tsx
+++ b/pages/api/pending-stake/[address].tsx
@@ -1,6 +1,10 @@
-import { getCacheControlHeader, getCurrentRound } from "@lib/api";
+import { getCacheControlHeader } from "@lib/api";
 import { bondingManager } from "@lib/api/abis/main/BondingManager";
-import { getBondingManagerAddress } from "@lib/api/contracts";
+import { roundsManager } from "@lib/api/abis/main/RoundsManager";
+import {
+  getBondingManagerAddress,
+  getRoundsManagerAddress,
+} from "@lib/api/contracts";
 import { badRequest, internalError, methodNotAllowed } from "@lib/api/errors";
 import { PendingFeesAndStake } from "@lib/api/types/get-pending-stake";
 import { l2PublicClient } from "@lib/chains";
@@ -20,17 +24,15 @@ const handler = async (
       const { address } = req.query;
 
       if (!!address && !Array.isArray(address) && isAddress(address)) {
-        const bondingManagerAddress = await getBondingManagerAddress();
+        const [bondingManagerAddress, roundsManagerAddress] = await Promise.all(
+          [getBondingManagerAddress(), getRoundsManagerAddress()]
+        );
 
-        const {
-          data: { protocol },
-        } = await getCurrentRound();
-        const currentRoundString = protocol?.currentRound?.id;
-
-        if (!currentRoundString) {
-          throw new Error("No current round found");
-        }
-        const currentRound = BigInt(currentRoundString);
+        const currentRound = await l2PublicClient.readContract({
+          address: roundsManagerAddress,
+          abi: roundsManager,
+          functionName: "currentRound",
+        });
 
         const [pendingStake, pendingFees] = await l2PublicClient.multicall({
           allowFailure: false,


### PR DESCRIPTION
Follow-up to #731, which moved `/api/current-round` on-chain but left `/api/pending-stake` on the subgraph.

## Problem

`/api/pending-stake/[address]` read the current round from the subgraph and passed it straight into on-chain `pendingStake` / `pendingFees` calls:

- when indexing lags, a stale round understates pending stake and fees in the header balance (`layouts/main.tsx`) and the staking widget;
- when the subgraph errors or returns no protocol, the handler threw `No current round found` and the route returned a 500.

## Fix

Read `currentRound` from the RoundsManager through `l2PublicClient`, in parallel with the BondingManager address lookup. The route becomes a pure contract read that cannot fail on subgraph health. Response shape is unchanged.

This was the last caller of the subgraph-backed `getCurrentRound()` helper, so it is removed. `queries/currentRound.graphql` stays — `getOrchestrators()` still uses `CurrentRoundDocument`.

## Notes

`getContractAddress` is not memoized, so this route now performs two controller reads instead of one. They run in parallel, so there is no added latency, and it replaces a subgraph HTTP query with an RPC read.