### PR TITLE
fix: compare LPT allowance and balance in wei

### DIFF
--- a/components/DelegatingWidget/Delegate.tsx
+++ b/components/DelegatingWidget/Delegate.tsx
@@ -147,10 +147,8 @@ const Delegate = ({
   };
 
   const { data: bondWithHintConfig } = useSimulateContract({
-    // Simulating without the allowance in place reverts, and nothing re-runs a
-    // cached failure once the approval lands. Gating on the allowance means the
-    // simulation first runs when it can succeed. A zero amount moves no tokens,
-    // so it needs no allowance.
+    // A reverted simulation is cached and never re-run, so only simulate once
+    // it can succeed. A zero amount moves no tokens, so it needs no allowance.
     query: {
       enabled:
         Boolean(to) && (bondAmountWei === 0n || sufficientTransferAllowance),

--- a/components/DelegatingWidget/Delegate.tsx
+++ b/components/DelegatingWidget/Delegate.tsx
@@ -221,7 +221,8 @@ const Delegate = ({
     reset();
   };
 
-  if (amountWei === null && !isTransferStake) {
+  // A stake transfer may bond nothing, but only from an empty field.
+  if (amountWei === null && (amount || !isTransferStake)) {
     return (
       <Button size="4" disabled variant="neutral" css={{ width: "100%" }}>
         Enter an Amount

--- a/components/DelegatingWidget/Delegate.tsx
+++ b/components/DelegatingWidget/Delegate.tsx
@@ -167,19 +167,21 @@ const Delegate = ({
   const [approvalSubmitted, setApprovalSubmitted] = useState<boolean>(false);
 
   const amountIsNonEmpty = useMemo(() => amount, [amount]);
+  // `tokenBalance` and `transferAllowance` are wei, so compare in wei.
+  const amountWei = useMemo(() => {
+    try {
+      return amount ? parseEther(amount) : BigInt(0);
+    } catch {
+      return BigInt(0);
+    }
+  }, [amount]);
   const sufficientBalance = useMemo(
-    () =>
-      amountIsNonEmpty &&
-      parseFloat(amount) > 0 &&
-      Number(tokenBalance) >= amount,
-    [amount, amountIsNonEmpty, tokenBalance]
+    () => amountWei > BigInt(0) && BigInt(tokenBalance ?? 0) >= amountWei,
+    [amountWei, tokenBalance]
   );
   const sufficientTransferAllowance = useMemo(
-    () =>
-      amountIsNonEmpty &&
-      Number(transferAllowance) > 0 &&
-      Number(transferAllowance) >= amount,
-    [amount, amountIsNonEmpty, transferAllowance]
+    () => amountWei > BigInt(0) && BigInt(transferAllowance ?? 0) >= amountWei,
+    [amountWei, transferAllowance]
   );
 
   // show approve flow when: no error on inputs, not approved or pending, or approved in current session
@@ -260,7 +262,7 @@ const Delegate = ({
             </Button>
             <Button
               size="4"
-              disabled={!sufficientTransferAllowance}
+              disabled={!sufficientTransferAllowance || !bondWithHintConfig}
               variant="primary"
               onClick={onDelegate}
               css={{ width: "100%" }}
@@ -282,6 +284,7 @@ const Delegate = ({
       {cutChangeNotice}
       <Button
         size="4"
+        disabled={!bondWithHintConfig}
         onClick={onDelegate}
         variant="primary"
         css={{ width: "100%" }}

--- a/components/DelegatingWidget/Delegate.tsx
+++ b/components/DelegatingWidget/Delegate.tsx
@@ -186,14 +186,12 @@ const Delegate = ({
 
   const [approvalSubmitted, setApprovalSubmitted] = useState<boolean>(false);
 
-  const amountIsNonEmpty = useMemo(() => amount, [amount]);
-
   // show approve flow when: no error on inputs, not approved or pending, or approved in current session
   const showApproveFlow = useMemo(
     () =>
-      (amountIsNonEmpty && +amount >= 0 && !sufficientTransferAllowance) ||
+      (amountWei !== null && !sufficientTransferAllowance) ||
       (approvalSubmitted && sufficientTransferAllowance),
-    [amount, amountIsNonEmpty, sufficientTransferAllowance, approvalSubmitted]
+    [amountWei, sufficientTransferAllowance, approvalSubmitted]
   );
 
   const onApprove = async () => {

--- a/components/DelegatingWidget/Delegate.tsx
+++ b/components/DelegatingWidget/Delegate.tsx
@@ -8,6 +8,7 @@ import {
   InfoCircledIcon,
 } from "@radix-ui/react-icons";
 import { formatPercent } from "@utils/numberFormatters";
+import { parseAmountToWei } from "@utils/web3";
 import {
   useBondingManagerAddress,
   useLivepeerTokenAddress,
@@ -15,7 +16,6 @@ import {
 import { useHandleTransaction } from "hooks/useHandleTransaction";
 import { useOrchestratorRewardCutSpike } from "hooks/useOrchestratorRewardCutSpike";
 import { useMemo, useState } from "react";
-import { parseEther } from "viem";
 import { useSimulateContract, useWriteContract } from "wagmi";
 
 import ProgressSteps from "../ProgressSteps";
@@ -124,27 +124,21 @@ const Delegate = ({
     }
   );
 
-  // `type="number"` accepts values `parseEther` rejects (e.g. `1e3`), so parse
-  // once, defensively, and reuse it everywhere.
-  const amountWei = useMemo(() => {
-    try {
-      return amount ? parseEther(amount) : BigInt(0);
-    } catch {
-      return BigInt(0);
-    }
-  }, [amount]);
+  // null when the amount is absent or not yet a valid number.
+  const amountWei = useMemo(() => parseAmountToWei(amount), [amount]);
+  const bondAmountWei = amountWei ?? 0n;
   // `tokenBalance` and `transferAllowance` are wei, so compare in wei.
   const sufficientBalance = useMemo(
-    () => amountWei > BigInt(0) && BigInt(tokenBalance ?? 0) >= amountWei,
-    [amountWei, tokenBalance]
+    () => bondAmountWei > 0n && BigInt(tokenBalance ?? 0) >= bondAmountWei,
+    [bondAmountWei, tokenBalance]
   );
   const sufficientTransferAllowance = useMemo(
-    () => amountWei > BigInt(0) && BigInt(transferAllowance ?? 0) >= amountWei,
-    [amountWei, transferAllowance]
+    () => bondAmountWei > 0n && BigInt(transferAllowance ?? 0) >= bondAmountWei,
+    [bondAmountWei, transferAllowance]
   );
 
   const bondWithHintArgs = {
-    amount: amountWei,
+    amount: bondAmountWei,
     to,
     oldDelegateNewPosPrev,
     oldDelegateNewPosNext,
@@ -159,7 +153,7 @@ const Delegate = ({
     // so it needs no allowance.
     query: {
       enabled:
-        Boolean(to) && (amountWei === BigInt(0) || sufficientTransferAllowance),
+        Boolean(to) && (bondAmountWei === 0n || sufficientTransferAllowance),
     },
     address: bondingManagerAddress,
     abi: bondingManager,
@@ -229,7 +223,7 @@ const Delegate = ({
     reset();
   };
 
-  if (!amountIsNonEmpty && !isTransferStake) {
+  if (amountWei === null && !isTransferStake) {
     return (
       <Button size="4" disabled variant="neutral" css={{ width: "100%" }}>
         Enter an Amount
@@ -237,7 +231,7 @@ const Delegate = ({
     );
   }
 
-  if (amountIsNonEmpty && +amount >= 0 && !sufficientBalance) {
+  if (amountWei !== null && !sufficientBalance) {
     return (
       <Button size="4" disabled variant="neutral" css={{ width: "100%" }}>
         Insufficient Balance

--- a/components/DelegatingWidget/Delegate.tsx
+++ b/components/DelegatingWidget/Delegate.tsx
@@ -124,8 +124,27 @@ const Delegate = ({
     }
   );
 
+  // `type="number"` accepts values `parseEther` rejects (e.g. `1e3`), so parse
+  // once, defensively, and reuse it everywhere.
+  const amountWei = useMemo(() => {
+    try {
+      return amount ? parseEther(amount) : BigInt(0);
+    } catch {
+      return BigInt(0);
+    }
+  }, [amount]);
+  // `tokenBalance` and `transferAllowance` are wei, so compare in wei.
+  const sufficientBalance = useMemo(
+    () => amountWei > BigInt(0) && BigInt(tokenBalance ?? 0) >= amountWei,
+    [amountWei, tokenBalance]
+  );
+  const sufficientTransferAllowance = useMemo(
+    () => amountWei > BigInt(0) && BigInt(transferAllowance ?? 0) >= amountWei,
+    [amountWei, transferAllowance]
+  );
+
   const bondWithHintArgs = {
-    amount: amount?.toString() ? parseEther(amount) : BigInt(0),
+    amount: amountWei,
     to,
     oldDelegateNewPosPrev,
     oldDelegateNewPosNext,
@@ -134,12 +153,19 @@ const Delegate = ({
   };
 
   const { data: bondWithHintConfig } = useSimulateContract({
-    query: { enabled: Boolean(to) },
+    // Simulating without the allowance in place reverts, and nothing re-runs a
+    // cached failure once the approval lands. Gating on the allowance means the
+    // simulation first runs when it can succeed. A zero amount moves no tokens,
+    // so it needs no allowance.
+    query: {
+      enabled:
+        Boolean(to) && (amountWei === BigInt(0) || sufficientTransferAllowance),
+    },
     address: bondingManagerAddress,
     abi: bondingManager,
     functionName: "bondWithHint",
     args: [
-      BigInt(bondWithHintArgs.amount?.toString()),
+      bondWithHintArgs.amount,
       to,
       oldDelegateNewPosPrev,
       oldDelegateNewPosNext,
@@ -167,22 +193,6 @@ const Delegate = ({
   const [approvalSubmitted, setApprovalSubmitted] = useState<boolean>(false);
 
   const amountIsNonEmpty = useMemo(() => amount, [amount]);
-  // `tokenBalance` and `transferAllowance` are wei, so compare in wei.
-  const amountWei = useMemo(() => {
-    try {
-      return amount ? parseEther(amount) : BigInt(0);
-    } catch {
-      return BigInt(0);
-    }
-  }, [amount]);
-  const sufficientBalance = useMemo(
-    () => amountWei > BigInt(0) && BigInt(tokenBalance ?? 0) >= amountWei,
-    [amountWei, tokenBalance]
-  );
-  const sufficientTransferAllowance = useMemo(
-    () => amountWei > BigInt(0) && BigInt(transferAllowance ?? 0) >= amountWei,
-    [amountWei, transferAllowance]
-  );
 
   // show approve flow when: no error on inputs, not approved or pending, or approved in current session
   const showApproveFlow = useMemo(

--- a/components/DelegatingWidget/Footer.tsx
+++ b/components/DelegatingWidget/Footer.tsx
@@ -6,6 +6,7 @@ import {
   simulateNewActiveSetOrder,
 } from "@lib/utils";
 import { Box, Button } from "@livepeer/design-system";
+import { parseAmountToWei } from "@utils/web3";
 import { AccountQueryResult, OrchestratorsSortedQueryResult } from "apollo";
 import {
   StakingAction,
@@ -16,7 +17,6 @@ import {
 } from "hooks";
 import { CHAIN_INFO } from "lib/chains";
 import { useMemo } from "react";
-import { parseEther } from "viem";
 
 import Delegate from "./Delegate";
 import Footnote from "./Footnote";
@@ -91,15 +91,12 @@ const Footer = ({
         : null,
     [delegatorPendingStakeAndFees]
   );
+  // null when the amount is absent or not yet a valid number.
+  const amountWei = useMemo(() => parseAmountToWei(amount), [amount]);
   const sufficientStake = useMemo(() => {
-    if (!delegator || !amount || stakeWei === null) return false;
-    try {
-      const amountWei = parseEther(amount);
-      return amountWei <= stakeWei;
-    } catch {
-      return false;
-    }
-  }, [delegator, amount, stakeWei]);
+    if (!delegator || amountWei === null || stakeWei === null) return false;
+    return amountWei <= stakeWei;
+  }, [delegator, amountWei, stakeWei]);
   const canUndelegate = useMemo(
     () => isMyTranscoder && isDelegated && parseFloat(amount) > 0,
     [isMyTranscoder, isDelegated, amount]
@@ -109,11 +106,11 @@ const Footer = ({
       simulateNewActiveSetOrder({
         action,
         transcoders: JSON.parse(JSON.stringify(transcoders)),
-        amount: parseEther(amount ? amount.toString() : "0"),
+        amount: amountWei ?? 0n,
         newDelegate: transcoder?.id ?? "",
         oldDelegate: delegator?.delegate?.id,
       }),
-    [action, transcoders, amount, transcoder, delegator]
+    [action, transcoders, amountWei, transcoder, delegator]
   );
   const { newPosPrev, newPosNext } = useMemo(
     () => getHint(delegator?.delegate?.id, newActiveSetOrder),
@@ -135,15 +132,11 @@ const Footer = ({
   );
   const willDeactivate = useMemo(() => {
     // Wait for stake data to load before determining deactivation
-    if (!isOwnOrchestrator || stakeWei === null || !amount) return false;
-    try {
-      const amountWei = parseEther(amount);
-      // Deactivates if unbonding all stake (amount >= current stake)
-      return amountWei > 0n && amountWei >= stakeWei;
-    } catch {
+    if (!isOwnOrchestrator || stakeWei === null || amountWei === null)
       return false;
-    }
-  }, [isOwnOrchestrator, stakeWei, amount]);
+    // Deactivates if unbonding all stake (amount >= current stake)
+    return amountWei > 0n && amountWei >= stakeWei;
+  }, [isOwnOrchestrator, stakeWei, amountWei]);
 
   if (isWrongRouteChain) {
     return (

--- a/utils/web3.test.ts
+++ b/utils/web3.test.ts
@@ -1,4 +1,10 @@
-import { checkAddressEquality, formatAddress, fromWei, toWei } from "./web3";
+import {
+  checkAddressEquality,
+  formatAddress,
+  fromWei,
+  parseAmountToWei,
+  toWei,
+} from "./web3";
 
 describe("checkAddressEquality", () => {
   it("returns false for invalid addresses", () => {
@@ -40,6 +46,41 @@ describe("toWei", () => {
   it("converts ether number to bigint wei", () => {
     expect(toWei(1)).toBe(1000000000000000000n);
     expect(toWei(0.5)).toBe(500000000000000000n);
+  });
+});
+
+describe("parseAmountToWei", () => {
+  it("converts decimal amounts to wei", () => {
+    expect(parseAmountToWei("0.1")).toBe(100000000000000000n);
+    expect(parseAmountToWei("2.5")).toBe(2500000000000000000n);
+    expect(parseAmountToWei("100000")).toBe(100000000000000000000000n);
+  });
+
+  it("keeps decimals that exceed float precision", () => {
+    expect(parseAmountToWei("1.000000000000000001")).toBe(1000000000000000001n);
+  });
+
+  it("accepts exponent notation", () => {
+    expect(parseAmountToWei("1e3")).toBe(1000000000000000000000n);
+    expect(parseAmountToWei("1E3")).toBe(1000000000000000000000n);
+    expect(parseAmountToWei("1e-2")).toBe(10000000000000000n);
+  });
+
+  it("returns null for an absent or unparseable amount", () => {
+    expect(parseAmountToWei("")).toBeNull();
+    expect(parseAmountToWei(null)).toBeNull();
+    expect(parseAmountToWei(undefined)).toBeNull();
+    expect(parseAmountToWei("abc")).toBeNull();
+    expect(parseAmountToWei("1e")).toBeNull();
+  });
+
+  // Exponents are normalised through `Number`, which only writes decimals
+  // between 1e-6 and 1e21. Decimal notation has no such limit.
+  it("rejects exponents outside the range Number writes as a decimal", () => {
+    expect(parseAmountToWei("1e-6")).toBe(1000000000000n);
+    expect(parseAmountToWei("1e-7")).toBeNull();
+    expect(parseAmountToWei("0.0000001")).toBe(100000000000n);
+    expect(parseAmountToWei("1e21")).toBeNull();
   });
 });
 

--- a/utils/web3.ts
+++ b/utils/web3.ts
@@ -58,7 +58,8 @@ export const fromWei = (wei: bigint | string | null | undefined) => {
 };
 
 /**
- * Convert Ether amount (number) to Wei (bigint)
+ * Convert Ether amount (number) to Wei (bigint).
+ * @deprecated Use parseAmountToWei instead.
  * @param ether - The value in Ether
  * @returns BigInt representation in Wei
  */
@@ -67,18 +68,14 @@ export const toWei = (ether: number) => parseEther(ether.toString());
 /**
  * Parse a user-entered amount into Wei.
  *
- * `parseEther` throws on the exponent notation `<input type="number">` accepts
- * (e.g. `1e3`), so those are normalised to a decimal first. Plain decimals skip
- * `Number` to avoid float precision loss.
+ * `parseEther` only accepts decimals, so exponent notation (e.g. `1e3`) is
+ * normalised first.
  *
  * @param amount - The user-entered amount in Ether
- * @returns BigInt representation in Wei, or null when the amount is absent or
- *   not a valid decimal number
+ * @returns BigInt representation in Wei, or null when it cannot be parsed
  */
 export const parseAmountToWei = (amount: string | null | undefined) => {
-  if (!amount) {
-    return null;
-  }
+  if (!amount) return null;
   try {
     return parseEther(/[eE]/.test(amount) ? Number(amount).toString() : amount);
   } catch {

--- a/utils/web3.ts
+++ b/utils/web3.ts
@@ -65,6 +65,27 @@ export const fromWei = (wei: bigint | string | null | undefined) => {
 export const toWei = (ether: number) => parseEther(ether.toString());
 
 /**
+ * Parse a user-entered amount into Wei.
+ *
+ * `parseEther` throws on values `<input type="number">` accepts but cannot
+ * represent as a decimal (e.g. `1e3`), which would crash the render.
+ *
+ * @param amount - The user-entered amount in Ether
+ * @returns BigInt representation in Wei, or null when the amount is absent or
+ *   not a valid decimal number
+ */
+export const parseAmountToWei = (amount: string | null | undefined) => {
+  if (!amount) {
+    return null;
+  }
+  try {
+    return parseEther(amount);
+  } catch {
+    return null;
+  }
+};
+
+/**
  * Shorten an Ethereum address for display.
  * @deprecated Use formatAddress instead
  * @param address - The address to shorten.

--- a/utils/web3.ts
+++ b/utils/web3.ts
@@ -67,8 +67,9 @@ export const toWei = (ether: number) => parseEther(ether.toString());
 /**
  * Parse a user-entered amount into Wei.
  *
- * `parseEther` throws on values `<input type="number">` accepts but cannot
- * represent as a decimal (e.g. `1e3`), which would crash the render.
+ * `parseEther` throws on the exponent notation `<input type="number">` accepts
+ * (e.g. `1e3`), so those are normalised to a decimal first. Plain decimals skip
+ * `Number` to avoid float precision loss.
  *
  * @param amount - The user-entered amount in Ether
  * @returns BigInt representation in Wei, or null when the amount is absent or
@@ -79,7 +80,7 @@ export const parseAmountToWei = (amount: string | null | undefined) => {
     return null;
   }
   try {
-    return parseEther(amount);
+    return parseEther(/[eE]/.test(amount) ? Number(amount).toString() : amount);
   } catch {
     return null;
   }


### PR DESCRIPTION
Fixes #737.

## Problem

`/api/account-balance` returns `balance` and `allowance` as raw wei, but `Delegate.tsx` compared them against `amount`, the human-readable LPT input:

```js
Number(tokenBalance)      >= amount   // 1.4e19 >= 5
Number(transferAllowance) >= amount   // 1.1e17 >= 5
```

Both are true for any realistic input, so a wallet holding a partial (non-zero but insufficient) allowance never saw the approve flow, the `bondWithHint` simulation reverted, `bondWithHintConfig` stayed undefined, and `onDelegate` threw into a `console.error` — leaving an enabled Delegate button that did nothing. The `Insufficient Balance` guard could never fire either.

Only partial allowances are affected: at allowance `0` the approve flow shows correctly and grants `MAX_UINT256`, which is why the normal path works.

## Fix

Convert the input with `parseEther` and compare in wei via `BigInt`. Also disable the Delegate button while `bondWithHintConfig` is undefined, so a failed simulation can no longer present as a working button.

## Notes

Introduced in 989c09b (#165), which created `/api/account-balance` and rewired both consumers to it — `InputBox` kept its `fromWei`, `Footer` dropped it. That split is why the displayed balance stayed correct while the comparison broke.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staking/undelegation and approval readiness by using consistent wei-based balance and allowance checks, preventing incorrect enablement.
  * Action buttons now more reliably disable when the entered amount is missing/invalid, when balance is insufficient, or when required bonding/approval prerequisites aren’t met.
* **New Features**
  * Added a more robust amount parser for user-entered Ether values, supporting exponent notation.
* **Tests**
  * Added coverage for precision, exponent handling, and invalid/empty inputs.
* **Documentation**
  * Marked the legacy `toWei` helper as deprecated in its docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->