### PR TITLE
fix: report the submitted amount in the delegation confirmation

### DIFF
--- a/components/DelegatingWidget/Delegate.tsx
+++ b/components/DelegatingWidget/Delegate.tsx
@@ -155,13 +155,19 @@ const Delegate = ({
     error: bondError,
   } = useWriteContract();
 
+  // The amount is cleared on submit, well before the hash arrives, so the
+  // confirmation reports what was sent rather than what the input holds now.
+  const [submittedArgs, setSubmittedArgs] = useState<
+    typeof bondWithHintArgs | null
+  >(null);
+
   useHandleTransaction(
     "bond",
     bondData,
     bondError,
     bondIsLoading,
     bondIsSuccess,
-    bondWithHintArgs
+    submittedArgs ?? bondWithHintArgs
   );
 
   const [approvalSubmitted, setApprovalSubmitted] = useState<boolean>(false);
@@ -208,6 +214,7 @@ const Delegate = ({
       if (!bondWithHintConfig) {
         throw new Error("No config for bond with hint");
       }
+      setSubmittedArgs(bondWithHintArgs);
       bondWrite(bondWithHintConfig.request);
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
Fixes #741.

## Problem

Every plain delegation confirms with the stake-migration copy:

> Congrats! You've successfully migrated your stake to a new orchestrator.

`TxConfirmedDialog/index.tsx:120` selects that from `Number(tx.inputData.amount) <= 0`, which is the right rule — a genuine "Move Delegated Stake" bonds zero. The problem is the amount it reads.

`onDelegate` submits and then calls `reset()` → `setAmount("")` immediately, without waiting for the hash. `useHandleTransaction`'s `useEffect(..., [data])` runs later and records the *current* args, by which point the amount is `0`. The hash can never arrive before `reset()`, so it happens on every delegation rather than intermittently.

## Fix

Capture the args when the transaction is submitted and pass those to `useHandleTransaction`, falling back to the live ones before submission.

Display only — the calldata is unchanged, and `unbond` is unaffected since `Undelegate.tsx` never calls `reset()`.

## Testing

Not verified against a wallet. Delegating a real amount should confirm with "successfully delegated N LPT", and Move Delegated Stake should still show the migration copy, since that path legitimately bonds zero.

## Note

This is the third item from #739, split out because it is self-contained. That issue still covers the receipt-waiting and cache-invalidation work in the same hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)