### PR TITLE
fix: temporarily compute the LIP-118 tally on-chain while the subgraph resyncs

### DIFF
--- a/constants/manualPolls.ts
+++ b/constants/manualPolls.ts
@@ -1,3 +1,4 @@
+import { PollTally } from "@lib/api/types/get-poll-tally";
 import { PollsQuery } from "apollo";
 
 /**
@@ -7,15 +8,20 @@ import { PollsQuery } from "apollo";
  * voting list/detail pages, deduped by poll address — once the subgraph
  * reindexes a poll, its real (tallied) copy wins and the manual entry drops out.
  *
- * These carry no vote tally (the subgraph computes the stake-weighted counts),
- * so the UI shows a "counts not loaded" note for them; voting itself is on-chain
- * and works regardless.
+ * The subgraph normally computes the stake-weighted counts, so these carry no
+ * tally of their own: the UI fills it in from `/api/polls/tally/[poll]`, which
+ * recomputes it from chain state. Voting itself is on-chain and works regardless.
  *
  * Remove entries (or delete this file and its imports) once indexing recovers.
  */
 type SubgraphPoll = PollsQuery["polls"][number];
 
-export const MANUAL_POLLS: SubgraphPoll[] = [
+type ManualPoll = SubgraphPoll & {
+  /** L2 block the poll was created in — lower bound for on-chain vote lookups. */
+  startBlockL2: number;
+};
+
+export const MANUAL_POLLS: ManualPoll[] = [
   {
     // LIP-118 "Delegated Reward Calling" — created during the subgraph indexing halt.
     // tx: 0xb8ab2a824b4a5b16b76be99f1313a8238f35acc2259b139562277e1df8ba02e4
@@ -27,6 +33,7 @@ export const MANUAL_POLLS: SubgraphPoll[] = [
     quota: "500000",
     tally: null,
     votes: [],
+    startBlockL2: 485384564,
   },
 ];
 
@@ -35,7 +42,7 @@ const norm = (id: string) => id.toLowerCase();
 /** The manually-listed poll for `id`, if any. */
 export const getManualPoll = (
   id: string | undefined | null
-): SubgraphPoll | undefined =>
+): ManualPoll | undefined =>
   id ? MANUAL_POLLS.find((p) => norm(p.id) === norm(id)) : undefined;
 
 /** Whether `id` is a manually-listed poll (i.e. not sourced from the subgraph). */
@@ -55,4 +62,28 @@ export const mergeManualPolls = (
     if (!seen.has(norm(poll.id))) list.push(poll);
   }
   return list;
+};
+
+/**
+ * Fill a manual poll's missing tally with the one computed on-chain by
+ * `/api/polls/tally/[poll]`. Subgraph-sourced polls are returned untouched, so
+ * this becomes a no-op as soon as indexing catches up.
+ */
+export const withManualTally = (
+  poll: SubgraphPoll,
+  tally: PollTally | undefined | null
+): SubgraphPoll => {
+  if (!tally || norm(tally.poll) !== norm(poll.id) || !isManualPoll(poll.id)) {
+    return poll;
+  }
+
+  return {
+    ...poll,
+    tally: { __typename: "PollTally", ...tally.tally },
+    // The list/widget show a vote count, which the subgraph would supply.
+    votes: tally.votes.map((vote) => ({
+      __typename: "Vote" as const,
+      id: `${vote.voter}-${norm(poll.id)}`,
+    })),
+  };
 };

--- a/constants/manualPolls.ts
+++ b/constants/manualPolls.ts
@@ -1,6 +1,3 @@
-import { PollTally } from "@lib/api/types/get-poll-tally";
-import { PollsQuery } from "apollo";
-
 /**
  * TEMPORARY stopgap: manually surface governance polls that were created while
  * the subgraph was behind on indexing, so voting stays functional during the
@@ -14,6 +11,10 @@ import { PollsQuery } from "apollo";
  *
  * Remove entries (or delete this file and its imports) once indexing recovers.
  */
+
+import { PollTally } from "@lib/api/types/get-poll-tally";
+import { PollsQuery } from "apollo";
+
 type SubgraphPoll = PollsQuery["polls"][number];
 
 type ManualPoll = SubgraphPoll & {

--- a/hooks/useSwr.tsx
+++ b/hooks/useSwr.tsx
@@ -14,6 +14,7 @@ import {
   AllPerformanceMetrics,
   PerformanceMetrics,
 } from "@lib/api/types/get-performance";
+import { PollTally } from "@lib/api/types/get-poll-tally";
 import { ProtocolDayData } from "@lib/api/types/get-protocol-day-data";
 import { Regions } from "@lib/api/types/get-regions";
 import { SupplyChangeData } from "@lib/api/types/get-supply-change";
@@ -24,6 +25,7 @@ import {
   VotingPower,
 } from "@lib/api/types/get-treasury-proposal";
 import { formatAddress } from "@utils/web3";
+import { isManualPoll } from "constants/manualPolls";
 import useSWR from "swr";
 import { Address } from "viem";
 
@@ -123,6 +125,21 @@ export const useCurrentRoundData = () => {
   const { data } = useSWR<CurrentRoundInfo>(`/current-round`, {
     refreshInterval: 10000,
   });
+
+  return data ?? null;
+};
+
+/**
+ * TEMPORARY stopgap: on-chain tally for a poll the subgraph hasn't indexed yet.
+ * Remove together with `constants/manualPolls` once indexing recovers.
+ */
+export const useManualPollTally = (id: string | undefined | null) => {
+  const { data } = useSWR<PollTally>(
+    id && isManualPoll(id) ? `/polls/tally/${id.toLowerCase()}` : null,
+    // Matches the endpoint's cache window — polling faster just re-reads the
+    // same cached object.
+    { refreshInterval: 60000 }
+  );
 
   return data ?? null;
 };

--- a/lib/api/pollTally.ts
+++ b/lib/api/pollTally.ts
@@ -240,7 +240,7 @@ export const getPollTally = async (
       const excluded = registeredTranscoder
         ? nonVoteStake.get(voter) ?? 0n
         : 0n;
-      const weight = voteStake - excluded;
+      const weight = voteStake > excluded ? voteStake - excluded : 0n;
 
       if (choice === "Yes") yes += weight;
       else no += weight;

--- a/lib/api/pollTally.ts
+++ b/lib/api/pollTally.ts
@@ -1,0 +1,270 @@
+import { l2PublicClient } from "@lib/chains";
+import { Address, formatEther, getAbiItem, getAddress } from "viem";
+
+import { bondingManager } from "./abis/main/BondingManager";
+import { poll as pollAbi } from "./abis/main/Poll";
+import { roundsManager } from "./abis/main/RoundsManager";
+import { getBondingManagerAddress, getRoundsManagerAddress } from "./contracts";
+import { PollTally, PollTallyVote } from "./types/get-poll-tally";
+
+/**
+ * TEMPORARY stopgap: compute a poll's stake-weighted tally from chain state so
+ * results stay visible while the subgraph is behind on indexing.
+ *
+ * This mirrors the subgraph's tally rules (see livepeer/subgraph
+ * `src/mappings/poll.ts`):
+ *  - a vote's weight is the voter's stake at the current round,
+ *  - a registered transcoder votes with its *total* stake (own + delegated),
+ *  - a delegator that votes itself is subtracted from its delegate's weight
+ *    (`nonVoteStake`), so stake is never counted twice,
+ *  - only `Yes` (0) and `No` (1) choices count, and the latest vote per address
+ *    wins.
+ *
+ * CAVEAT: this reads stake as it is *now*, not as it was at the poll's end
+ * block. While a poll is open that matches what the subgraph reports. Once it
+ * closes the real result freezes and this one keeps moving as stake is bonded,
+ * unbonded, or earns rewards — enough to flip the derived passed/rejected
+ * status. That is left unhandled on purpose: the poll is expected to still be
+ * open for the few days this stopgap exists, and pinning the reads to the end
+ * block needs `NodeInterface.l2BlockRangeForL1` to map it onto L2, which reverts
+ * intermittently for the same input (the RPC's own flakiness, also the likely
+ * cause of the `getL2BlockRangeForL1` TODO in ./polls.ts). Pinning through it
+ * traded a small drift for an intermittent hard failure. If voting closes while
+ * the subgraph is still behind, treat these numbers as indicative and confirm
+ * the outcome from the vote events at the end block.
+ *
+ * Remove together with the manual poll list once indexing recovers.
+ */
+
+const VOTE_EVENT = getAbiItem({ abi: pollAbi, name: "Vote" });
+
+/** Choice IDs the contract accepts; anything else is ignored by the tally. */
+const CHOICES: Record<string, PollTallyVote["choice"]> = { 0: "Yes", 1: "No" };
+
+/** Infura caps `eth_getLogs` at 10k blocks on Arbitrum; stay under it. */
+const MAX_LOG_RANGE = 9_000n;
+
+/** Blocks re-scanned on every poll, so a reorg near the tip can't drop a vote. */
+const REORG_BUFFER = 200n;
+
+/** How many range chunks are in flight at once during a cold scan. */
+const CHUNK_CONCURRENCY = 10;
+
+type Choice = PollTallyVote["choice"];
+
+const decode = (logs: Awaited<ReturnType<typeof getRangeLogs>>) =>
+  logs.flatMap((log) => {
+    const choice = CHOICES[String(log.args.choiceID)];
+    return choice && log.args.voter
+      ? [{ voter: getAddress(log.args.voter), choice }]
+      : [];
+  });
+
+const getRangeLogs = (address: Address, fromBlock: bigint, toBlock: bigint) =>
+  l2PublicClient.getLogs({ address, event: VOTE_EVENT, fromBlock, toBlock });
+
+/**
+ * Read `Vote` logs across a block span. Tries the span in one request — cheap on
+ * providers that allow it — and falls back to fixed-size chunks for the ones
+ * that cap the range (Infura), a few at a time so we don't burst the rate limit.
+ */
+const getVoteLogs = async (
+  address: Address,
+  fromBlock: bigint,
+  toBlock: bigint
+): Promise<{ voter: Address; choice: Choice }[]> => {
+  if (fromBlock > toBlock) return [];
+
+  try {
+    return decode(await getRangeLogs(address, fromBlock, toBlock));
+  } catch (err) {
+    if (toBlock - fromBlock < MAX_LOG_RANGE) throw err;
+
+    const ranges: [bigint, bigint][] = [];
+    for (let start = fromBlock; start <= toBlock; start += MAX_LOG_RANGE) {
+      const end = start + MAX_LOG_RANGE - 1n;
+      ranges.push([start, end > toBlock ? toBlock : end]);
+    }
+
+    const votes: { voter: Address; choice: Choice }[] = [];
+    for (let i = 0; i < ranges.length; i += CHUNK_CONCURRENCY) {
+      const batch = await Promise.all(
+        ranges
+          .slice(i, i + CHUNK_CONCURRENCY)
+          .map(([start, end]) => getRangeLogs(address, start, end))
+      );
+      for (const logs of batch) votes.push(...decode(logs));
+    }
+
+    return votes;
+  }
+};
+
+/**
+ * Votes seen so far per poll, so only blocks appended since the last call are
+ * scanned. A poll's history is ~830k blocks and grows by ~345k a day, which is
+ * ~90 chunked requests to walk — worth paying once per process, not per request.
+ */
+const scanned = new Map<
+  Address,
+  { toBlock: bigint; choices: Map<Address, Choice> }
+>();
+
+/** Latest vote per address, matching the subgraph's overwrite on re-vote. */
+const getChoiceByVoter = async (
+  address: Address,
+  startBlock: bigint,
+  latestBlock: bigint
+) => {
+  const previous = scanned.get(address);
+  const choices = previous?.choices ?? new Map<Address, Choice>();
+  const fromBlock = previous
+    ? previous.toBlock > REORG_BUFFER
+      ? previous.toBlock - REORG_BUFFER
+      : startBlock
+    : startBlock;
+
+  // Re-scanning the buffer is idempotent: replaying a vote sets the same choice.
+  for (const { voter, choice } of await getVoteLogs(
+    address,
+    fromBlock,
+    latestBlock
+  )) {
+    choices.set(voter, choice);
+  }
+
+  scanned.set(address, { toBlock: latestBlock, choices });
+
+  return choices;
+};
+
+export const getPollTally = async (
+  pollAddress: Address,
+  startBlock: number
+): Promise<PollTally> => {
+  const [bondingManagerAddress, roundsManagerAddress, latestBlock] =
+    await Promise.all([
+      getBondingManagerAddress(),
+      getRoundsManagerAddress(),
+      l2PublicClient.getBlockNumber(),
+    ]);
+
+  const [currentRound, totalBonded, choiceByVoter] = await Promise.all([
+    l2PublicClient.readContract({
+      address: roundsManagerAddress,
+      abi: roundsManager,
+      functionName: "currentRound",
+    }),
+    l2PublicClient.readContract({
+      address: bondingManagerAddress,
+      abi: bondingManager,
+      functionName: "getTotalBonded",
+    }),
+    getChoiceByVoter(pollAddress, BigInt(startBlock), latestBlock),
+  ]);
+
+  const voters = [...choiceByVoter.keys()];
+
+  // `l2PublicClient` aggregates concurrent reads into multicall3 batches, so
+  // these are a handful of requests no matter how many addresses voted.
+  const read = { address: bondingManagerAddress, abi: bondingManager } as const;
+
+  const [delegators, registrations, transcoderStakes, pendingStakes] =
+    await Promise.all([
+      Promise.all(
+        voters.map((voter) =>
+          l2PublicClient.readContract({
+            ...read,
+            functionName: "getDelegator",
+            args: [voter],
+          })
+        )
+      ),
+      Promise.all(
+        voters.map((voter) =>
+          l2PublicClient.readContract({
+            ...read,
+            functionName: "isRegisteredTranscoder",
+            args: [voter],
+          })
+        )
+      ),
+      Promise.all(
+        voters.map((voter) =>
+          l2PublicClient.readContract({
+            ...read,
+            functionName: "transcoderTotalStake",
+            args: [voter],
+          })
+        )
+      ),
+      Promise.all(
+        voters.map((voter) =>
+          l2PublicClient.readContract({
+            ...read,
+            functionName: "pendingStake",
+            args: [voter, currentRound],
+          })
+        )
+      ),
+    ]);
+
+  // Delegators that voted themselves are subtracted from their delegate's
+  // weight, whether or not the delegate ended up voting.
+  const nonVoteStake = new Map<Address, bigint>();
+  const tallied = voters.map((voter, index) => {
+    const registeredTranscoder = registrations[index];
+    const delegate = getAddress(delegators[index][2]);
+    const isSelfDelegated = delegate === voter;
+    const voteStake = isSelfDelegated
+      ? transcoderStakes[index]
+      : pendingStakes[index];
+
+    if (!isSelfDelegated) {
+      nonVoteStake.set(
+        delegate,
+        (nonVoteStake.get(delegate) ?? 0n) + voteStake
+      );
+    }
+
+    return {
+      voter,
+      choice: choiceByVoter.get(voter) as Choice,
+      registeredTranscoder,
+      voteStake,
+    };
+  });
+
+  let yes = 0n;
+  let no = 0n;
+
+  const votes = tallied.map(
+    ({ voter, choice, registeredTranscoder, voteStake }) => {
+      // Only a *registered* transcoder's weight is reduced by its delegators'
+      // own votes — an unregistered delegate votes with its personal stake only.
+      const excluded = registeredTranscoder
+        ? nonVoteStake.get(voter) ?? 0n
+        : 0n;
+      const weight = voteStake - excluded;
+
+      if (choice === "Yes") yes += weight;
+      else no += weight;
+
+      return {
+        voter: voter.toLowerCase(),
+        choice,
+        voteStake: formatEther(voteStake),
+        nonVoteStake: formatEther(excluded),
+        registeredTranscoder,
+      };
+    }
+  );
+
+  return {
+    poll: pollAddress.toLowerCase(),
+    tally: { yes: formatEther(yes), no: formatEther(no) },
+    totalStake: formatEther(totalBonded),
+    votes,
+    updatedAt: Math.floor(Date.now() / 1000),
+  };
+};

--- a/lib/api/pollTally.ts
+++ b/lib/api/pollTally.ts
@@ -149,16 +149,11 @@ export const getPollTally = async (
       l2PublicClient.getBlockNumber(),
     ]);
 
-  const [currentRound, totalBonded, choiceByVoter] = await Promise.all([
+  const [currentRound, choiceByVoter] = await Promise.all([
     l2PublicClient.readContract({
       address: roundsManagerAddress,
       abi: roundsManager,
       functionName: "currentRound",
-    }),
-    l2PublicClient.readContract({
-      address: bondingManagerAddress,
-      abi: bondingManager,
-      functionName: "getTotalBonded",
     }),
     getChoiceByVoter(pollAddress, BigInt(startBlock), latestBlock),
   ]);
@@ -255,7 +250,6 @@ export const getPollTally = async (
         choice,
         voteStake: formatEther(voteStake),
         nonVoteStake: formatEther(excluded),
-        registeredTranscoder,
       };
     }
   );
@@ -263,8 +257,6 @@ export const getPollTally = async (
   return {
     poll: pollAddress.toLowerCase(),
     tally: { yes: formatEther(yes), no: formatEther(no) },
-    totalStake: formatEther(totalBonded),
     votes,
-    updatedAt: Math.floor(Date.now() / 1000),
   };
 };

--- a/lib/api/pollTally.ts
+++ b/lib/api/pollTally.ts
@@ -211,7 +211,7 @@ export const getPollTally = async (
     const registeredTranscoder = registrations[index];
     const delegate = getAddress(delegators[index][2]);
     const isSelfDelegated = delegate === voter;
-    const voteStake = isSelfDelegated
+    const voteStake = registeredTranscoder
       ? transcoderStakes[index]
       : pendingStakes[index];
 

--- a/lib/api/polls.ts
+++ b/lib/api/polls.ts
@@ -1,4 +1,9 @@
-import { AVERAGE_L1_BLOCK_TIME, CHAIN_INFO, l2Provider } from "@lib/chains";
+import {
+  AVERAGE_L1_BLOCK_TIME,
+  CHAIN_INFO,
+  l2Provider,
+  l2PublicClient,
+} from "@lib/chains";
 import dayjs from "@lib/dayjs";
 import {
   getApollo,
@@ -10,9 +15,11 @@ import {
 import { ethers } from "ethers";
 import fm from "front-matter";
 import { catIpfsJson, IpfsPoll } from "utils/ipfs";
-import { Address } from "viem";
+import { Address, formatEther } from "viem";
 
 import { nodeInterface } from "./abis/bridge/NodeInterface";
+import { bondingManager } from "./abis/main/BondingManager";
+import { getBondingManagerAddress } from "./contracts";
 
 export type Fm = {
   title: string;
@@ -190,12 +197,31 @@ const getTotalStake = async (l2BlockNumber?: number | undefined) => {
 
     return protocolResponse?.data?.protocol?.totalActiveStake;
   } catch (err) {
-    // The subgraph can be unavailable (e.g. an indexing halt). Total stake only
-    // feeds participation percentages, so degrade gracefully instead of failing
-    // the whole poll render — this keeps manually-listed polls viewable/votable.
+    // The subgraph can be unavailable (e.g. an indexing halt). Fall back to the
+    // current total bonded stake on-chain — the same value the subgraph tracks,
+    // except it can't be read at a past block, so participation for an ended
+    // poll is measured against today's stake rather than the stake at its end.
     const detail = err instanceof Error ? err.message : String(err);
-    console.warn(`Could not fetch total stake from subgraph (${detail})`);
-    return undefined;
+    console.warn(
+      `Could not fetch total stake from subgraph, falling back to chain (${detail})`
+    );
+
+    try {
+      const bondingManagerAddress = await getBondingManagerAddress();
+
+      const totalBonded = await l2PublicClient.readContract({
+        address: bondingManagerAddress,
+        abi: bondingManager,
+        functionName: "getTotalBonded",
+      });
+
+      return formatEther(totalBonded);
+    } catch (chainErr) {
+      const chainDetail =
+        chainErr instanceof Error ? chainErr.message : String(chainErr);
+      console.warn(`Could not fetch total bonded stake (${chainDetail})`);
+      return undefined;
+    }
   }
 };
 

--- a/lib/api/polls.ts
+++ b/lib/api/polls.ts
@@ -176,7 +176,9 @@ const getEstimatedEndTimeByBlockNumber = async (
     .unix();
 };
 
-const getTotalStake = async (l2BlockNumber?: number | undefined) => {
+const getTotalStakeFromSubgraph = async (
+  l2BlockNumber?: number | undefined
+) => {
   try {
     const client = getApollo();
 
@@ -197,31 +199,37 @@ const getTotalStake = async (l2BlockNumber?: number | undefined) => {
 
     return protocolResponse?.data?.protocol?.totalActiveStake;
   } catch (err) {
-    // The subgraph can be unavailable (e.g. an indexing halt). Fall back to the
-    // current total bonded stake on-chain — the same value the subgraph tracks,
-    // except it can't be read at a past block, so participation for an ended
-    // poll is measured against today's stake rather than the stake at its end.
     const detail = err instanceof Error ? err.message : String(err);
-    console.warn(
-      `Could not fetch total stake from subgraph, falling back to chain (${detail})`
-    );
+    console.warn(`Could not fetch total stake from subgraph (${detail})`);
+    return undefined;
+  }
+};
 
-    try {
-      const bondingManagerAddress = await getBondingManagerAddress();
+const getTotalStake = async (l2BlockNumber?: number | undefined) => {
+  const totalActiveStake = await getTotalStakeFromSubgraph(l2BlockNumber);
 
-      const totalBonded = await l2PublicClient.readContract({
-        address: bondingManagerAddress,
-        abi: bondingManager,
-        functionName: "getTotalBonded",
-      });
+  // A subgraph that is reindexing answers successfully with an empty protocol
+  // entity rather than failing, so fall back on a missing value too — not just
+  // on a thrown error. Total bonded stake is the same figure the subgraph
+  // tracks, except it can't be read at a past block, so participation for an
+  // ended poll is measured against today's stake rather than the stake at its
+  // end.
+  if (totalActiveStake) return totalActiveStake;
 
-      return formatEther(totalBonded);
-    } catch (chainErr) {
-      const chainDetail =
-        chainErr instanceof Error ? chainErr.message : String(chainErr);
-      console.warn(`Could not fetch total bonded stake (${chainDetail})`);
-      return undefined;
-    }
+  try {
+    const bondingManagerAddress = await getBondingManagerAddress();
+
+    const totalBonded = await l2PublicClient.readContract({
+      address: bondingManagerAddress,
+      abi: bondingManager,
+      functionName: "getTotalBonded",
+    });
+
+    return formatEther(totalBonded);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    console.warn(`Could not fetch total bonded stake (${detail})`);
+    return undefined;
   }
 };
 

--- a/lib/api/types/get-poll-tally.ts
+++ b/lib/api/types/get-poll-tally.ts
@@ -1,0 +1,25 @@
+/** A single voter's contribution to an on-chain computed poll tally. */
+export type PollTallyVote = {
+  voter: string;
+  choice: "Yes" | "No";
+  /** Stake behind the vote, in LPT (decimal string). */
+  voteStake: string;
+  /** Stake of this voter's delegators that voted themselves, in LPT. */
+  nonVoteStake: string;
+  registeredTranscoder: boolean;
+};
+
+/**
+ * Stake-weighted poll results computed directly from chain state, mirroring the
+ * subgraph's tally so it can stand in for `poll.tally` while indexing is behind.
+ */
+export type PollTally = {
+  poll: string;
+  /** Stake-weighted totals, in LPT (decimal strings). */
+  tally: { yes: string; no: string };
+  /** Total bonded stake used for participation, in LPT. */
+  totalStake: string;
+  votes: PollTallyVote[];
+  /** Unix seconds the tally was computed at. */
+  updatedAt: number;
+};

--- a/lib/api/types/get-poll-tally.ts
+++ b/lib/api/types/get-poll-tally.ts
@@ -6,7 +6,6 @@ export type PollTallyVote = {
   voteStake: string;
   /** Stake of this voter's delegators that voted themselves, in LPT. */
   nonVoteStake: string;
-  registeredTranscoder: boolean;
 };
 
 /**
@@ -17,9 +16,5 @@ export type PollTally = {
   poll: string;
   /** Stake-weighted totals, in LPT (decimal strings). */
   tally: { yes: string; no: string };
-  /** Total bonded stake used for participation, in LPT. */
-  totalStake: string;
   votes: PollTallyVote[];
-  /** Unix seconds the tally was computed at. */
-  updatedAt: number;
 };

--- a/pages/api/polls/tally/[poll].ts
+++ b/pages/api/polls/tally/[poll].ts
@@ -1,3 +1,10 @@
+/**
+ * TEMPORARY stopgap: serve a poll's stake-weighted tally computed from chain
+ * state, for polls the subgraph has not indexed yet. Restricted to the manually
+ * listed polls so it can't be used to scan arbitrary contracts — remove along
+ * with `constants/manualPolls` once indexing recovers.
+ */
+
 import { getCacheControlHeader } from "@lib/api";
 import {
   badRequest,
@@ -10,13 +17,6 @@ import { PollTally } from "@lib/api/types/get-poll-tally";
 import { getManualPoll } from "constants/manualPolls";
 import { NextApiRequest, NextApiResponse } from "next";
 import { Address, getAddress, isAddress } from "viem";
-
-/**
- * TEMPORARY stopgap: serve a poll's stake-weighted tally computed from chain
- * state, for polls the subgraph has not indexed yet. Restricted to the manually
- * listed polls so it can't be used to scan arbitrary contracts — remove along
- * with `constants/manualPolls` once indexing recovers.
- */
 
 /** Recompute at most once a minute per poll, CDN in front of us or not. */
 const MEMO_TTL_MS = 60_000;

--- a/pages/api/polls/tally/[poll].ts
+++ b/pages/api/polls/tally/[poll].ts
@@ -1,0 +1,89 @@
+import { getCacheControlHeader } from "@lib/api";
+import {
+  badRequest,
+  internalError,
+  methodNotAllowed,
+  notFound,
+} from "@lib/api/errors";
+import { getPollTally } from "@lib/api/pollTally";
+import { PollTally } from "@lib/api/types/get-poll-tally";
+import { getManualPoll } from "constants/manualPolls";
+import { NextApiRequest, NextApiResponse } from "next";
+import { Address, getAddress, isAddress } from "viem";
+
+/**
+ * TEMPORARY stopgap: serve a poll's stake-weighted tally computed from chain
+ * state, for polls the subgraph has not indexed yet. Restricted to the manually
+ * listed polls so it can't be used to scan arbitrary contracts — remove along
+ * with `constants/manualPolls` once indexing recovers.
+ */
+
+/** Recompute at most once a minute per poll, CDN in front of us or not. */
+const MEMO_TTL_MS = 60_000;
+
+const memo = new Map<
+  Address,
+  { expiresAt: number; tally: Promise<PollTally> }
+>();
+
+const getCachedPollTally = (pollAddress: Address, startBlock: number) => {
+  const cached = memo.get(pollAddress);
+
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.tally;
+  }
+
+  const tally = getPollTally(pollAddress, startBlock).catch((err) => {
+    // Don't cache failures — the next request should retry.
+    memo.delete(pollAddress);
+    throw err;
+  });
+
+  memo.set(pollAddress, { expiresAt: Date.now() + MEMO_TTL_MS, tally });
+
+  return tally;
+};
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse<PollTally | unknown>
+) => {
+  try {
+    const method = req.method;
+
+    if (method !== "GET") {
+      methodNotAllowed(res, method ?? "unknown", ["GET"]);
+      return;
+    }
+
+    const { poll } = req.query;
+
+    if (!poll || Array.isArray(poll) || !isAddress(poll)) {
+      badRequest(res, "Invalid poll address format");
+      return;
+    }
+
+    const manualPoll = getManualPoll(poll);
+
+    if (!manualPoll) {
+      notFound(
+        res,
+        "No manually listed poll for this address",
+        "Tallies are only computed on-chain for polls missing from the subgraph"
+      );
+      return;
+    }
+
+    res.setHeader("Cache-Control", getCacheControlHeader("minute"));
+
+    const tally = await getCachedPollTally(
+      getAddress(poll),
+      manualPoll.startBlockL2
+    );
+
+    res.status(200).json(tally);
+  } catch (err) {
+    internalError(res, err);
+  }
+};
+
+export default handler;

--- a/pages/voting/[poll].tsx
+++ b/pages/voting/[poll].tsx
@@ -28,16 +28,21 @@ import {
   useVoteQuery,
 } from "apollo";
 import { sentenceCase } from "change-case";
-import { getManualPoll, isManualPoll } from "constants/manualPolls";
+import {
+  getManualPoll,
+  isManualPoll,
+  withManualTally,
+} from "constants/manualPolls";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useWindowSize } from "react-use";
 
 import {
   useAccountAddress,
   useCurrentRoundData,
   useExplorerStore,
+  useManualPollTally,
 } from "../../hooks";
 import FourZeroFour from "../404";
 
@@ -89,21 +94,42 @@ const Poll = () => {
 
   const currentRound = useCurrentRoundData();
 
+  // Tally computed on-chain for polls the subgraph hasn't indexed yet.
+  const manualTally = useManualPollTally(pollId);
+
   useEffect(() => {
     const init = async () => {
       // Fall back to a manually-listed poll when the subgraph doesn't have it
       // (e.g. created while indexing was down), so it stays viewable/votable.
-      const source = data?.poll ?? getManualPoll(pollId);
+      const manualPoll = getManualPoll(pollId);
+      const source = data?.poll ?? manualPoll;
       if (source && currentRound?.currentL1Block) {
         const response = await getPollExtended(
-          source,
+          withManualTally(source, manualTally),
           currentRound.currentL1Block
         );
         setPollData(response);
       }
     };
     init();
-  }, [data, pollId, currentRound?.currentL1Block]);
+  }, [data, pollId, currentRound?.currentL1Block, manualTally]);
+
+  // The subgraph also backs "did I already vote?" — recover it from the
+  // on-chain tally while indexing is behind.
+  const manualVote = useMemo(() => {
+    const vote = manualTally?.votes.find(
+      (v) => v.voter === accountAddress?.toLowerCase()
+    );
+
+    return vote
+      ? {
+          __typename: "Vote" as const,
+          choiceID: vote.choice as PollChoice,
+          voteStake: vote.voteStake,
+          nonVoteStake: vote.nonVoteStake,
+        }
+      : undefined;
+  }, [manualTally, accountAddress]);
 
   // Only 404 on a genuine subgraph error with no manual fallback for this poll.
   if (pollError && !getManualPoll(pollId)) {
@@ -228,9 +254,9 @@ const Poll = () => {
                   }}
                 >
                   <Text size="1" css={{ color: "$blue11" }}>
-                    Live vote counts aren&apos;t available for this poll yet —
-                    the subgraph is still indexing it. The totals below may read
-                    0 until indexing catches up. Voting works normally.
+                    The subgraph is still indexing this poll, so the totals below
+                    are computed directly from chain state and refresh about once
+                    a minute. Voting works normally.
                   </Text>
                 </Box>
               )}
@@ -400,7 +426,7 @@ const Poll = () => {
                       }
                     | undefined
                     | null,
-                  vote: voteData?.vote as
+                  vote: (voteData?.vote ?? manualVote) as
                     | {
                         __typename: "Vote";
                         choiceID?: PollChoice;
@@ -427,7 +453,7 @@ const Poll = () => {
                       }
                     | undefined
                     | null,
-                  vote: voteData?.vote as
+                  vote: (voteData?.vote ?? manualVote) as
                     | {
                         __typename: "Vote";
                         choiceID?: PollChoice;

--- a/pages/voting/[poll].tsx
+++ b/pages/voting/[poll].tsx
@@ -254,9 +254,9 @@ const Poll = () => {
                   }}
                 >
                   <Text size="1" css={{ color: "$blue11" }}>
-                    The subgraph is still indexing this poll, so the totals below
-                    are computed directly from chain state and refresh about once
-                    a minute. Voting works normally.
+                    The subgraph is still indexing this poll, so the totals
+                    below are computed directly from chain state and refresh
+                    about once a minute. Voting works normally.
                   </Text>
                 </Box>
               )}


### PR DESCRIPTION
> [!WARNING]
> **Bandaid — revert once the subgraph has reindexed LIP-118.**
> Only exists because the subgraph is resyncing from scratch
> (livepeer/subgraph#247) and cannot serve poll tallies. Revert this and #734
> together; neither is meant to stay.

## Problem

The voting UI sources its stake-weighted counts from the subgraph. The subgraph is resyncing from scratch (livepeer/subgraph#247, currently ~block 5.8M of ~486M), so the manually surfaced LIP-118 poll (#734) is reachable and votable but shows **0% support / 0% participation** — including for people who already voted, whose sidebar reads "My Vote: N/A".

## Change

Adds `GET /api/polls/tally/[poll]`, which recomputes the tally from chain state.

The Poll contract stores nothing — `vote()` only emits `Vote(voter, choiceID)` — so the endpoint reads the vote logs and weights each voter through BondingManager, following the rules the subgraph documents in `src/mappings/poll.ts`:

- a registered transcoder votes with its total stake (own + delegated)
- weight is clamped at zero — `transcoderTotalStake` reads the transcoder pool and returns 0 outside it, which would otherwise make a delegate's weight negative
- a delegator that votes itself is subtracted from its delegate's weight (`nonVoteStake`), so stake is never double counted
- only `Yes`/`No` count, latest vote per address wins

The route is restricted to `MANUAL_POLLS`, so it can't be pointed at arbitrary contracts.

Also:

- `getTotalStake` falls back to `BondingManager.getTotalBonded()` when the subgraph is unavailable. The `protocol` entity is currently `null`, which would otherwise leave participation at 0% even with a tally present.
- The poll page recovers "My Vote" from the computed tally, so a voter isn't shown N/A and prompted to vote (and pay gas) twice.

## RPC cost

Infura caps `eth_getLogs` at 10k blocks on Arbitrum, so scans are chunked under that limit, 10 in flight. A scan cursor advances so only new blocks are read after the first pass, and results are memoised for 60s in-process as well as via `Cache-Control` at the CDN.

| | requests |
|---|---|
| cold scan (once per process) | ~92 today, ~320 by poll end — measured 0.52s |
| steady state | 1 `getLogs` + one batched round of contract reads, max once/60s |

## Verification

Run against Arbitrum with the production Infura key:

```
GET /api/polls/tally/0x74479927117d4158b32c03d5400c14bdd7e6a46a → 200
{"tally":{"yes":"15950.236512152106011868","no":"0"}, "totalStake":"29313650.734432784536262179", ...}
```

Matches an independent `cast` computation to the wei. Page renders 100% support / 15.95K LPT for / 0.05% participation. Guards checked: unknown poll → 404, malformed address → 400, `POST` → 405.

## Known limitation

Stake is read as of now. That matches the subgraph while a poll is open, but the real result freezes when voting closes whereas this keeps moving as stake is bonded, unbonded, or earns rewards — enough to flip the derived passed/rejected status.

Pinning the reads to the poll's end block was implemented and tested, then dropped: it needs `NodeInterface.l2BlockRangeForL1` to map the L1 end block onto L2, and non-archive Arbitrum nodes stop resolving that mapping past roughly 67-74 days (measured identically on Infura, arb1 and publicnode). It traded a small drift for a hard failure. The same boundary explains the existing `getL2BlockRangeForL1` TODO in `lib/api/polls.ts`: block 18328665 is a 2023 L1 block, well outside the window. Documented in the module comment instead.

Voting closes in ~6 days and the subgraph needs ~2, so this window is not expected to open. If it does, treat the numbers as indicative and confirm from the vote events at the end block.

## Revert

**This PR is a stopgap and should be reverted, not maintained.**

Revert when the subgraph has reindexed LIP-118 (`polls` and `pollTally` populated
for `0x74479927117d4158b32c03d5400c14bdd7e6a46a`):

1. Revert this PR via GitHub's **Revert** button, matching the precedent of
   `Revert "refactor: temporarily hide minute usage data with warning overlay (#452)" (#470)`.
2. Revert #734 as well, which added `constants/manualPolls.ts` for the same outage.

Reverting removes `lib/api/pollTally.ts`, `GET /api/polls/tally/[poll]`, the
"My Vote" recovery on the poll page, and the `getTotalBonded` fallback in
`getTotalStake`.

Nothing depends on it staying: the UI prefers subgraph data wherever it exists,
so a reindexed poll drops the manual entry and the computed tally on its own,
even before the revert lands. The only cost of leaving it in place is carrying
governance-critical code that duplicates the subgraph's rules and can drift
from them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added on-chain, stake-weighted tallying for supported manual polls.
  - Poll results now include detailed vote information and refresh approximately every minute.
  - Voting pages can identify whether you have already voted, even when indexed data is delayed.

- **Bug Fixes**
  - Added a fallback to on-chain totals when subgraph data is unavailable or outdated.
  - Improved reliability when retrieving poll results across larger block ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

