### PR TITLE
fix: type the wallet chains without a rainbowkit deep import

### DIFF
--- a/components/Web3Providers/index.tsx
+++ b/components/Web3Providers/index.tsx
@@ -3,7 +3,6 @@ import {
   type Locale,
   RainbowKitProvider,
 } from "@rainbow-me/rainbowkit";
-import { _chains } from "@rainbow-me/rainbowkit/dist/config/getDefaultConfig";
 import {
   baseAccount,
   braveWallet,
@@ -26,11 +25,10 @@ const Index = ({
   locale?: string;
 }) => {
   const config = useMemo(() => {
-    const chains = (
+    const chains =
       DEFAULT_CHAIN.id === L1_CHAIN.id
-        ? [DEFAULT_CHAIN]
-        : [DEFAULT_CHAIN, L1_CHAIN]
-    ) as _chains;
+        ? ([DEFAULT_CHAIN] as const)
+        : ([DEFAULT_CHAIN, L1_CHAIN] as const);
 
     return getDefaultConfig({
       appName: "Livepeer Explorer",


### PR DESCRIPTION
## Problem

`components/Web3Providers/index.tsx` imports `_chains` from `@rainbow-me/rainbowkit/dist/config/getDefaultConfig`. RainbowKit 2.2.10 only declares three entries in its `exports` map (`.`, `./styles.css`, `./wallets`), so that deep path is unresolvable as soon as a bundler enforces the map. Next 16.2's Turbopack does, which is why #755 (bump next to 16.2.11) fails its build:

```
./components/Web3Providers/index.tsx:6:25
Type error: Cannot find module '@rainbow-me/rainbowkit/dist/config/getDefaultConfig'
  or its corresponding type declarations.
```

## Fix

Assert each chain tuple `as const` instead of casting to the private `_chains` type. That produces the same readonly-tuple shape `getDefaultConfig` expects, with no reach into package internals.

## History

This restores the change from #621, which #654 silently reverted by merging a stale branch. #621's other half, the `ConnectButtonProps` deep import, was independently fixed in #710.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm format:check` on Next 16.1.7
- With `next@16.2.11` applied locally, the type error is gone and `next build` compiles successfully (the run then stops at static generation, which needs network access to the subgraph gateway)
