### PR TITLE
fix: truncate long ENS names in EthAddressBadge

### DIFF
--- a/components/EthAddressBadge/index.tsx
+++ b/components/EthAddressBadge/index.tsx
@@ -8,11 +8,24 @@ interface EthAddressBadgeProps {
 
 const EthAddressBadge = ({ value }: EthAddressBadgeProps) => {
   const ensName = useEnsData(value);
+  const displayName = ensName?.name || ensName?.idShort || "";
 
   return (
-    <Link passHref href={`/accounts/${value}/delegating`}>
-      <Badge css={{ cursor: "pointer" }} variant="primary" size="1">
-        {ensName?.name ? ensName?.name : ensName?.idShort ?? ""}
+    <Link passHref href={`/accounts/${value}/delegating`} title={displayName}>
+      <Badge
+        css={{
+          cursor: "pointer",
+          display: "inline-block",
+          maxWidth: 240,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          verticalAlign: "bottom",
+        }}
+        variant="primary"
+        size="1"
+      >
+        {displayName}
       </Badge>
     </Link>
   );


### PR DESCRIPTION
## Problem

A long ENS name (a 47-character `0x...eth` literal) widens the voter column enough to make the votes table scroll horizontally.

## Fix

Cap the badge at 240px with a CSS ellipsis, and expose the full name through the link's `title` so it stays readable on hover.

## History

This restores #655, which #654 silently reverted by merging a stale branch. The file on `main` is byte-identical to its pre-#655 state, so this is a straight re-application.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm format:check`
