### PR TITLE
fix: pass explicit RPC transports to wagmi config

### DIFF
--- a/components/Web3Providers/index.tsx
+++ b/components/Web3Providers/index.tsx
@@ -14,8 +14,14 @@ import {
   walletConnectWallet,
 } from "@rainbow-me/rainbowkit/wallets";
 import rainbowTheme from "constants/rainbowTheme";
-import { DEFAULT_CHAIN, L1_CHAIN, WALLET_CONNECT_PROJECT_ID } from "lib/chains";
+import {
+  DEFAULT_CHAIN,
+  L1_CHAIN,
+  NETWORK_RPC_URLS,
+  WALLET_CONNECT_PROJECT_ID,
+} from "lib/chains";
 import { useMemo } from "react";
+import { fallback, http } from "viem";
 import { WagmiProvider } from "wagmi";
 
 const Index = ({
@@ -37,6 +43,12 @@ const Index = ({
       projectId: WALLET_CONNECT_PROJECT_ID ?? "",
       chains,
       ssr: false,
+      transports: Object.fromEntries(
+        chains.map((c) => [
+          c.id,
+          fallback((NETWORK_RPC_URLS[c.id] ?? []).map((url) => http(url))),
+        ])
+      ),
       wallets: [
         {
           groupName: "Popular",


### PR DESCRIPTION
## Problem

`components/Web3Providers/index.tsx` calls `getDefaultConfig` with no `transports` field, so wagmi falls back to viem's per-chain default RPCs. For `mainnet` that default is `https://eth.merkle.io`, which returns no CORS headers for the production origin and rate-limits aggressively.

Every L1 read in the browser fails with a CORS error, and the resulting viem retry storm keeps RainbowKit's `<ConnectButton.Custom>` from settling its `mounted` flag. The wallet button renders at `opacity: 0` on the migrate routes (the only routes targeting L1), and migrate flows cannot load delegator state.

The regression dates to the wagmi v1 to v2 migration, where the v1 `infuraProvider({ apiKey })` wiring was removed and never replaced. `NEXT_PUBLIC_INFURA_KEY` stayed in `lib/chains.ts` but was only consumed by Apollo and the standalone `l1PublicClient` / `l2PublicClient`, never by the wagmi config, so setting it in Vercel did not help.

## Fix

Pass an explicit `transports` map built from the existing `NETWORK_RPC_URLS` list, so wagmi, Apollo, and the standalone viem clients share one RPC source of truth and the same `NEXT_PUBLIC_INFURA_KEY` / `NEXT_PUBLIC_L1_RPC_URL` / `NEXT_PUBLIC_L2_RPC_URL` env vars cover all three.

```ts
transports: Object.fromEntries(
  chains.map((c) => [
    c.id,
    fallback((NETWORK_RPC_URLS[c.id] ?? []).map((url) => http(url))),
  ])
),
```

`DEFAULT_CHAIN` resolves to either `arbitrum` or `mainnet` and `NETWORK_RPC_URLS` has an entry for both, so the `?? []` guard is defensive only.

Closes #664

## Relationship to #665

This supersedes #665, which carried the same fix plus a second commit flipping `chainStatus` from `"none"` to `"icon"` on the connect button. That second commit is obsolete: #710 has since added a purpose-built "Wrong Network" button driven by `useIsWrongRouteChain()`, and `main` deliberately keeps `chainStatus="none"` alongside it. Re-applying `"icon"` would add a persistent chain pill on every route and duplicate the wrong-network signal. #665 can be closed once this lands.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm format:check`
- Cherry-picks cleanly onto #762 and typechecks in combination, so the two can land in either order
