### PR TITLE
fix: mark decorative images as decorative

### DIFF
--- a/components/AccountCell/index.tsx
+++ b/components/AccountCell/index.tsx
@@ -50,6 +50,7 @@ const Index = ({ active, address }) => {
               borderColor: "$neutral5",
             }}
             src={identity.avatar}
+            alt=""
           />
         ) : (
           <QRCodeCanvas

--- a/components/DelegatingWidget/Header.tsx
+++ b/components/DelegatingWidget/Header.tsx
@@ -42,6 +42,7 @@ const Header = ({
               height: 40,
             }}
             src={delegateProfile.avatar}
+            alt=""
           />
         ) : (
           <QRCodeCanvas

--- a/components/IdentityAvatar/index.tsx
+++ b/components/IdentityAvatar/index.tsx
@@ -82,6 +82,7 @@ const IdentityAvatar = ({ identity, address, size = 24, css = {} }: Props) => {
           transition: "opacity 150ms ease",
         }}
         src={avatarSrc}
+        alt=""
         onLoad={() => setImageLoaded(true)}
         onError={() => setHasAvatarError(true)}
       />

--- a/components/Profile/index.tsx
+++ b/components/Profile/index.tsx
@@ -104,6 +104,7 @@ const Index = ({
                 height: "100%",
               }}
               src={identity.avatar}
+              alt=""
             />
           ) : (
             <Box

--- a/components/TxSummaryDialog/index.tsx
+++ b/components/TxSummaryDialog/index.tsx
@@ -55,7 +55,7 @@ const Index = () => {
             <Box
               as="img"
               src="/img/green-loader.svg"
-              alt="loader"
+              alt=""
               css={{
                 animation: `${rotate} 2s linear`,
                 animationIterationCount: "infinite",

--- a/pages/migrate/broadcaster.tsx
+++ b/pages/migrate/broadcaster.tsx
@@ -739,7 +739,7 @@ const MigrateBroadcaster = () => {
 
             {state.image && (
               <Box css={{ textAlign: "center", marginBottom: "$5" }}>
-                <Box as="img" src={state.image} />
+                <Box as="img" src={state.image} alt="" />
               </Box>
             )}
 

--- a/pages/migrate/delegator/index.tsx
+++ b/pages/migrate/delegator/index.tsx
@@ -747,7 +747,7 @@ const MigrateUndelegatedStake = () => {
 
             {state.image && (
               <Box css={{ textAlign: "center", marginBottom: "$5" }}>
-                <Box as="img" src={state.image} />
+                <Box as="img" src={state.image} alt="" />
               </Box>
             )}
 

--- a/pages/migrate/orchestrator.tsx
+++ b/pages/migrate/orchestrator.tsx
@@ -710,7 +710,7 @@ const MigrateOrchestrator = () => {
 
             {state.image && (
               <Box css={{ textAlign: "center", marginBottom: "$5" }}>
-                <Box as="img" src={state.image} />
+                <Box as="img" src={state.image} alt="" />
               </Box>
             )}
 


### PR DESCRIPTION
## Problem

Lighthouse `image-alt` fails on `main`: 12 nodes on `/` and 1 on each migrate page. Two further images had no alt but never rendered on an audited route, and one carried alt text that is announced as content.

A missing `alt` is not neutral — assistive technology falls back to the source, so the home page announces *"slash api slash ens-data slash image slash novignis dot eth"* twelve times.

## Fix

Empty alt on all seven, because every one of them sits beside the text it depicts:

| Image | Adjacent text |
| --- | --- |
| `IdentityAvatar` (orchestrator rows, 12 per page) | `textTruncate(identity.name, 20)` + address badge |
| `AccountCell` | `identity?.name ?? formatAddress(address)` |
| `DelegatingWidget/Header` | `delegateProfile?.name ?? formatAddress(transcoder?.id)` |
| `Profile` header | `identity?.name ?? formatAddress(account)` |
| `/img/arbitrum.svg` on 3 migrate pages | title reads "Migrate Orchestrator to Arbitrum One" |
| `TxSummaryDialog` spinner | previously `alt="loader"`, announced as content |

Naming them would satisfy `image-alt` and violate `image-redundant-alt`: a row would announce as *"novignis.eth avatar, novignis.eth, 0x0074…"*. WCAG 1.1.1 and the W3C WAI images tutorial both put "information already provided by adjacent text" in the decorative bucket, and `jsx-a11y/alt-text` states it directly: *"either with meaningful text, or an empty string for decorative images"*.

`alt=""` is still a real change — it is an explicit presentational declaration that passes the audit, unlike an absent attribute.

## Verification

Lighthouse on this branch:

```
/                      score=1  Image elements have [alt] attributes
/migrate/orchestrator  score=1  Image elements have [alt] attributes
```

Home accessibility score 0.81 → 0.86. `pnpm lint`, `pnpm typecheck`, `pnpm format:check`, `pnpm test` (121/121).

## Notes

Lint cannot catch this class of bug here: these are `<Box as="img">` Stitches components, so `jsx-a11y/alt-text` and `@next/next/no-img-element` never see an image element. Only a rendered audit does.

First of five PRs splitting #509. Original work by @Roaring30s, credited via `Co-Authored-By`. Two other parts of #509 (`productionBrowserSourceMaps` and the `<meta name="description">` tag) already reached `main` independently.

Remaining Lighthouse accessibility failures on `/`, out of scope here: `link-name` (the logo anchor), `landmark-one-main`, `aria-allowed-attr`, `color-contrast`, `td-has-header`.
