### PR TITLE
chore: commit the module resolution Next already enforces

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Problem

Since #755 brought `next@16.2.11`, every `next dev` / `next build` rewrites `tsconfig.json`:

```
We detected TypeScript in your project and reconfigured your tsconfig.json file for you.
	- moduleResolution was set to bundler (to match modern bundler resolution)
```

`main` has `"moduleResolution": "node"` committed, so every checkout goes dirty on the first dev run. Next also reserializes the file with `JSON.stringify`, expanding every array to one item per line and undoing the Prettier formatting.

Confirmed the boundary: a worktree pinned to `next@16.1.7` is untouched after several dev runs; the same worktree on `16.2.11` rewrites the file at startup. This is new 16.2 behaviour, not a local misconfiguration.

## Why it is worth committing rather than discarding

The two values resolve modules differently:

| | `node` (Node10) | `bundler` (TS 5.0+) |
| --- | --- | --- |
| package.json `exports` map | ignored | authoritative |

`pnpm typecheck` runs `tsc` directly on a clean checkout, so CI resolves with `node`. Vercel builds with `bundler`. Anything importing a path a package does not export type-checks green in CI and fails on Vercel, which is exactly what happened with `@rainbow-me/rainbowkit/dist/config/getDefaultConfig` in #762.

Committing the value the toolchain already enforces closes that gap and stops the phantom diff.

## Verification

- `pnpm typecheck` under `bundler` on current `main` — clean, no new errors
- `pnpm lint`, `pnpm format:check`
- `pnpm test` — 121/121

Only the one line changes; the file keeps its Prettier formatting rather than Next's serialization.

Closes #766
