### PR TITLE
fix: replace hijacked discord.gg/livepeer invite link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Question
-    url: https://discord.gg/livepeer
+    url: https://discord.gg/55SZFEEH5y
     about: "Have a question? Join us in the 'lounge' channel on the Livepeer Discord server. We're here to help!"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,4 +48,4 @@ In general, we follow the ["fork-and-pull" Git workflow](https://github.com/susa
 
 ## Getting Help
 
-Join us in the [Livepeer Discord](https://discord.com/invite/livepeer) and post your question in the `#🛋️|lounge` channel.
+Join us in the [Livepeer Discord](https://discord.gg/55SZFEEH5y) and post your question in the `#🛋️|lounge` channel.

--- a/components/Claim/index.tsx
+++ b/components/Claim/index.tsx
@@ -246,7 +246,7 @@ const Claim = () => {
           )}
           <Button
             as="a"
-            href="https://discord.gg/livepeer"
+            href="https://discord.gg/55SZFEEH5y"
             target="_blank"
             size="3"
             variant="transparentWhite"

--- a/components/Drawer/index.tsx
+++ b/components/Drawer/index.tsx
@@ -227,7 +227,7 @@ const Index = ({
             </EmbedModal>
             <A
               css={{ fontSize: "$2", marginBottom: "$2", display: "block" }}
-              href="https://discord.gg/livepeer"
+              href="https://discord.gg/55SZFEEH5y"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -785,7 +785,7 @@ const Layout = ({ children, title = "Livepeer Explorer" }) => {
                                 </PopoverLink>
                                 <PopoverLink
                                   newWindow={true}
-                                  href={`https://discord.gg/livepeer`}
+                                  href={`https://discord.gg/55SZFEEH5y`}
                                 >
                                   Discord
                                 </PopoverLink>

--- a/pages/migrate/broadcaster.tsx
+++ b/pages/migrate/broadcaster.tsx
@@ -857,7 +857,7 @@ const MigrateBroadcaster = () => {
           <Button
             css={{ bottom: 20, right: 20 }}
             as="a"
-            href="https://discord.gg/livepeer"
+            href="https://discord.gg/55SZFEEH5y"
             target="_blank"
             size="3"
             ghost

--- a/pages/migrate/delegator/index.tsx
+++ b/pages/migrate/delegator/index.tsx
@@ -868,7 +868,7 @@ const MigrateUndelegatedStake = () => {
           <Button
             css={{ bottom: 20, right: 20 }}
             as="a"
-            href="https://discord.gg/livepeer"
+            href="https://discord.gg/55SZFEEH5y"
             target="_blank"
             size="3"
             ghost

--- a/pages/migrate/orchestrator.tsx
+++ b/pages/migrate/orchestrator.tsx
@@ -839,7 +839,7 @@ const MigrateOrchestrator = () => {
           <Button
             css={{ bottom: 20, right: 20 }}
             as="a"
-            href="https://discord.gg/livepeer"
+            href="https://discord.gg/55SZFEEH5y"
             target="_blank"
             size="3"
             ghost


### PR DESCRIPTION
## Description

The `discord.gg/livepeer` vanity invite was hijacked and no longer points to the official Livepeer Discord server. This replaces every occurrence in the Explorer with the official invite `https://discord.gg/55SZFEEH5y`, mirroring what was done for the website in livepeer/website#94.

## Type of Change

- [x] fix: Bug fix

## Related Issue(s)

Related: livepeer/website#94

## Changes Made

- Update the Discord link in the header/footer nav popover, the Drawer, and the Claim flow
- Update the Discord support links on the broadcaster, delegator, and orchestrator migrate pages
- Update the "Question" contact link in the issue template config
- Update the "Getting Help" link in `CONTRIBUTING.md` (was the `discord.com/invite/livepeer` form of the same hijacked vanity)

## Testing

- [x] Tested locally

## Impact / Risk

Risk level: Low

Impacted areas: UI / Config / Docs

User impact: Discord links now lead to the official server instead of the hijacked one.

Rollback plan: PR revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)