### PR TITLE
fix: guard getOrchestrators against a null current round

### DIFF
--- a/lib/api/ssr.test.ts
+++ b/lib/api/ssr.test.ts
@@ -1,0 +1,48 @@
+import { ApolloClient, NormalizedCacheObject } from "@apollo/client";
+
+import { CurrentRoundDocument, OrchestratorsDocument } from "../../apollo";
+import { getOrchestrators } from "./ssr";
+
+const mockClient = (query: jest.Mock) =>
+  ({ query } as unknown as ApolloClient<NormalizedCacheObject>);
+
+describe("getOrchestrators", () => {
+  it("refuses to query orchestrators when the subgraph returns no current round", async () => {
+    const query = jest.fn().mockResolvedValueOnce({
+      data: { protocol: null },
+    });
+
+    await expect(getOrchestrators(mockClient(query))).rejects.toThrow(
+      /no current round/i
+    );
+
+    // Only the current-round query may run; the orchestrators query must never
+    // reach the gateway with a null activationRound filter.
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledWith(
+      expect.objectContaining({ query: CurrentRoundDocument })
+    );
+  });
+
+  it("queries orchestrators with the resolved round", async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: { protocol: { currentRound: { id: "123" } } },
+      })
+      .mockResolvedValueOnce({
+        data: { transcoders: [] },
+      });
+
+    const result = await getOrchestrators(mockClient(query));
+
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(query).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: OrchestratorsDocument,
+        variables: { currentRound: "123", currentRoundString: "123" },
+      })
+    );
+    expect(result.orchestrators.data).toEqual({ transcoders: [] });
+  });
+});

--- a/lib/api/ssr.ts
+++ b/lib/api/ssr.ts
@@ -83,14 +83,22 @@ export async function getOrchestrators(client = getApollo()) {
     query: CurrentRoundDocument,
   });
 
+  const currentRound = protocolResponse?.data?.protocol?.currentRound?.id;
+
+  if (!currentRound) {
+    throw new Error(
+      "Cannot fetch orchestrators: the subgraph returned no current round"
+    );
+  }
+
   const orchestrators = await client.query<
     OrchestratorsQuery,
     OrchestratorsQueryVariables
   >({
     query: OrchestratorsDocument,
     variables: {
-      currentRound: protocolResponse?.data?.protocol?.currentRound?.id,
-      currentRoundString: protocolResponse?.data?.protocol?.currentRound?.id,
+      currentRound,
+      currentRoundString: currentRound,
     },
   });
 


### PR DESCRIPTION
## Description

When the subgraph returns no `protocol` (or no `currentRound`), `getOrchestrators` passes `null` straight into the orchestrators query's `activationRound_lte` / `deactivationRound_gt` filters. Indexers reject that filter (`unsupported filter <= for value null`), the query throws, and — because it is the first call in `pages/index.tsx`'s `try` block — the whole home page payload falls back to `hadError`. It also burns gateway credits on a query that can never succeed, and surfaces as a misleading indexer-health error rather than the actual cause.

This guards the query: when there is no current round, it fails fast with a clear message instead of sending the invalid filter to the gateway.

## Type of Change

- [x] fix: Bug fix

## Related Issue(s)

Closes: #745

## Changes Made

- Extract `currentRound` from the protocol response and throw a descriptive error when it is missing, before issuing the orchestrators query.
- Reuse the resolved `currentRound` for both the `currentRound` and `currentRoundString` variables.

## Testing

- [x] Added/updated tests
- [x] All tests passing

### How to test

`lib/api/ssr.test.ts` covers both paths: it asserts the orchestrators query is never issued when the round is missing, and that the resolved round is passed through when present. The regression test was verified to fail against the pre-fix code (the promise resolved instead of rejecting).

## Impact / Risk

Risk level: Low

Impacted areas: API (server-side data fetching for `/`, `/orchestrators`, and `/leaderboard`)

User impact: When the subgraph has no current round, the affected pages fail fast with a clear logged cause instead of issuing an invalid query. Page rendering behavior is unchanged (still surfaces the existing error state).

Rollback plan: PR revert.

## Additional Notes

The separate question of what the home page should show when the subgraph returns nothing (degraded vs. empty state) is intentionally out of scope here and tracked in #746.

Assisted by an AI agent (Hermes); the change was verified against the repo's lint, typecheck, and test gates before opening.
