### PR TITLE
fix: prefer configured RPC override over Infura

### DIFF
--- a/lib/chains.ts
+++ b/lib/chains.ts
@@ -106,13 +106,13 @@ export const ALL_SUPPORTED_CHAIN_IDS = [
  */
 export const NETWORK_RPC_URLS = {
   [chain.mainnet.id]: [
-    `https://mainnet.infura.io/v3/${INFURA_KEY}`,
     process.env.NEXT_PUBLIC_L1_RPC_URL,
+    `https://mainnet.infura.io/v3/${INFURA_KEY}`,
   ].filter(Boolean) as string[],
 
   [chain.arbitrum.id]: [
-    `https://arbitrum-mainnet.infura.io/v3/${INFURA_KEY}`,
     process.env.NEXT_PUBLIC_L2_RPC_URL,
+    `https://arbitrum-mainnet.infura.io/v3/${INFURA_KEY}`,
   ].filter(Boolean) as string[],
 };
 


### PR DESCRIPTION
Closes #747.

\`lib/chains.ts\`'s \`NETWORK_RPC_URLS\` listed Infura before \`NEXT_PUBLIC_L1_RPC_URL\`/\`NEXT_PUBLIC_L2_RPC_URL\`. viem's \`fallback()\` and the \`ethers.providers.JsonRpcProvider\` instances both take the first entry, so setting the override made it a backup to Infura rather than the active endpoint — traffic kept going to mainnet Infura. That blocks local fork testing (\`anvil --fork-url ... --chain-id 42161\` has no effect), and blanking \`INFURA_KEY\` isn't an option since \`chains.ts\` throws without it.

Fix: reorder each array so the configured override comes first when set. Infura remains the fallback. When no override is configured, Infura stays the sole/first entry, so production behavior is unchanged.

Verified:
- \`npm run typecheck\` — clean
- \`npm run lint\` — clean
- Standalone check of the array-building logic for both branches (override set → override first; override unset → Infura-only, matching current production behavior)