### PR TITLE
ci: auto-update deps with a cooldown and block vulnerable ones in pr

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    # Never install a release younger than a week: gives the ecosystem time
+    # to detect and yank compromised versions before we ever resolve them.
+    cooldown:
+      default-days: 7
+    # One combined PR per week instead of one per package.
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,23 @@ jobs:
 
       - name: 🧪 Run tests
         run: pnpm test
+
+      # Fails on known critical advisories in production dependencies.
+      # Tighten to `high` once the remaining high (sharp, pinned by next)
+      # clears upstream.
+      - name: 🔒 Audit production dependencies
+        run: pnpm audit --prod --audit-level=critical
+
+  # Fails the PR if it introduces a dependency with a known vulnerability.
+  dependency-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: ⬇️ Checkout code
+        uses: actions/checkout@v4
+
+      - name: 🔍 Review dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high


### PR DESCRIPTION
Two guardrails so the dependency tree stays close to the clean state reached in #788:

- `dependabot.yml`: weekly grouped version updates with a 7-day release cooldown — compromised npm releases are typically detected and yanked within days, so we never resolve a version younger than a week. Also keeps GitHub Actions pinned versions fresh.
- CI: `dependency-review-action` fails a PR that introduces a dependency with a known high/critical advisory, and `pnpm audit --prod --audit-level=critical` fails if the production tree ever contains a fixable critical (to be tightened to high once the sharp advisory clears upstream).

Complements the repo's native settings: Dependabot alerts + security updates handle known CVEs after merge; these catch them before merge and keep drift small.
