### PR TITLE
chore: drop the unused top-level stitches dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@radix-ui/react-icons": "^1.3.2",
     "@rainbow-me/rainbowkit": "^2.2.11",
     "@reach/tabs": "^0.17.0",
-    "@stitches/react": "1.2.5",
     "@tanstack/react-query": "^5.102.8",
     "change-case": "^4.1.2",
     "copy-to-clipboard": "^3.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,6 @@ importers:
       '@reach/tabs':
         specifier: ^0.17.0
         version: 0.17.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      '@stitches/react':
-        specifier: 1.2.5
-        version: 1.2.5(react@19.2.1)
       '@tanstack/react-query':
         specifier: ^5.102.8
         version: 5.102.8(react@19.2.1)
@@ -3948,11 +3945,6 @@ packages:
 
   '@stitches/core@1.2.8':
     resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
-
-  '@stitches/react@1.2.5':
-    resolution: {integrity: sha512-95Wwjp5cvoYQjg616OBiHZM1PnIF51pnFQIgSPxPzS/xXBrer9sNO1tfpVfLYfOifvuotse2IFNbypJ92BXzvg==}
-    peerDependencies:
-      react: '>= 16.3.0'
 
   '@stitches/react@1.2.8':
     resolution: {integrity: sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==}
@@ -14852,10 +14844,6 @@ snapshots:
       - fastestsmallesttextencoderdecoder
 
   '@stitches/core@1.2.8': {}
-
-  '@stitches/react@1.2.5(react@19.2.1)':
-    dependencies:
-      react: 19.2.1
 
   '@stitches/react@1.2.8(react@19.2.1)':
     dependencies:


### PR DESCRIPTION
`@stitches/react` is declared at top level but nothing in the app imports it — `@livepeer/design-system` bundles its own copy, which is what `getCssText()` in `_document.tsx` uses. With pnpm's strict layout the top-level declaration feeds nothing.

Verified: typecheck, 363/363 tests, production build, and the SSR'd stitches style block still renders from the design system's copy.
