### PR TITLE
ci: group github actions updates into one weekly pr

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # One combined PR; action majors are routine tag moves and CI
+    # validates the grouped PR anyway.
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
The npm entry groups minor+patch updates, but the github-actions entry had no group, so #790–#794 opened as five separate PRs. This groups all action updates (majors included — action majors are routine tag moves, and CI validates the combined PR).

After merging, comment `@dependabot recreate` on any of #790–#794 to collapse them into one grouped PR.
